### PR TITLE
Fix latency in handling events.

### DIFF
--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/ArchaiusConfigImpl.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/ArchaiusConfigImpl.java
@@ -64,9 +64,11 @@ public class ArchaiusConfigImpl implements Config {
     private final DynamicBooleanProperty canSoftDeleteDataMetadata;
     private final DynamicBooleanProperty canCascadeViewsMetadataOnTableDelete;
     private final DynamicIntProperty userMetadataMaxInClauseItems;
+    private final DynamicIntProperty snsClientThreadCount;
     private final DynamicBooleanProperty snsEnabled;
     private final DynamicStringProperty snsTopicTableArn;
     private final DynamicStringProperty snsTopicPartitionArn;
+    private final DynamicBooleanProperty snsNotificationTopicPartitionEnabled;
 
     /**
      * Default constructor.
@@ -102,7 +104,7 @@ public class ArchaiusConfigImpl implements Config {
             .getIntProperty("metacat.elacticsearch.refresh.threshold.unmarked.tables.delete", 1000);
         this.epochInSeconds = factory.getBooleanProperty("metacat.type.epoch_in_seconds", true);
         this.eventBusExecutorThreadCount = factory.getIntProperty("metacat.event.bus.executor.thread.count", 20);
-        this.eventBusThreadCount = factory.getIntProperty("metacat.event.thread.count", 20);
+        this.eventBusThreadCount = factory.getIntProperty("metacat.event.thread.count", 50);
         this.hivePartitionWhitelistPattern = factory
             .getStringProperty("metacat.hive.metastore.partition.name.whitelist.pattern", "");
         this.lookupServiceUserAdmin = factory.getStringProperty("metacat.lookup_service.user_admin", "admin");
@@ -137,6 +139,9 @@ public class ArchaiusConfigImpl implements Config {
             = factory.getStringProperty("metacat.notifications.sns.topic.table.arn", null);
         this.snsTopicPartitionArn
             = factory.getStringProperty("metacat.notifications.sns.topic.partition.arn", null);
+        this.snsClientThreadCount = factory.getIntProperty("metacat.notifications.sns.client.thread.count", 50);
+        this.snsNotificationTopicPartitionEnabled =
+            factory.getBooleanProperty("metacat.notifications.sns.topic.partition.enabled", true);
     }
 
     private void setQualifiedNamesToElasticSearchRefreshExcludeQualifiedNames() {
@@ -354,5 +359,15 @@ public class ArchaiusConfigImpl implements Config {
     @Override
     public String getSnsTopicPartitionArn() {
         return this.snsTopicPartitionArn.get();
+    }
+
+    @Override
+    public int getSNSClientThreadCount() {
+        return this.snsClientThreadCount.get();
+    }
+
+    @Override
+    public boolean isSnsNotificationTopicPartitionEnabled() {
+        return this.snsNotificationTopicPartitionEnabled.get();
     }
 }

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/Config.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/Config.java
@@ -203,4 +203,18 @@ public interface Config {
      * @return The partition topic ARN or null if no property set
      */
     String getSnsTopicPartitionArn();
+
+    /**
+     * Get the size of the thread pool used by SNS client.
+     * @return size of the thread pool used by SNS client
+     */
+    int getSNSClientThreadCount();
+
+    /**
+     * Whether or not notifications should be published to SNS Partition topic. If this is enabled, the
+     * partition topic arn must also exist or SNS won't be enabled.
+     *
+     * @return Whether SNS notifications to partitions topic should be enabled
+     */
+    boolean isSnsNotificationTopicPartitionEnabled();
 }

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/util/ThreadServiceManager.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/util/ThreadServiceManager.java
@@ -74,7 +74,7 @@ public class ThreadServiceManager {
             "metacat-" + usage + "-pool-%d", maxQueueSize);
         executor = MoreExecutors.listeningDecorator(executorService);
         final CompositeMonitor<?> newThreadPoolMonitor =
-            Monitors.newThreadPoolMonitor("metacat." + usage + ".pool", (ThreadPoolExecutor) executor);
+            Monitors.newThreadPoolMonitor("metacat." + usage + ".pool", (ThreadPoolExecutor) executorService);
         DefaultMonitorRegistry.getInstance().register(newThreadPoolMonitor);
     }
 

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/util/ThreadServiceManager.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/util/ThreadServiceManager.java
@@ -19,6 +19,9 @@ import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.inject.Inject;
 import com.netflix.metacat.common.server.Config;
+import com.netflix.servo.DefaultMonitorRegistry;
+import com.netflix.servo.monitor.CompositeMonitor;
+import com.netflix.servo.monitor.Monitors;
 import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.PostConstruct;
@@ -70,6 +73,9 @@ public class ThreadServiceManager {
         final ExecutorService executorService = newFixedThreadPool(maxThreads,
             "metacat-" + usage + "-pool-%d", maxQueueSize);
         executor = MoreExecutors.listeningDecorator(executorService);
+        final CompositeMonitor<?> newThreadPoolMonitor =
+            Monitors.newThreadPoolMonitor("metacat." + usage + ".pool", (ThreadPoolExecutor) executor);
+        DefaultMonitorRegistry.getInstance().register(newThreadPoolMonitor);
     }
 
     @SuppressWarnings("checkstyle:hiddenfield")

--- a/metacat-main/src/main/java/com/netflix/metacat/main/init/MetacatInitializationService.java
+++ b/metacat-main/src/main/java/com/netflix/metacat/main/init/MetacatInitializationService.java
@@ -71,7 +71,6 @@ public class MetacatInitializationService {
         injector.getInstance(ThreadServiceManager.class).start();
         // Start the thrift services
         injector.getInstance(MetacatThriftService.class).start();
-
         // Initialize elastic search client
         final Client client = injector.getInstance(Client.class);
         if (client != null) {

--- a/metacat-main/src/test/groovy/com/netflix/metacat/main/services/notifications/sns/SNSNotificationServiceImplProviderSpec.groovy
+++ b/metacat-main/src/test/groovy/com/netflix/metacat/main/services/notifications/sns/SNSNotificationServiceImplProviderSpec.groovy
@@ -55,6 +55,7 @@ class SNSNotificationServiceImplProviderSpec extends Specification {
 
         then: "Should return a SNSNotificationServiceImpl implementation"
         service instanceof SNSNotificationServiceImpl
+        1 * config.getSNSClientThreadCount() >> 1
         1 * this.config.isSnsNotificationEnabled() >> true
         1 * this.config.getSnsTopicPartitionArn() >> UUID.randomUUID().toString()
         1 * this.config.getSnsTopicTableArn() >> UUID.randomUUID().toString()


### PR DESCRIPTION
1. Use AmazonSNSAsyncClient instead of AmazonSNSCLient for publishing messages.
2. Log latency for events processed in elastic search and SNS handlers.
3. Fire the table change event before firing the list of partition events.