### PR TITLE
Make subscribers asynchronous

### DIFF
--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/ArchaiusConfigImpl.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/ArchaiusConfigImpl.java
@@ -101,8 +101,8 @@ public class ArchaiusConfigImpl implements Config {
         this.elasticSearchThresholdUnmarkedTablesDelete = factory
             .getIntProperty("metacat.elacticsearch.refresh.threshold.unmarked.tables.delete", 1000);
         this.epochInSeconds = factory.getBooleanProperty("metacat.type.epoch_in_seconds", true);
-        this.eventBusExecutorThreadCount = factory.getIntProperty("metacat.event.bus.executor.thread.count", 10);
-        this.eventBusThreadCount = factory.getIntProperty("metacat.event.thread.count", 10);
+        this.eventBusExecutorThreadCount = factory.getIntProperty("metacat.event.bus.executor.thread.count", 20);
+        this.eventBusThreadCount = factory.getIntProperty("metacat.event.thread.count", 20);
         this.hivePartitionWhitelistPattern = factory
             .getStringProperty("metacat.hive.metastore.partition.name.whitelist.pattern", "");
         this.lookupServiceUserAdmin = factory.getStringProperty("metacat.lookup_service.user_admin", "admin");

--- a/metacat-main/src/main/java/com/netflix/metacat/main/services/notifications/NotificationService.java
+++ b/metacat-main/src/main/java/com/netflix/metacat/main/services/notifications/NotificationService.java
@@ -17,6 +17,7 @@
  */
 package com.netflix.metacat.main.services.notifications;
 
+import com.google.common.eventbus.AllowConcurrentEvents;
 import com.google.common.eventbus.Subscribe;
 import com.netflix.metacat.common.server.events.MetacatCreateTablePostEvent;
 import com.netflix.metacat.common.server.events.MetacatDeleteTablePartitionPostEvent;
@@ -42,6 +43,7 @@ public interface NotificationService {
      * @param event The event passed within the JVM after a partition has been successfully added
      */
     @Subscribe
+    @AllowConcurrentEvents
     void notifyOfPartitionAddition(@NotNull final MetacatSaveTablePartitionPostEvent event);
 
     /**
@@ -50,6 +52,7 @@ public interface NotificationService {
      * @param event The event passed within the JVM after a partition has been successfully deleted
      */
     @Subscribe
+    @AllowConcurrentEvents
     void notifyOfPartitionDeletion(@NotNull final MetacatDeleteTablePartitionPostEvent event);
 
     /**
@@ -58,6 +61,7 @@ public interface NotificationService {
      * @param event The event passed within the JVM after a table has been successfully created
      */
     @Subscribe
+    @AllowConcurrentEvents
     void notifyOfTableCreation(@NotNull final MetacatCreateTablePostEvent event);
 
     /**
@@ -66,6 +70,7 @@ public interface NotificationService {
      * @param event The event passed within the JVM after a table has been successfully deleted
      */
     @Subscribe
+    @AllowConcurrentEvents
     void notifyOfTableDeletion(@NotNull final MetacatDeleteTablePostEvent event);
 
     /**
@@ -74,6 +79,7 @@ public interface NotificationService {
      * @param event The event passed within the JVM after a table has been successfully renamed
      */
     @Subscribe
+    @AllowConcurrentEvents
     void notifyOfTableRename(@NotNull final MetacatRenameTablePostEvent event);
 
     /**
@@ -82,5 +88,6 @@ public interface NotificationService {
      * @param event The event passed within the JVM after a table has been successfully updated
      */
     @Subscribe
+    @AllowConcurrentEvents
     void notifyOfTableUpdate(@NotNull final MetacatUpdateTablePostEvent event);
 }

--- a/metacat-main/src/main/java/com/netflix/metacat/main/services/notifications/sns/SNSNotificationServiceImplProvider.java
+++ b/metacat-main/src/main/java/com/netflix/metacat/main/services/notifications/sns/SNSNotificationServiceImplProvider.java
@@ -85,7 +85,7 @@ public class SNSNotificationServiceImplProvider implements Provider<Notification
             final Retryer<PublishResult> retry = RetryerBuilder.<PublishResult>newBuilder()
                 .retryIfExceptionOfType(InternalErrorException.class)
                 .retryIfExceptionOfType(ThrottledException.class)
-                .withWaitStrategy(WaitStrategies.incrementingWait(10, TimeUnit.SECONDS, 30, TimeUnit.SECONDS))
+                .withWaitStrategy(WaitStrategies.incrementingWait(10, TimeUnit.MILLISECONDS, 30, TimeUnit.MILLISECONDS))
                 .withStopStrategy(StopStrategies.stopAfterAttempt(3))
                 .build();
             return new SNSNotificationServiceImpl(new AmazonSNSClient(), tableArn, partitionArn, this.mapper, retry);

--- a/metacat-main/src/main/java/com/netflix/metacat/main/services/search/ElasticSearchUtilImpl.java
+++ b/metacat-main/src/main/java/com/netflix/metacat/main/services/search/ElasticSearchUtilImpl.java
@@ -67,7 +67,7 @@ import java.util.stream.Collectors;
 public class ElasticSearchUtilImpl implements ElasticSearchUtil {
     protected static final Retryer<Void> RETRY_ES_PUBLISH = RetryerBuilder.<Void>newBuilder()
         .retryIfExceptionOfType(ElasticsearchException.class)
-        .withWaitStrategy(WaitStrategies.incrementingWait(10, TimeUnit.SECONDS, 30, TimeUnit.SECONDS))
+        .withWaitStrategy(WaitStrategies.incrementingWait(10, TimeUnit.MILLISECONDS, 30, TimeUnit.MILLISECONDS))
         .withStopStrategy(StopStrategies.stopAfterAttempt(3))
         .build();
     protected XContentType contentType = Requests.INDEX_CONTENT_TYPE;

--- a/metacat-main/src/main/java/com/netflix/metacat/main/services/search/MetacatEventHandlers.java
+++ b/metacat-main/src/main/java/com/netflix/metacat/main/services/search/MetacatEventHandlers.java
@@ -14,6 +14,7 @@
 package com.netflix.metacat.main.services.search;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.eventbus.AllowConcurrentEvents;
 import com.google.common.eventbus.Subscribe;
 import com.netflix.metacat.common.MetacatRequestContext;
 import com.netflix.metacat.common.dto.DatabaseDto;
@@ -62,6 +63,7 @@ public class MetacatEventHandlers {
      * @param event event
      */
     @Subscribe
+    @AllowConcurrentEvents
     public void metacatCreateDatabasePostEventHandler(final MetacatCreateDatabasePostEvent event) {
         log.debug("Received CreateDatabaseEvent {}", event);
         CounterWrapper.incrementCounter("metacat.elasticsearch.events.database.create");
@@ -76,6 +78,7 @@ public class MetacatEventHandlers {
      * @param event event
      */
     @Subscribe
+    @AllowConcurrentEvents
     public void metacatCreateMViewPostEventHandler(final MetacatCreateMViewPostEvent event) {
         log.debug("Received CreateViewEvent {}", event);
         CounterWrapper.incrementCounter("metacat.elasticsearch.events.view.create");
@@ -90,6 +93,7 @@ public class MetacatEventHandlers {
      * @param event event
      */
     @Subscribe
+    @AllowConcurrentEvents
     public void metacatCreateTablePostEventHandler(final MetacatCreateTablePostEvent event) {
         log.debug("Received CreateTableEvent {}", event);
         CounterWrapper.incrementCounter("metacat.elasticsearch.events.table.create");
@@ -104,6 +108,7 @@ public class MetacatEventHandlers {
      * @param event event
      */
     @Subscribe
+    @AllowConcurrentEvents
     public void metacatDeleteDatabasePostEventHandler(final MetacatDeleteDatabasePostEvent event) {
         log.debug("Received DeleteDatabaseEvent {}", event);
         CounterWrapper.incrementCounter("metacat.elasticsearch.events.database.delete");
@@ -116,6 +121,7 @@ public class MetacatEventHandlers {
      * @param event event
      */
     @Subscribe
+    @AllowConcurrentEvents
     public void metacatDeleteMViewPostEventHandler(final MetacatDeleteMViewPostEvent event) {
         log.debug("Received DeleteViewEvent {}", event);
         CounterWrapper.incrementCounter("metacat.elasticsearch.events.view.delete");
@@ -128,6 +134,7 @@ public class MetacatEventHandlers {
      * @param event event
      */
     @Subscribe
+    @AllowConcurrentEvents
     public void metacatDeleteTablePostEventHandler(final MetacatDeleteTablePostEvent event) {
         log.debug("Received DeleteTableEvent {}", event);
         CounterWrapper.incrementCounter("metacat.elasticsearch.events.table.delete");
@@ -151,6 +158,7 @@ public class MetacatEventHandlers {
      * @param event event
      */
     @Subscribe
+    @AllowConcurrentEvents
     public void metacatDeleteMViewPartitionPostEventHandler(final MetacatDeleteMViewPartitionPostEvent event) {
         log.debug("Received DeleteViewPartitionEvent {}", event);
         CounterWrapper.incrementCounter("metacat.elasticsearch.events.view.partition.delete");
@@ -165,6 +173,7 @@ public class MetacatEventHandlers {
      * @param event event
      */
     @Subscribe
+    @AllowConcurrentEvents
     public void metacatDeleteTablePartitionPostEventHandler(final MetacatDeleteTablePartitionPostEvent event) {
         log.debug("Received DeleteTablePartitionEvent {}", event);
         CounterWrapper.incrementCounter("metacat.elasticsearch.events.table.partition.delete");
@@ -179,6 +188,7 @@ public class MetacatEventHandlers {
      * @param event event
      */
     @Subscribe
+    @AllowConcurrentEvents
     public void metacatRenameTablePostEventHandler(final MetacatRenameTablePostEvent event) {
         log.debug("Received RenameTableEvent {}", event);
         CounterWrapper.incrementCounter("metacat.elasticsearch.events.table.rename");
@@ -195,6 +205,7 @@ public class MetacatEventHandlers {
      * @param event event
      */
     @Subscribe
+    @AllowConcurrentEvents
     public void metacatUpdateMViewPostEventHandler(final MetacatUpdateMViewPostEvent event) {
         log.debug("Received UpdateViewEvent {}", event);
         CounterWrapper.incrementCounter("metacat.elasticsearch.events.view.update");
@@ -209,6 +220,7 @@ public class MetacatEventHandlers {
      * @param event event
      */
     @Subscribe
+    @AllowConcurrentEvents
     public void metacatUpdateTablePostEventHandler(final MetacatUpdateTablePostEvent event) {
         log.debug("Received UpdateTableEvent {}", event);
         CounterWrapper.incrementCounter("metacat.elasticsearch.events.table.update");
@@ -234,6 +246,7 @@ public class MetacatEventHandlers {
      * @param event event
      */
     @Subscribe
+    @AllowConcurrentEvents
     public void metacatSaveMViewPartitionPostEventHandler(final MetacatSaveMViewPartitionPostEvent event) {
         log.debug("Received SaveViewPartitionEvent {}", event);
         CounterWrapper.incrementCounter("metacat.elasticsearch.events.view.partition.save");
@@ -250,6 +263,7 @@ public class MetacatEventHandlers {
      * @param event event
      */
     @Subscribe
+    @AllowConcurrentEvents
     public void metacatSaveTablePartitionPostEventHandler(final MetacatSaveTablePartitionPostEvent event) {
         log.debug("Received SaveTablePartitionEvent {}", event);
         CounterWrapper.incrementCounter("metacat.elasticsearch.events.table.partition.save");


### PR DESCRIPTION
Since the even handling was synchronized, the events were waiting in the queue to be processed by one of the 10 workers.