### PR TITLE
Removed the automatic registration of listeners to Metacat event bus.

### DIFF
--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/CommonModule.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/CommonModule.java
@@ -14,11 +14,6 @@
 package com.netflix.metacat.common.server;
 
 import com.google.inject.AbstractModule;
-import com.google.inject.TypeLiteral;
-import com.google.inject.matcher.Matchers;
-import com.google.inject.spi.InjectionListener;
-import com.google.inject.spi.TypeEncounter;
-import com.google.inject.spi.TypeListener;
 import com.netflix.metacat.common.json.MetacatJson;
 import com.netflix.metacat.common.json.MetacatJsonLocator;
 import com.netflix.metacat.common.server.model.Lookup;
@@ -44,13 +39,7 @@ public class CommonModule extends AbstractModule {
         bind(MetacatJson.class).toInstance(MetacatJsonLocator.INSTANCE);
         bind(DeadEventHandler.class).asEagerSingleton();
         bind(DataSourceManager.class).toInstance(DataSourceManager.get());
-        final MetacatEventBus eventBus = new MetacatEventBus(config);
-        bind(MetacatEventBus.class).toInstance(eventBus);
-        bindListener(Matchers.any(), new TypeListener() {
-            public <I> void hear(final TypeLiteral<I> typeLiteral, final TypeEncounter<I> typeEncounter) {
-                typeEncounter.register((InjectionListener<I>) eventBus::register);
-            }
-        });
+        bind(MetacatEventBus.class).asEagerSingleton();
         bind(ConverterUtil.class).asEagerSingleton();
         bind(DozerTypeConverter.class).asEagerSingleton();
         binder().bind(ConnectorTypeConverter.class).toProvider(TypeConverterProvider.class);

--- a/metacat-common/src/main/java/com/netflix/metacat/common/QualifiedName.java
+++ b/metacat-common/src/main/java/com/netflix/metacat/common/QualifiedName.java
@@ -42,6 +42,7 @@ public final class QualifiedName implements Serializable {
 
     private String qualifiedName;
     private Map<String, String> qualifiedNameMap;
+    private Map<String, String> parts;
     private Type type;
 
     private QualifiedName(@Nonnull final String catalogName,
@@ -349,7 +350,7 @@ public final class QualifiedName implements Serializable {
     @JsonValue
     public Map<String, String> toJson() {
         if (qualifiedNameMap == null) {
-            final Map<String, String> map = new HashMap<>(4);
+            final Map<String, String> map = new HashMap<>(5);
             map.put("qualifiedName", toString());
             map.put("catalogName", catalogName);
 
@@ -373,6 +374,37 @@ public final class QualifiedName implements Serializable {
         }
 
         return qualifiedNameMap;
+    }
+
+    /**
+     * Returns the qualified name in parts.
+     * @return parts of the qualified name as a Map
+     */
+    public Map<String, String> parts() {
+        if (parts == null) {
+            final Map<String, String> map = new HashMap<>(4);
+            map.put("catalogName", catalogName);
+
+            if (!databaseName.isEmpty()) {
+                map.put("databaseName", databaseName);
+            }
+
+            if (!tableName.isEmpty()) {
+                map.put("tableName", tableName);
+            }
+
+            if (!partitionName.isEmpty()) {
+                map.put("partitionName", partitionName);
+            }
+
+            if (!viewName.isEmpty()) {
+                map.put("viewName", viewName);
+            }
+
+            parts = map;
+        }
+
+        return parts;
     }
 
     public boolean isViewDefinition() {

--- a/metacat-main/src/main/java/com/netflix/metacat/main/api/RequestWrapper.java
+++ b/metacat-main/src/main/java/com/netflix/metacat/main/api/RequestWrapper.java
@@ -13,7 +13,6 @@
 
 package com.netflix.metacat.main.api;
 
-import com.google.common.collect.Maps;
 import com.netflix.metacat.common.QualifiedName;
 import com.netflix.metacat.common.exception.MetacatAlreadyExistsException;
 import com.netflix.metacat.common.exception.MetacatBadRequestException;
@@ -36,7 +35,6 @@ import com.netflix.servo.tag.TagList;
 import lombok.extern.slf4j.Slf4j;
 
 import javax.ws.rs.core.Response;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
@@ -74,7 +72,7 @@ public final class RequestWrapper {
         final QualifiedName name,
         final String resourceRequestName,
         final Supplier<R> supplier) {
-        final BasicTagList tags = getQualifiedNameTagList(name).copy("request", resourceRequestName);
+        final BasicTagList tags = BasicTagList.copyOf(name.parts()).copy("request", resourceRequestName);
         DynamicCounter.increment("dse.metacat.counter.requests", tags);
         final Stopwatch timer = DynamicTimer.start("dse.metacat.timer.requests", tags);
         try {
@@ -115,12 +113,6 @@ public final class RequestWrapper {
             log.info("### Time taken to complete {} is {} ms", resourceRequestName,
                 timer.getDuration(TimeUnit.MILLISECONDS));
         }
-    }
-
-    private static BasicTagList getQualifiedNameTagList(final QualifiedName name) {
-        final Map<String, String> tags = Maps.newHashMap(name.toJson());
-        tags.remove("qualifiedName");
-        return BasicTagList.copyOf(tags);
     }
 
     /**

--- a/metacat-main/src/main/java/com/netflix/metacat/main/init/MetacatInitializationService.java
+++ b/metacat-main/src/main/java/com/netflix/metacat/main/init/MetacatInitializationService.java
@@ -18,6 +18,7 @@ import com.netflix.metacat.common.server.Config;
 import com.netflix.metacat.common.server.events.MetacatEventBus;
 import com.netflix.metacat.common.server.usermetadata.UserMetadataService;
 import com.netflix.metacat.common.server.util.ThreadServiceManager;
+import com.netflix.metacat.main.manager.ConnectorManager;
 import com.netflix.metacat.main.manager.PluginManager;
 import com.netflix.metacat.main.manager.CatalogManager;
 import com.netflix.metacat.main.services.notifications.NotificationService;
@@ -87,10 +88,11 @@ public class MetacatInitializationService {
      * @throws Exception error
      */
     public void stop() throws Exception {
+        injector.getInstance(ConnectorManager.class).stop();
         injector.getInstance(UserMetadataService.class).stop();
+        injector.getInstance(MetacatEventBus.class).shutdown();
         injector.getInstance(ThreadServiceManager.class).stop();
-        // Start the thrift services
-        final MetacatThriftService thriftService = injector.getInstance(MetacatThriftService.class);
-        thriftService.stop();
+        // Stop the thrift services
+        injector.getInstance(MetacatThriftService.class).stop();
     }
 }

--- a/metacat-main/src/main/java/com/netflix/metacat/main/services/notifications/sns/SNSNotificationServiceImpl.java
+++ b/metacat-main/src/main/java/com/netflix/metacat/main/services/notifications/sns/SNSNotificationServiceImpl.java
@@ -23,6 +23,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.fge.jsonpatch.JsonPatch;
 import com.github.fge.jsonpatch.diff.JsonDiff;
+import com.google.common.collect.Maps;
+import com.netflix.metacat.common.QualifiedName;
 import com.netflix.metacat.common.dto.PartitionDto;
 import com.netflix.metacat.common.dto.TableDto;
 import com.netflix.metacat.common.dto.notifications.sns.SNSMessage;
@@ -42,11 +44,14 @@ import com.netflix.metacat.common.server.events.MetacatSaveTablePartitionPostEve
 import com.netflix.metacat.common.server.events.MetacatUpdateTablePostEvent;
 import com.netflix.metacat.common.server.monitoring.CounterWrapper;
 import com.netflix.metacat.main.services.notifications.NotificationService;
+import com.netflix.servo.monitor.DynamicCounter;
+import com.netflix.servo.tag.BasicTagList;
 import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nonnull;
 import javax.validation.constraints.Size;
 import java.io.IOException;
+import java.util.Map;
 import java.util.UUID;
 
 /**
@@ -90,12 +95,13 @@ public class SNSNotificationServiceImpl implements NotificationService {
     public void notifyOfPartitionAddition(@Nonnull final MetacatSaveTablePartitionPostEvent event) {
         log.debug("Received SaveTablePartitionPostEvent {}", event);
         CounterWrapper.incrementCounter("metacat.notifications.sns.events.partitions.add");
+        final String name = event.getName().toString();
+        final long timestamp = event.getRequestContext().getTimestamp();
+        final String requestId = event.getRequestContext().getId();
+        AddPartitionMessage message = null;
         try {
-            final String name = event.getName().toString();
-            final long timestamp = event.getRequestContext().getTimestamp();
-            final String requestId = event.getRequestContext().getId();
             for (final PartitionDto partition : event.getPartitions()) {
-                final AddPartitionMessage message = new AddPartitionMessage(
+                message = new AddPartitionMessage(
                     UUID.randomUUID().toString(),
                     timestamp,
                     requestId,
@@ -106,9 +112,14 @@ public class SNSNotificationServiceImpl implements NotificationService {
                 log.debug("Published create partition message {} on {}", message, this.partitionTopicArn);
                 CounterWrapper.incrementCounter("metacat.notifications.sns.partitions.add.succeeded");
             }
-
+        } catch (final Exception e) {
+            handleException(event.getName(), "Unable to publish partition creation notification",
+                "metacat.notifications.sns.partitions.add.failed", message, e);
+        }
+        UpdateTablePartitionsMessage tableMessage = null;
+        try {
             // Publish a global message stating how many partitions were updated for the table to the table topic
-            final UpdateTablePartitionsMessage message = new UpdateTablePartitionsMessage(
+            tableMessage = new UpdateTablePartitionsMessage(
                 UUID.randomUUID().toString(),
                 timestamp,
                 requestId,
@@ -118,13 +129,13 @@ public class SNSNotificationServiceImpl implements NotificationService {
                     0
                 )
             );
-            this.publishNotification(this.tableTopicArn, message);
+            this.publishNotification(this.tableTopicArn, tableMessage);
             // TODO: In ideal world this this be an injected object to the class so we can mock for tests
             //       swap out implementations etc.
             CounterWrapper.incrementCounter("metacat.notifications.sns.tables.addPartitions.succeeded");
         } catch (final Exception e) {
-            log.error("Unable to publish partition creation notification", e);
-            CounterWrapper.incrementCounter("metacat.notifications.sns.partitions.add.failed");
+            handleException(event.getName(), "Unable to publish table partition add notification",
+                "metacat.notifications.sns.tables.addPartitions.failed", tableMessage, e);
         }
     }
 
@@ -135,12 +146,13 @@ public class SNSNotificationServiceImpl implements NotificationService {
     public void notifyOfPartitionDeletion(@Nonnull final MetacatDeleteTablePartitionPostEvent event) {
         log.debug("Received DeleteTablePartition event {}", event);
         CounterWrapper.incrementCounter("metacat.notifications.sns.events.partitions.delete");
+        final String name = event.getName().toString();
+        final long timestamp = event.getRequestContext().getTimestamp();
+        final String requestId = event.getRequestContext().getId();
+        DeletePartitionMessage message = null;
         try {
-            final String name = event.getName().toString();
-            final long timestamp = event.getRequestContext().getTimestamp();
-            final String requestId = event.getRequestContext().getId();
             for (final String partitionId : event.getPartitionIds()) {
-                final DeletePartitionMessage message = new DeletePartitionMessage(
+                message = new DeletePartitionMessage(
                     UUID.randomUUID().toString(),
                     timestamp,
                     requestId,
@@ -151,9 +163,14 @@ public class SNSNotificationServiceImpl implements NotificationService {
                 CounterWrapper.incrementCounter("metacat.notifications.sns.partitions.delete.succeeded");
                 log.debug("Published delete partition message {} on {}", message, this.partitionTopicArn);
             }
-
+        } catch (final Exception e) {
+            handleException(event.getName(), "Unable to publish partition deletion notification",
+                "metacat.notifications.sns.partitions.delete.failed", message, e);
+        }
+        UpdateTablePartitionsMessage tableMessage = null;
+        try {
             // Publish a global message stating how many partitions were updated for the table to the table topic
-            final UpdateTablePartitionsMessage message = new UpdateTablePartitionsMessage(
+            tableMessage = new UpdateTablePartitionsMessage(
                 UUID.randomUUID().toString(),
                 timestamp,
                 requestId,
@@ -163,11 +180,11 @@ public class SNSNotificationServiceImpl implements NotificationService {
                     event.getPartitionIds().size()
                 )
             );
-            this.publishNotification(this.tableTopicArn, message);
+            this.publishNotification(this.tableTopicArn, tableMessage);
             CounterWrapper.incrementCounter("metacat.notifications.sns.tables.deletePartitions.succeeded");
         } catch (final Exception e) {
-            log.error("Unable to publish partition deletion notification", e);
-            CounterWrapper.incrementCounter("metacat.notifications.sns.partitions.delete.failed");
+            handleException(event.getName(), "Unable to publish table partition delete notification",
+                "metacat.notifications.sns.tables.deletePartitions.failed", tableMessage, e);
         }
     }
 
@@ -178,8 +195,9 @@ public class SNSNotificationServiceImpl implements NotificationService {
     public void notifyOfTableCreation(@Nonnull final MetacatCreateTablePostEvent event) {
         log.debug("Received CreateTableEvent {}", event);
         CounterWrapper.incrementCounter("metacat.notifications.sns.events.tables.create");
+        CreateTableMessage message = null;
         try {
-            final CreateTableMessage message = new CreateTableMessage(
+            message = new CreateTableMessage(
                 UUID.randomUUID().toString(),
                 event.getRequestContext().getTimestamp(),
                 event.getRequestContext().getId(),
@@ -189,8 +207,8 @@ public class SNSNotificationServiceImpl implements NotificationService {
             this.publishNotification(this.tableTopicArn, message);
             CounterWrapper.incrementCounter("metacat.notifications.sns.tables.create.succeeded");
         } catch (final Exception e) {
-            log.error("Unable to publish create table notification", e);
-            CounterWrapper.incrementCounter("metacat.notifications.sns.tables.create.failed");
+            handleException(event.getName(), "Unable to publish create table notification",
+                "metacat.notifications.sns.tables.create.failed", message, e);
         }
     }
 
@@ -201,8 +219,9 @@ public class SNSNotificationServiceImpl implements NotificationService {
     public void notifyOfTableDeletion(@Nonnull final MetacatDeleteTablePostEvent event) {
         log.debug("Received DeleteTableEvent {}", event);
         CounterWrapper.incrementCounter("metacat.notifications.sns.events.tables.delete");
+        DeleteTableMessage message = null;
         try {
-            final DeleteTableMessage message = new DeleteTableMessage(
+            message = new DeleteTableMessage(
                 UUID.randomUUID().toString(),
                 event.getRequestContext().getTimestamp(),
                 event.getRequestContext().getId(),
@@ -212,8 +231,8 @@ public class SNSNotificationServiceImpl implements NotificationService {
             this.publishNotification(this.tableTopicArn, message);
             CounterWrapper.incrementCounter("metacat.notifications.sns.tables.delete.succeeded");
         } catch (final Exception e) {
-            log.error("Unable to publish delete table notification", e);
-            CounterWrapper.incrementCounter("metacat.notifications.sns.tables.delete.failed");
+            handleException(event.getName(), "Unable to publish delete table notification",
+                "metacat.notifications.sns.tables.delete.failed", message, e);
         }
     }
 
@@ -224,8 +243,9 @@ public class SNSNotificationServiceImpl implements NotificationService {
     public void notifyOfTableRename(@Nonnull final MetacatRenameTablePostEvent event) {
         log.debug("Received RenameTableEvent {}", event);
         CounterWrapper.incrementCounter("metacat.notifications.sns.events.tables.rename");
+        UpdateTableMessage message = null;
         try {
-            final UpdateTableMessage message = this.createUpdateTableMessage(
+            message = this.createUpdateTableMessage(
                 UUID.randomUUID().toString(),
                 event.getRequestContext().getTimestamp(),
                 event.getRequestContext().getId(),
@@ -236,8 +256,8 @@ public class SNSNotificationServiceImpl implements NotificationService {
             this.publishNotification(this.tableTopicArn, message);
             CounterWrapper.incrementCounter("metacat.notifications.sns.tables.rename.succeeded");
         } catch (final Exception e) {
-            log.error("Unable to publish rename table notification", e);
-            CounterWrapper.incrementCounter("metacat.notifications.sns.tables.rename.failed");
+            handleException(event.getName(), "Unable to publish rename table notification",
+                "metacat.notifications.sns.tables.rename.failed", message, e);
         }
     }
 
@@ -248,8 +268,9 @@ public class SNSNotificationServiceImpl implements NotificationService {
     public void notifyOfTableUpdate(@Nonnull final MetacatUpdateTablePostEvent event) {
         log.debug("Received UpdateTableEvent {}", event);
         CounterWrapper.incrementCounter("metacat.notifications.sns.events.tables.update");
+        UpdateTableMessage message = null;
         try {
-            final UpdateTableMessage message = this.createUpdateTableMessage(
+            message = this.createUpdateTableMessage(
                 UUID.randomUUID().toString(),
                 event.getRequestContext().getTimestamp(),
                 event.getRequestContext().getId(),
@@ -260,9 +281,21 @@ public class SNSNotificationServiceImpl implements NotificationService {
             this.publishNotification(this.tableTopicArn, message);
             CounterWrapper.incrementCounter("metacat.notifications.sns.tables.update.succeeded");
         } catch (final Exception e) {
-            log.error("Unable to publish update table notification", e);
-            CounterWrapper.incrementCounter("metacat.notifications.sns.tables.update.failed");
+            handleException(event.getName(), "Unable to publish update table notification",
+                "metacat.notifications.sns.tables.update.failed", message, e);
         }
+    }
+
+    private void handleException(final QualifiedName name, final String message, final String counterKey,
+        final SNSMessage payload, final Exception e) {
+        log.error(String.format("%s with payload: %s", message, payload), e);
+        DynamicCounter.increment(counterKey, getQualifiedNameTagList(name));
+    }
+
+    private static BasicTagList getQualifiedNameTagList(final QualifiedName name) {
+        final Map<String, String> tags = Maps.newHashMap(name.toJson());
+        tags.remove("qualifiedName");
+        return BasicTagList.copyOf(tags);
     }
 
     private UpdateTableMessage createUpdateTableMessage(

--- a/metacat-main/src/main/java/com/netflix/metacat/main/services/notifications/sns/SNSNotificationServiceImpl.java
+++ b/metacat-main/src/main/java/com/netflix/metacat/main/services/notifications/sns/SNSNotificationServiceImpl.java
@@ -23,7 +23,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.fge.jsonpatch.JsonPatch;
 import com.github.fge.jsonpatch.diff.JsonDiff;
-import com.google.common.collect.Maps;
 import com.netflix.metacat.common.QualifiedName;
 import com.netflix.metacat.common.dto.PartitionDto;
 import com.netflix.metacat.common.dto.TableDto;
@@ -51,7 +50,6 @@ import lombok.extern.slf4j.Slf4j;
 import javax.annotation.Nonnull;
 import javax.validation.constraints.Size;
 import java.io.IOException;
-import java.util.Map;
 import java.util.UUID;
 
 /**
@@ -288,14 +286,8 @@ public class SNSNotificationServiceImpl implements NotificationService {
 
     private void handleException(final QualifiedName name, final String message, final String counterKey,
         final SNSMessage payload, final Exception e) {
-        log.error(String.format("%s with payload: %s", message, payload), e);
-        DynamicCounter.increment(counterKey, getQualifiedNameTagList(name));
-    }
-
-    private static BasicTagList getQualifiedNameTagList(final QualifiedName name) {
-        final Map<String, String> tags = Maps.newHashMap(name.toJson());
-        tags.remove("qualifiedName");
-        return BasicTagList.copyOf(tags);
+        log.error("{} with payload: {}", message, payload, e);
+        DynamicCounter.increment(counterKey, BasicTagList.copyOf(name.parts()));
     }
 
     private UpdateTableMessage createUpdateTableMessage(


### PR DESCRIPTION
Removed the automatic registration of listeners to Metacat event bus. Added more context info to logs and metrics on SNS publish failures.