### PR TITLE
Connector property override capability for services

### DIFF
--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/connectors/ConnectorModule.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/connectors/ConnectorModule.java
@@ -1,0 +1,96 @@
+/*
+ *
+ *  Copyright 2017 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.metacat.common.server.connectors;
+
+import com.google.common.base.Throwables;
+import com.google.inject.AbstractModule;
+import lombok.NonNull;
+
+import javax.annotation.Nonnull;
+import java.util.Map;
+
+/**
+ * A module that provides some reusable helper methods for connectors.
+ *
+ * @author tgianos
+ * @since 1.0.0
+ */
+public abstract class ConnectorModule extends AbstractModule {
+
+    /**
+     * The key which a user can set a value in a catalog to override the default database service class.
+     */
+    private static final String DATABASE_SERVICE_CLASS_KEY = "metacat.connector.databaseService.class";
+
+    /**
+     * The key which a user can set a value in a catalog to override the default table service class.
+     */
+    private static final String TABLE_SERVICE_CLASS_KEY = "metacat.connector.tableService.class";
+
+    /**
+     * The key which a user can set a value in a catalog to override the default partition service class.
+     */
+    private static final String PARTITION_SERVICE_CLASS_KEY = "metacat.connector.partitionService.class";
+
+    protected Class<? extends ConnectorDatabaseService> getDatabaseServiceClass(
+        @Nonnull @NonNull final Map<String, String> configuration,
+        @Nonnull @NonNull final Class<? extends ConnectorDatabaseService> defaultServiceClass
+    ) {
+        if (configuration.containsKey(DATABASE_SERVICE_CLASS_KEY)) {
+            final String className = configuration.get(DATABASE_SERVICE_CLASS_KEY);
+            return this.getServiceClass(className, ConnectorDatabaseService.class);
+        } else {
+            return defaultServiceClass;
+        }
+    }
+
+    protected Class<? extends ConnectorTableService> getTableServiceClass(
+        @Nonnull @NonNull final Map<String, String> configuration,
+        @Nonnull @NonNull final Class<? extends ConnectorTableService> defaultServiceClass
+    ) {
+        if (configuration.containsKey(TABLE_SERVICE_CLASS_KEY)) {
+            final String className = configuration.get(TABLE_SERVICE_CLASS_KEY);
+            return this.getServiceClass(className, ConnectorTableService.class);
+        } else {
+            return defaultServiceClass;
+        }
+    }
+
+    protected Class<? extends ConnectorPartitionService> getPartitionServiceClass(
+        @Nonnull @NonNull final Map<String, String> configuration,
+        @Nonnull @NonNull final Class<? extends ConnectorPartitionService> defaultServiceClass
+    ) {
+        if (configuration.containsKey(PARTITION_SERVICE_CLASS_KEY)) {
+            final String className = configuration.get(PARTITION_SERVICE_CLASS_KEY);
+            return this.getServiceClass(className, ConnectorPartitionService.class);
+        } else {
+            return defaultServiceClass;
+        }
+    }
+
+    private <S extends ConnectorBaseService> Class<? extends S> getServiceClass(
+        @Nonnull @NonNull final String className,
+        @Nonnull @NonNull final Class<? extends S> baseClass
+    ) {
+        try {
+            return Class.forName(className).asSubclass(baseClass);
+        } catch (final ClassNotFoundException cnfe) {
+            throw Throwables.propagate(cnfe);
+        }
+    }
+}

--- a/metacat-connector-cassandra/src/main/java/com/netflix/metacat/connector/cassandra/CassandraConnectorModule.java
+++ b/metacat-connector-cassandra/src/main/java/com/netflix/metacat/connector/cassandra/CassandraConnectorModule.java
@@ -19,11 +19,11 @@ package com.netflix.metacat.connector.cassandra;
 
 import com.datastax.driver.core.Cluster;
 import com.google.common.collect.ImmutableList;
-import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.Scopes;
 import com.google.inject.Singleton;
 import com.netflix.metacat.common.server.connectors.ConnectorDatabaseService;
+import com.netflix.metacat.common.server.connectors.ConnectorModule;
 import com.netflix.metacat.common.server.connectors.ConnectorPartitionService;
 import com.netflix.metacat.common.server.connectors.ConnectorTableService;
 import lombok.NonNull;
@@ -39,7 +39,7 @@ import java.util.Map;
  * @author tgianos
  * @since 1.0.0
  */
