### PR TITLE
Fixed issue where the old table info was missing user metadata

### DIFF
--- a/metacat-main/src/main/java/com/netflix/metacat/main/api/MetacatV1Resource.java
+++ b/metacat-main/src/main/java/com/netflix/metacat/main/api/MetacatV1Resource.java
@@ -356,7 +356,7 @@ public class MetacatV1Resource implements MetacatV1 {
                     && tableName.equalsIgnoreCase(table.getName().getTableName()),
                 "Table name does not match the name in the table");
 
-            final TableDto oldTable = tableService.get(name, false)
+            final TableDto oldTable = tableService.get(name, true)
                 .orElseThrow(() -> new IllegalStateException(
                     "expect existing table to be present"));
             eventBus.postSync(new MetacatUpdateTablePreEvent(name, metacatRequestContext, oldTable, table));


### PR DESCRIPTION
Fixed issue where the old table info was missing user metadata which is incorrect. Event listeners that rely on this event will get incorrect data about the table.