### PR TITLE
Fixed bug where s3 catalog partition listing was failing when requested for a filter and a offset 

### DIFF
--- a/metacat-s3-connector/src/main/java/com/netflix/metacat/s3/connector/S3SplitDetailManager.java
+++ b/metacat-s3-connector/src/main/java/com/netflix/metacat/s3/connector/S3SplitDetailManager.java
@@ -161,11 +161,15 @@ public class S3SplitDetailManager implements ConnectorSplitDetailManager{
         }).collect(Collectors.toList());
         //
         if( pageable != null && pageable.isPageable() && !Strings.isNullOrEmpty(filterExpression)){
-            int limit = pageable.getLimit();
+            int limit = pageable.getOffset() + pageable.getLimit();
             if( result.size() < limit){
                 limit = result.size();
             }
-            result = result.subList(pageable.getOffset(), limit);
+            if( pageable.getOffset() > limit) {
+                result = Lists.newArrayList();
+            } else {
+                result = result.subList(pageable.getOffset(), limit);
+            }
         }
         return result;
     }


### PR DESCRIPTION
Fixed the pagination logic in S3SplitDetailManager for S3 connector.