### PR TITLE
Creating a catalog is not supported. Clarify HTTP response

### DIFF
--- a/metacat-main/src/main/java/com/netflix/metacat/main/api/MetacatV1Resource.java
+++ b/metacat-main/src/main/java/com/netflix/metacat/main/api/MetacatV1Resource.java
@@ -86,7 +86,7 @@ public class MetacatV1Resource implements MetacatV1 {
 
     @Override
     public void createCatalog(CreateCatalogDto createCatalogDto) {
-        throw new MetacatNotSupportedException();
+        throw new MetacatNotSupportedException("Create catalog is not supported.");
     }
 
     @Override


### PR DESCRIPTION
Hi,

I spent some time to  create a catalog, until I noticed it wasn't supported. I think the response should be more explicit than "null".
This one line patch clarify the status of the API, but I'm wondering if a 501 status code would be better than a 415.

Thanks.
