### PR TITLE
Fixed regression issue where setting tags for a redshift table was broken.

### DIFF
--- a/metacat-client/src/main/java/com/netflix/metacat/client/Client.java
+++ b/metacat-client/src/main/java/com/netflix/metacat/client/Client.java
@@ -25,6 +25,7 @@ import com.netflix.metacat.common.api.MetacatV1;
 import com.netflix.metacat.common.api.MetadataV1;
 import com.netflix.metacat.common.api.PartitionV1;
 import com.netflix.metacat.common.api.ResolverV1;
+import com.netflix.metacat.common.api.TagV1;
 import com.netflix.metacat.common.json.MetacatJsonLocator;
 import feign.Feign;
 import feign.Request;
@@ -50,6 +51,7 @@ public final class Client {
     private final PartitionV1 partitionApi;
     private final MetadataV1 metadataApi;
     private final ResolverV1 resolverApi;
+    private final TagV1 tagApi;
 
     private Client(
         @Nonnull
@@ -90,6 +92,7 @@ public final class Client {
         partitionApi = getApiClient(PartitionV1.class);
         metadataApi = getApiClient(MetadataV1.class);
         resolverApi = getApiClient(ResolverV1.class);
+        tagApi = getApiClient(TagV1.class);
     }
 
     /**
@@ -300,5 +303,14 @@ public final class Client {
      */
     public ResolverV1 getResolverApi() {
         return resolverApi;
+    }
+
+    /**
+     * Return an API instance that can be used to interact with
+     * the metacat server for tagging metadata.
+     * @return An instance api conforming to TagV1 interface
+     */
+    public TagV1 getTagApi() {
+        return tagApi;
     }
 }

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/connectors/ConnectorBaseService.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/connectors/ConnectorBaseService.java
@@ -21,6 +21,7 @@ import com.netflix.metacat.common.QualifiedName;
 import com.netflix.metacat.common.dto.Pageable;
 import com.netflix.metacat.common.dto.Sort;
 import com.netflix.metacat.common.server.connectors.model.BaseInfo;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -92,8 +93,9 @@ public interface ConnectorBaseService<T extends BaseInfo> {
      * @return Return true, if the resource exists.
      * @throws UnsupportedOperationException If the connector doesn't implement this method
      */
+    @SuppressFBWarnings
     default boolean exists(@Nonnull final ConnectorContext context, @Nonnull final QualifiedName name) {
-        throw new UnsupportedOperationException(UNSUPPORTED_MESSAGE);
+        return get(context, name) != null;
     }
 
     /**

--- a/metacat-connector-jdbc/src/main/java/com/netflix/metacat/connector/jdbc/services/JdbcConnectorTableService.java
+++ b/metacat-connector-jdbc/src/main/java/com/netflix/metacat/connector/jdbc/services/JdbcConnectorTableService.java
@@ -110,10 +110,7 @@ public class JdbcConnectorTableService implements ConnectorTableService {
     @Override
     public TableInfo get(@Nonnull final ConnectorContext context, @Nonnull final QualifiedName name) {
         log.debug("Beginning to get table metadata for qualified name {} for request {}", name, context);
-        // If table does not exist, throw TableNotFoundException.
-        if (!exists(context, name)) {
-            throw new TableNotFoundException(name);
-        }
+
         try (Connection connection = this.dataSource.getConnection()) {
             final String database = name.getDatabaseName();
             connection.setSchema(database);
@@ -138,6 +135,11 @@ public class JdbcConnectorTableService implements ConnectorTableService {
 
                     fields.add(fieldInfo.build());
                 }
+            }
+            final List<FieldInfo> fieldInfos = fields.build();
+            // If table does not exist, throw TableNotFoundException.
+            if (fieldInfos.isEmpty() && !exists(context, name)) {
+                throw new TableNotFoundException(name);
             }
             log.debug("Finished getting table metadata for qualified name {} for request {}", name, context);
             return TableInfo.builder().name(name).fields(fields.build()).build();

--- a/metacat-connector-jdbc/src/test/groovy/com/netflix/metacat/connector/jdbc/services/JdbcConnectorDatabaseServiceSpec.groovy
+++ b/metacat-connector-jdbc/src/test/groovy/com/netflix/metacat/connector/jdbc/services/JdbcConnectorDatabaseServiceSpec.groovy
@@ -276,14 +276,6 @@ class JdbcConnectorDatabaseServiceSpec extends Specification {
         )      | "update"        | UnsupportedOperationException
         (
             {
-                new JdbcConnectorDatabaseService(Mock(DataSource), Mock(JdbcExceptionMapper)).exists(
-                    Mock(ConnectorContext),
-                    QualifiedName.ofDatabase("catalog", "database")
-                )
-            }
-        )      | "exists"        | UnsupportedOperationException
-        (
-            {
                 new JdbcConnectorDatabaseService(Mock(DataSource), Mock(JdbcExceptionMapper)).rename(
                     Mock(ConnectorContext),
                     QualifiedName.ofDatabase("catalog", "database"),

--- a/metacat-connector-redshift/src/test/groovy/com/netflix/metacat/connector/redshift/RedshiftConnectorTableServiceSpec.groovy
+++ b/metacat-connector-redshift/src/test/groovy/com/netflix/metacat/connector/redshift/RedshiftConnectorTableServiceSpec.groovy
@@ -60,11 +60,9 @@ class RedshiftConnectorTableServiceSpec extends Specification {
         then:
         1 * this.dataSource.getConnection() >> connection
         1 * connection.createStatement() >> statement
-        1 * connection.getMetaData() >> metadata
-        1 * metadata.storesUpperCaseIdentifiers() >> true
-        1 * connection.setSchema(database.toUpperCase())
+        1 * connection.setSchema(database)
         1 * statement.executeUpdate(
-            "DROP TABLE " + qName.getCatalogName() + "." + qName.getDatabaseName() + "." + table.toUpperCase()
+            "DROP TABLE " + qName.getCatalogName() + "." + qName.getDatabaseName() + "." + table
         )
     }
 
@@ -83,8 +81,6 @@ class RedshiftConnectorTableServiceSpec extends Specification {
         then:
         1 * this.dataSource.getConnection() >> connection
         1 * connection.createStatement() >> statement
-        1 * connection.getMetaData() >> metadata
-        1 * metadata.storesUpperCaseIdentifiers() >> false
         1 * connection.setSchema(database)
         1 * statement.executeUpdate(
             "DROP TABLE " + qName.getCatalogName() + "." + qName.getDatabaseName() + "." + table
@@ -115,10 +111,8 @@ class RedshiftConnectorTableServiceSpec extends Specification {
         then:
         1 * this.dataSource.getConnection() >> connection
         1 * connection.createStatement() >> statement
-        1 * connection.getMetaData() >> metadata
-        1 * metadata.storesUpperCaseIdentifiers() >> true
         1 * statement.executeUpdate(
-            "ALTER TABLE " + oldName.getCatalogName() + "." + oldName.getDatabaseName() + ".C RENAME TO D"
+            "ALTER TABLE " + oldName.getCatalogName() + "." + oldName.getDatabaseName() + ".c RENAME TO d"
         )
     }
 
@@ -135,8 +129,6 @@ class RedshiftConnectorTableServiceSpec extends Specification {
         then:
         1 * this.dataSource.getConnection() >> connection
         1 * connection.createStatement() >> statement
-        1 * connection.getMetaData() >> metadata
-        1 * metadata.storesUpperCaseIdentifiers() >> false
         1 * statement.executeUpdate(
             "ALTER TABLE " + oldName.getCatalogName() + "." + oldName.getDatabaseName() + ".c RENAME TO d"
         )
@@ -183,15 +175,5 @@ class RedshiftConnectorTableServiceSpec extends Specification {
                 )
             }
         )      | "update"        | UnsupportedOperationException
-        (
-            {
-                new JdbcConnectorTableService(
-                    Mock(DataSource), Mock(JdbcTypeConverter), Mock(JdbcExceptionMapper)
-                ).exists(
-                    Mock(ConnectorContext),
-                    QualifiedName.ofTable("catalog", "database", "table")
-                )
-            }
-        )      | "exists"        | UnsupportedOperationException
     }
 }

--- a/metacat-functional-tests/src/functionalTest/groovy/com/netflix/metacat/MetacatFunctionalSpec.groovy
+++ b/metacat-functional-tests/src/functionalTest/groovy/com/netflix/metacat/MetacatFunctionalSpec.groovy
@@ -23,6 +23,7 @@ import com.netflix.metacat.common.QualifiedName
 import com.netflix.metacat.common.api.MetacatV1
 import com.netflix.metacat.common.api.PartitionV1
 import com.netflix.metacat.common.api.ResolverV1
+import com.netflix.metacat.common.api.TagV1
 import com.netflix.metacat.common.dto.*
 import com.netflix.metacat.common.exception.MetacatAlreadyExistsException
 import com.netflix.metacat.common.exception.MetacatBadRequestException
@@ -47,6 +48,7 @@ class MetacatFunctionalSpec extends Specification {
     public static MetacatV1 api
     public static PartitionV1 partitionApi
     public static ResolverV1 resolverApi
+    public static TagV1 tagApi
     public static final MetacatJson metacatJson = MetacatJsonLocator.INSTANCE
     public static final long BATCH_ID = System.currentTimeSeconds()
     public static final int timediff = 24 * 3600
@@ -64,6 +66,7 @@ class MetacatFunctionalSpec extends Specification {
         api = client.api
         partitionApi = client.partitionApi
         resolverApi = client.resolverApi
+        tagApi = client.tagApi
         TestCatalogs.resetAll()
     }
 
@@ -370,22 +373,6 @@ class MetacatFunctionalSpec extends Specification {
 
         where:
         name << TestCatalogs.getCreatedDatabases(TestCatalogs.ALL)
-    }
-
-    def "getTable: Test get table for #name"() {
-        given:
-        def catalogName = name.catalogName
-        def databaseName = name.databaseName
-        def tableName = name.tableName
-
-        when:
-        def table = api.getTable(catalogName, databaseName, tableName, true, true, true)
-
-        then:
-        table != null
-
-        where:
-        name << TestCatalogs.getAllTables(TestCatalogs.ALL)
     }
 
     def 'createTable: should fail for #catalog where it is not supported'() {
@@ -1155,6 +1142,54 @@ class MetacatFunctionalSpec extends Specification {
 
         where:
         name << TestCatalogs.getCreatedTables(TestCatalogs.getCanDeleteTable(TestCatalogs.ALL))
+    }
+
+    def "getTable: Test get table for #name"() {
+        given:
+        def catalogName = name.catalogName
+        def databaseName = name.databaseName
+        def tableName = name.tableName
+
+        when:
+        def table = api.getTable(catalogName, databaseName, tableName, true, true, true)
+
+        then:
+        table != null
+
+        where:
+        name << TestCatalogs.getAllTables(TestCatalogs.ALL)
+    }
+
+    def "getTable: Test get non-existing table #name should throw NotFoundException"() {
+        given:
+        def catalogName = name.catalogName
+        def databaseName = name.databaseName
+        def tableName = name.tableName + UUID.randomUUID()
+
+        when:
+        api.getTable(catalogName, databaseName, tableName, true, true, true)
+
+        then:
+        thrown(MetacatNotFoundException)
+
+        where:
+        name << TestCatalogs.getAllTables(TestCatalogs.ALL)
+    }
+
+    def "setTableTags: Test tag table for #name"() {
+        given:
+        def catalogName = name.catalogName
+        def databaseName = name.databaseName
+        def tableName = name.tableName
+        def tags = ['test', 'unused'] as Set<String>
+        when:
+        tagApi.setTableTags(catalogName, databaseName, tableName, tags)
+        then:
+        metacatJson.convertValue(api.getTable(catalogName, databaseName, tableName, false, true, true).getDefinitionMetadata().get('tags'), Set.class) == tags
+        cleanup:
+        tagApi.removeTableTags(catalogName, databaseName, tableName, true, [] as Set<String>)
+        where:
+        name << TestCatalogs.getAllTables(TestCatalogs.ALL)
     }
 
     def 'deletePartition: #name'() {

--- a/metacat-functional-tests/src/functionalTest/groovy/com/netflix/metacat/TestCatalogs.groovy
+++ b/metacat-functional-tests/src/functionalTest/groovy/com/netflix/metacat/TestCatalogs.groovy
@@ -100,9 +100,9 @@ class TestCatalogs {
                 QualifiedName.ofDatabase('postgresql-96-db', 'pg_catalog'),
             ],
             preExistingTables: [
-                QualifiedName.ofTable('postgresql-96-db', 'world', 'City'),
-                QualifiedName.ofTable('postgresql-96-db', 'world', 'Country'),
-                QualifiedName.ofTable('postgresql-96-db', 'world', 'countrylanguage'),
+                QualifiedName.ofTable('postgresql-96-db', 'public', 'City'),
+                QualifiedName.ofTable('postgresql-96-db', 'public', 'Country'),
+                QualifiedName.ofTable('postgresql-96-db', 'public', 'countrylanguage'),
             ],
             type: 'postgresql',
         ),


### PR DESCRIPTION
ConnectorBaseService.exists method was not implemented by the Redshift connector.
Fixed regression issue where getTable for non-existing redshift tables were not failing with a 404 error.