-public class CassandraConnectorModule extends AbstractModule {
+public class CassandraConnectorModule extends ConnectorModule {
 
     private static final String CONTACT_POINTS_KEY = "cassandra.contactPoints";
     private static final String PORT_KEY = "cassandra.port";
@@ -70,9 +70,15 @@ public class CassandraConnectorModule extends AbstractModule {
     protected void configure() {
         this.bind(CassandraTypeConverter.class).toInstance(new CassandraTypeConverter());
         this.bind(CassandraExceptionMapper.class).toInstance(new CassandraExceptionMapper());
-        this.bind(ConnectorDatabaseService.class).to(CassandraConnectorDatabaseService.class).in(Scopes.SINGLETON);
-        this.bind(ConnectorTableService.class).to(CassandraConnectorTableService.class).in(Scopes.SINGLETON);
-        this.bind(ConnectorPartitionService.class).to(CassandraConnectorPartitionService.class).in(Scopes.SINGLETON);
+        this.bind(ConnectorDatabaseService.class)
+            .to(this.getDatabaseServiceClass(this.configuration, CassandraConnectorDatabaseService.class))
+            .in(Scopes.SINGLETON);
+        this.bind(ConnectorTableService.class)
+            .to(this.getTableServiceClass(this.configuration, CassandraConnectorTableService.class))
+            .in(Scopes.SINGLETON);
+        this.bind(ConnectorPartitionService.class)
+            .to(this.getPartitionServiceClass(this.configuration, CassandraConnectorPartitionService.class))
+            .in(Scopes.SINGLETON);
     }
 
     /**

--- a/metacat-connector-mysql/src/main/java/com/netflix/metacat/connector/mysql/MySqlConnectorModule.java
+++ b/metacat-connector-mysql/src/main/java/com/netflix/metacat/connector/mysql/MySqlConnectorModule.java
@@ -17,9 +17,9 @@
  */
 package com.netflix.metacat.connector.mysql;
 
-import com.google.inject.AbstractModule;
 import com.google.inject.Scopes;
 import com.netflix.metacat.common.server.connectors.ConnectorDatabaseService;
+import com.netflix.metacat.common.server.connectors.ConnectorModule;
 import com.netflix.metacat.common.server.connectors.ConnectorPartitionService;
 import com.netflix.metacat.common.server.connectors.ConnectorTableService;
 import com.netflix.metacat.common.server.util.DataSourceManager;
@@ -39,7 +39,7 @@ import java.util.Map;
  * @author tgianos
  * @since 1.0.0
  */
-public class MySqlConnectorModule extends AbstractModule {
+public class MySqlConnectorModule extends ConnectorModule {
 
     private final String name;
     private final Map<String, String> configuration;
@@ -67,8 +67,14 @@ public class MySqlConnectorModule extends AbstractModule {
             .toInstance(DataSourceManager.get().load(this.name, this.configuration).get(this.name));
         this.bind(JdbcTypeConverter.class).to(MySqlTypeConverter.class).in(Scopes.SINGLETON);
         this.bind(JdbcExceptionMapper.class).to(MySqlExceptionMapper.class).in(Scopes.SINGLETON);
-        this.bind(ConnectorDatabaseService.class).to(MySqlConnectorDatabaseService.class).in(Scopes.SINGLETON);
-        this.bind(ConnectorTableService.class).to(JdbcConnectorTableService.class).in(Scopes.SINGLETON);
-        this.bind(ConnectorPartitionService.class).to(JdbcConnectorPartitionService.class).in(Scopes.SINGLETON);
+        this.bind(ConnectorDatabaseService.class)
+            .to(this.getDatabaseServiceClass(this.configuration, MySqlConnectorDatabaseService.class))
+            .in(Scopes.SINGLETON);
+        this.bind(ConnectorTableService.class)
+            .to(this.getTableServiceClass(this.configuration, JdbcConnectorTableService.class))
+            .in(Scopes.SINGLETON);
+        this.bind(ConnectorPartitionService.class)
+            .to(this.getPartitionServiceClass(this.configuration, JdbcConnectorPartitionService.class))
+            .in(Scopes.SINGLETON);
     }
 }

--- a/metacat-connector-postgresql/src/main/java/com/netflix/metacat/connector/postgresql/PostgreSqlConnectorModule.java
+++ b/metacat-connector-postgresql/src/main/java/com/netflix/metacat/connector/postgresql/PostgreSqlConnectorModule.java
@@ -17,9 +17,9 @@
  */
 package com.netflix.metacat.connector.postgresql;
 
-import com.google.inject.AbstractModule;
 import com.google.inject.Scopes;
 import com.netflix.metacat.common.server.connectors.ConnectorDatabaseService;
+import com.netflix.metacat.common.server.connectors.ConnectorModule;
 import com.netflix.metacat.common.server.connectors.ConnectorPartitionService;
 import com.netflix.metacat.common.server.connectors.ConnectorTableService;
 import com.netflix.metacat.common.server.util.DataSourceManager;
@@ -39,7 +39,7 @@ import java.util.Map;
  * @author tgianos
  * @since 1.0.0
  */
-public class PostgreSqlConnectorModule extends AbstractModule {
+public class PostgreSqlConnectorModule extends ConnectorModule {
 
     private final String name;
     private final Map<String, String> configuration;
@@ -67,8 +67,14 @@ public class PostgreSqlConnectorModule extends AbstractModule {
             .toInstance(DataSourceManager.get().load(this.name, this.configuration).get(this.name));
         this.bind(JdbcTypeConverter.class).to(PostgreSqlTypeConverter.class).in(Scopes.SINGLETON);
         this.bind(JdbcExceptionMapper.class).to(PostgreSqlExceptionMapper.class).in(Scopes.SINGLETON);
-        this.bind(ConnectorDatabaseService.class).to(PostgreSqlConnectorDatabaseService.class).in(Scopes.SINGLETON);
-        this.bind(ConnectorTableService.class).to(JdbcConnectorTableService.class).in(Scopes.SINGLETON);
-        this.bind(ConnectorPartitionService.class).to(JdbcConnectorPartitionService.class).in(Scopes.SINGLETON);
+        this.bind(ConnectorDatabaseService.class)
+            .to(this.getDatabaseServiceClass(this.configuration, PostgreSqlConnectorDatabaseService.class))
+            .in(Scopes.SINGLETON);
+        this.bind(ConnectorTableService.class)
+            .to(this.getTableServiceClass(this.configuration, JdbcConnectorTableService.class))
+            .in(Scopes.SINGLETON);
+        this.bind(ConnectorPartitionService.class)
+            .to(this.getPartitionServiceClass(this.configuration, JdbcConnectorPartitionService.class))
+            .in(Scopes.SINGLETON);
     }
 }

--- a/metacat-connector-redshift/src/main/java/com/netflix/metacat/connector/redshift/RedshiftConnectorModule.java
+++ b/metacat-connector-redshift/src/main/java/com/netflix/metacat/connector/redshift/RedshiftConnectorModule.java
@@ -17,9 +17,9 @@
  */
 package com.netflix.metacat.connector.redshift;
 
-import com.google.inject.AbstractModule;
 import com.google.inject.Scopes;
 import com.netflix.metacat.common.server.connectors.ConnectorDatabaseService;
+import com.netflix.metacat.common.server.connectors.ConnectorModule;
 import com.netflix.metacat.common.server.connectors.ConnectorPartitionService;
 import com.netflix.metacat.common.server.connectors.ConnectorTableService;
 import com.netflix.metacat.common.server.util.DataSourceManager;
@@ -40,7 +40,7 @@ import java.util.Map;
  * @author tgianos
  * @since 1.0.0
  */
-public class RedshiftConnectorModule extends AbstractModule {
+public class RedshiftConnectorModule extends ConnectorModule {
 
     private final String name;
     private final Map<String, String> configuration;
@@ -68,8 +68,14 @@ public class RedshiftConnectorModule extends AbstractModule {
             .toInstance(DataSourceManager.get().load(this.name, this.configuration).get(this.name));
         this.bind(JdbcTypeConverter.class).to(RedshiftTypeConverter.class).in(Scopes.SINGLETON);
         this.bind(JdbcExceptionMapper.class).to(RedshiftExceptionMapper.class).in(Scopes.SINGLETON);
-        this.bind(ConnectorDatabaseService.class).to(JdbcConnectorDatabaseService.class).in(Scopes.SINGLETON);
-        this.bind(ConnectorTableService.class).to(JdbcConnectorTableService.class).in(Scopes.SINGLETON);
-        this.bind(ConnectorPartitionService.class).to(JdbcConnectorPartitionService.class).in(Scopes.SINGLETON);
+        this.bind(ConnectorDatabaseService.class)
+            .to(this.getDatabaseServiceClass(this.configuration, JdbcConnectorDatabaseService.class))
+            .in(Scopes.SINGLETON);
+        this.bind(ConnectorTableService.class)
+            .to(this.getTableServiceClass(this.configuration, JdbcConnectorTableService.class))
+            .in(Scopes.SINGLETON);
+        this.bind(ConnectorPartitionService.class)
+            .to(this.getPartitionServiceClass(this.configuration, JdbcConnectorPartitionService.class))
+            .in(Scopes.SINGLETON);
     }
 }

--- a/metacat-main/src/main/java/com/netflix/metacat/main/services/notifications/sns/SNSNotificationsModule.java
+++ b/metacat-main/src/main/java/com/netflix/metacat/main/services/notifications/sns/SNSNotificationsModule.java
@@ -18,7 +18,7 @@
 package com.netflix.metacat.main.services.notifications.sns;
 
 import com.google.inject.AbstractModule;
-import com.google.inject.Singleton;
+import com.google.inject.Scopes;
 import com.google.inject.multibindings.Multibinder;
 import com.netflix.metacat.main.services.notifications.NotificationService;
 import lombok.extern.slf4j.Slf4j;
@@ -41,6 +41,6 @@ public class SNSNotificationsModule extends AbstractModule {
             this.binder(),
             NotificationService.class
         );
-        notificationServices.addBinding().toProvider(SNSNotificationServiceImplProvider.class).in(Singleton.class);
+        notificationServices.addBinding().toProvider(SNSNotificationServiceImplProvider.class).in(Scopes.SINGLETON);
     }
 }


### PR DESCRIPTION
Allow users to override the default services for MySql, Postgres, Cassandra and Redshift connectors.

Properties for the connector catalog can be set to a different class that implements the desired interface in order to override the default. The properties are:
`metacat.connector.databaseService.class`
`metacat.connector.tableService.class`
`metacat.connector.partitionService.class`