### PR TITLE
Bug fixes.

### DIFF
--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/util/ThreadServiceManager.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/util/ThreadServiceManager.java
@@ -35,16 +35,40 @@ import java.util.concurrent.TimeUnit;
 @Slf4j
 public class ThreadServiceManager {
     private ListeningExecutorService executor;
+    private final int maxThreads;
+    private final int maxQueueSize;
+    private final String usage;
+
+    /**
+     * Constructor taking in the config.
+     * @param config configurations
+     */
     @Inject
-    private Config config;
+    public ThreadServiceManager(final Config config) {
+        this.maxThreads = config.getServiceMaxNumberOfThreads();
+        this.maxQueueSize = 1000;
+        this.usage = "service";
+    }
+
+    /**
+     * Constructor.
+     * @param maxThreads maximum number of threads
+     * @param maxQueueSize maximum queue size
+     * @param usage an identifier where this pool is used
+     */
+    public ThreadServiceManager(final int maxThreads, final int maxQueueSize, final String usage) {
+        this.maxThreads = maxThreads;
+        this.maxQueueSize = maxQueueSize;
+        this.usage = usage;
+    }
 
     /**
      * Starts the manager.
      */
     @PostConstruct
     public void start() {
-        final ExecutorService executorService = newFixedThreadPool(config.getServiceMaxNumberOfThreads(),
-            "metacat-service-pool-%d", 1000);
+        final ExecutorService executorService = newFixedThreadPool(maxThreads,
+            "metacat-" + usage + "-pool-%d", maxQueueSize);
         executor = MoreExecutors.listeningDecorator(executorService);
     }
 

--- a/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/HiveConnectorFactory.java
+++ b/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/HiveConnectorFactory.java
@@ -24,6 +24,7 @@ import com.netflix.metacat.common.server.connectors.ConnectorFactory;
 import com.netflix.metacat.common.server.connectors.ConnectorPartitionService;
 import com.netflix.metacat.common.server.connectors.ConnectorTableService;
 import com.netflix.metacat.common.server.util.DataSourceManager;
+import com.netflix.metacat.common.server.util.ThreadServiceManager;
 import com.netflix.metacat.connector.hive.client.embedded.EmbeddedHiveClient;
 import com.netflix.metacat.connector.hive.client.thrift.HiveMetastoreClientFactory;
 import com.netflix.metacat.connector.hive.client.thrift.MetacatHiveClient;
@@ -87,6 +88,7 @@ public class HiveConnectorFactory implements ConnectorFactory {
         }
         final Module hiveModule = new HiveConnectorModule(catalogName, configuration, infoConverter, client);
         this.injector = Guice.createInjector(hiveModule);
+        injector.getInstance(ThreadServiceManager.class).start();
     }
 
     private IMetacatHiveClient createLocalClient() throws Exception {
@@ -154,6 +156,7 @@ public class HiveConnectorFactory implements ConnectorFactory {
     public void stop() {
         try {
             client.shutdown();
+            injector.getInstance(ThreadServiceManager.class).stop();
         } catch (TException e) {
             log.warn("Failed shutting down the catalog: {}", catalogName, e);
         }

--- a/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/HiveConnectorFastPartitionService.java
+++ b/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/HiveConnectorFastPartitionService.java
@@ -132,7 +132,6 @@ public class HiveConnectorFastPartitionService extends HiveConnectorPartitionSer
                                              final ThreadServiceManager threadServiceManager) {
         super(catalogName, metacatHiveClient, hiveMetacatConverters);
         this.threadServiceManager = threadServiceManager;
-        this.threadServiceManager.start();
     }
 
     /**

--- a/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/HiveConnectorFastTableService.java
+++ b/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/HiveConnectorFastTableService.java
@@ -22,7 +22,6 @@ import com.google.common.collect.Maps;
 import com.netflix.metacat.common.QualifiedName;
 import com.netflix.metacat.common.server.connectors.ConnectorContext;
 import com.netflix.metacat.common.server.util.DataSourceManager;
-import com.netflix.metacat.common.server.util.ThreadServiceManager;
 import com.netflix.metacat.connector.hive.converters.HiveConnectorInfoConverter;
 import lombok.NonNull;
 import org.apache.commons.dbutils.QueryRunner;
@@ -50,8 +49,6 @@ public class HiveConnectorFastTableService extends HiveConnectorTableService {
             + "from DBS d, TBLS t, SDS s where d.DB_ID=t.DB_ID and t.sd_id=s.sd_id";
     private static final String SQL_EXIST_TABLE_BY_NAME =
         "select 1 from DBS d join TBLS t on d.DB_ID=t.DB_ID where d.name=? and t.tbl_name=?";
-    private final boolean allowRenameTable;
-    private final ThreadServiceManager threadServiceManager;
 
     /**
      * Constructor.
@@ -60,7 +57,6 @@ public class HiveConnectorFastTableService extends HiveConnectorTableService {
      * @param metacatHiveClient            hive client
      * @param hiveConnectorDatabaseService databaseService
      * @param hiveMetacatConverters        hive converter
-     * @param threadServiceManager         threadservicemanager
      * @param allowRenameTable             allow rename table
      */
     @Inject
@@ -68,12 +64,8 @@ public class HiveConnectorFastTableService extends HiveConnectorTableService {
                                          @Nonnull @NonNull final IMetacatHiveClient metacatHiveClient,
     @Nonnull @NonNull final HiveConnectorDatabaseService hiveConnectorDatabaseService,
                                          @Nonnull @NonNull final HiveConnectorInfoConverter hiveMetacatConverters,
-                                         final ThreadServiceManager threadServiceManager,
                                          @Named("allowRenameTable") final boolean allowRenameTable) {
         super(catalogName, metacatHiveClient, hiveConnectorDatabaseService, hiveMetacatConverters, allowRenameTable);
-        this.allowRenameTable = allowRenameTable;
-        this.threadServiceManager = threadServiceManager;
-        this.threadServiceManager.start();
     }
 
     /**

--- a/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/HiveConnectorModule.java
+++ b/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/HiveConnectorModule.java
@@ -43,6 +43,7 @@ public class HiveConnectorModule implements Module {
     private final IMetacatHiveClient hiveMetastoreClient;
     private final boolean fastService;
     private final boolean allowRenameTable;
+    private final int threadPoolSize;
 
     /**
      * Constructor.
@@ -62,12 +63,13 @@ public class HiveConnectorModule implements Module {
                 .parseBoolean(configuration.getOrDefault(HiveConfigConstants.USE_FASTHIVE_SERVICE, "false"));
         this.allowRenameTable = Boolean
                 .parseBoolean(configuration.getOrDefault(HiveConfigConstants.ALLOW_RENAME_TABLE, "false"));
+        this.threadPoolSize = Integer.parseInt(configuration.getOrDefault(HiveConfigConstants.THREAD_POOL_SIZE, "20"));
     }
 
     @Override
     public void configure(final Binder binder) {
         binder.bind(Config.class).toInstance(new ArchaiusConfigImpl());
-        binder.bind(ThreadServiceManager.class).asEagerSingleton();
+        binder.bind(ThreadServiceManager.class).toInstance(new ThreadServiceManager(threadPoolSize, 1000, catalogName));
         binder.bind(String.class).annotatedWith(Names.named("catalogName")).toInstance(catalogName);
         binder.bind(Boolean.class).annotatedWith(Names.named("allowRenameTable")).toInstance(allowRenameTable);
         binder.bind(HiveConnectorInfoConverter.class).toInstance(infoConverter);

--- a/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/util/HiveConfigConstants.java
+++ b/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/util/HiveConfigConstants.java
@@ -46,6 +46,10 @@ public final class HiveConfigConstants {
      * USE_FASTPARTITION_SERVICE.
      */
     public static final String USE_FASTHIVE_SERVICE = "hive.use.embedded.fastservice";
+    /**
+     * USE_FASTPARTITION_SERVICE.
+     */
+    public static final String THREAD_POOL_SIZE = "hive.thread.pool.size";
 
     /**
      * USE_METASTORE_LOCAL.

--- a/metacat-main/src/main/java/com/netflix/metacat/main/api/PartitionV1Resource.java
+++ b/metacat-main/src/main/java/com/netflix/metacat/main/api/PartitionV1Resource.java
@@ -507,7 +507,8 @@ public class PartitionV1Resource implements PartitionV1 {
                 // This metadata is actually for the table, if it is present update that
                 if (partitionsSaveRequestDto.getDefinitionMetadata() != null
                     || partitionsSaveRequestDto.getDataMetadata() != null) {
-                    final TableDto dto = v1.getTable(catalogName, databaseName, tableName, true, false, false);
+                    final TableDto dto = new TableDto();
+                    dto.setName(name);
                     dto.setDefinitionMetadata(partitionsSaveRequestDto.getDefinitionMetadata());
                     dto.setDataMetadata(partitionsSaveRequestDto.getDataMetadata());
                     v1.updateTable(catalogName, databaseName, tableName, dto);
@@ -537,7 +538,8 @@ public class PartitionV1Resource implements PartitionV1 {
                 // This metadata is actually for the view, if it is present update that
                 if (partitionsSaveRequestDto.getDefinitionMetadata() != null
                     || partitionsSaveRequestDto.getDataMetadata() != null) {
-                    final TableDto dto = v1.getMView(catalogName, databaseName, tableName, viewName);
+                    final TableDto dto = new TableDto();
+                    dto.setName(name);
                     dto.setDefinitionMetadata(partitionsSaveRequestDto.getDefinitionMetadata());
                     dto.setDataMetadata(partitionsSaveRequestDto.getDataMetadata());
                     v1.updateMView(catalogName, databaseName, tableName, viewName, dto);


### PR DESCRIPTION
1. SavePartition API should update only table metadata and not the schema when updating metrics.
2. Fixed the usage of threadservicemanager in hive connector.