### PR TITLE
Move plugins to runtime scope

### DIFF
--- a/metacat-main/build.gradle
+++ b/metacat-main/build.gradle
@@ -12,18 +12,13 @@
  */
 
 dependencies {
-    compile project(':metacat-connector-s3')
-    compile project(':metacat-connector-hive')
-    compile project(":metacat-connector-mysql")
-    compile project(":metacat-connector-postgresql")
-    compile project(':metacat-common-server')
-    compile project(':metacat-thrift')
-    testCompile project(':metacat-user-metadata-mysql')
+    compile project(":metacat-common-server")
+    compile project(":metacat-thrift")
 
     compile "com.amazonaws:aws-java-sdk-sns:${amazon_sns_version}"
-    compile 'org.elasticsearch:elasticsearch:1.7.1'
-    compile ('com.github.rholder:guava-retrying:2.0.0'){
-        exclude module: 'guava'
+    compile "org.elasticsearch:elasticsearch:1.7.1"
+    compile("com.github.rholder:guava-retrying:2.0.0") {
+        exclude module: "guava"
     }
 
     compile "com.google.inject:guice:${guice_version}"
@@ -31,8 +26,15 @@ dependencies {
     compile "com.google.inject.extensions:guice-multibindings:${guice_version}"
     compile "com.google.inject.extensions:guice-servlet:${guice_version}"
     compile "javax.validation:validation-api:1.1.0.Final"
-    testCompile 'io.airlift:testing-mysql-server:0.1'
-    testCompile project(':metacat-common').sourceSets.test.output
+
+    runtime project(":metacat-connector-s3")
+    runtime project(":metacat-connector-hive")
+    runtime project(":metacat-connector-mysql")
+    runtime project(":metacat-connector-postgresql")
+
+    testCompile project(":metacat-user-metadata-mysql")
+    testCompile "io.airlift:testing-mysql-server:0.1"
+    testCompile project(":metacat-common").sourceSets.test.output
 }
 
 test {


### PR DESCRIPTION
They shouldn't be `compile` scope. This makes sure they're not leaking compile dependencies into the build.