### PR TITLE
Fixing the esmigration to get the mergeIndex from fast properties

### DIFF
--- a/metacat-main/src/main/java/com/netflix/metacat/main/services/search/ElasticSearchUtilImpl.java
+++ b/metacat-main/src/main/java/com/netflix/metacat/main/services/search/ElasticSearchUtilImpl.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
 package com.netflix.metacat.main.services.search;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -62,7 +75,6 @@ public class ElasticSearchUtilImpl implements ElasticSearchUtil {
     protected final Client client;
     private final Config config;
     private final MetacatJson metacatJson;
-    private final String esMergeIndex;
 
     /**
      * Constructor.
@@ -78,7 +90,6 @@ public class ElasticSearchUtilImpl implements ElasticSearchUtil {
         this.client = client;
         this.metacatJson = metacatJson;
         this.esIndex = config.getEsIndex();
-        this.esMergeIndex = config.getMergeEsIndex();
     }
 
     /**
@@ -638,7 +649,7 @@ public class ElasticSearchUtilImpl implements ElasticSearchUtil {
                 docs.add(doc);
             }
         });
-        bulkSaveToIndex(type, docs, esMergeIndex);
+        bulkSaveToIndex(type, docs, config.getMergeEsIndex());
     }
 
     /*
@@ -659,7 +670,7 @@ public class ElasticSearchUtilImpl implements ElasticSearchUtil {
      */
     private void ensureMigrationBySave(final String type, final List<ElasticSearchDoc> docs) {
         if (!Strings.isNullOrEmpty(config.getMergeEsIndex())) {
-            bulkSaveToIndex(type, docs, esMergeIndex);
+            bulkSaveToIndex(type, docs, config.getMergeEsIndex());
         }
     }
 }

--- a/metacat-main/src/test/groovy/com/netflix/metacat/main/search/BaseEsSpec.groovy
+++ b/metacat-main/src/test/groovy/com/netflix/metacat/main/search/BaseEsSpec.groovy
@@ -72,12 +72,10 @@ class BaseEsSpec extends Specification {
 
         metacatJson = MetacatJsonLocator.INSTANCE
         config.getEsIndex() >> esIndex
-        config.isIndexMigration() >> false
         es = new ElasticSearchUtilImpl(client, config, metacatJson)
 
         config2.getEsIndex() >> esIndex
         config2.getMergeEsIndex() >> esMergeIndex
-        config2.isIndexMigration() >> true
         esMig = new ElasticSearchUtilImpl(client, config2, metacatJson)
     }
 


### PR DESCRIPTION
Removing the mergeIndex from class member and get the mergeIndex from fast properties.
The current issue is that the variable holding the mergeIndex will not be updated from the fast property change.
