### PR TITLE
Hive connector code cleanup

### DIFF
--- a/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/HiveConnectorDatabaseService.java
+++ b/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/HiveConnectorDatabaseService.java
@@ -21,8 +21,8 @@ import com.netflix.metacat.common.QualifiedName;
 import com.netflix.metacat.common.dto.Pageable;
 import com.netflix.metacat.common.dto.Sort;
 import com.netflix.metacat.common.exception.MetacatNotSupportedException;
-import com.netflix.metacat.common.server.connectors.ConnectorRequestContext;
 import com.netflix.metacat.common.server.connectors.ConnectorDatabaseService;
+import com.netflix.metacat.common.server.connectors.ConnectorRequestContext;
 import com.netflix.metacat.common.server.connectors.ConnectorUtils;
 import com.netflix.metacat.common.server.connectors.exception.ConnectorException;
 import com.netflix.metacat.common.server.connectors.exception.DatabaseAlreadyExistsException;
@@ -51,29 +51,26 @@ import java.util.List;
 public class HiveConnectorDatabaseService implements ConnectorDatabaseService {
     private final IMetacatHiveClient metacatHiveClient;
     private final HiveConnectorInfoConverter hiveMetacatConverters;
-    private final String catalogName;
 
     /**
      * Constructor.
      *
-     * @param catalogName           catalogname
-     * @param metacatHiveClient     hiveclient
+     * @param metacatHiveClient     hive client
      * @param hiveMetacatConverters hive converter
      */
-    public HiveConnectorDatabaseService(final String catalogName,
-                                        final IMetacatHiveClient metacatHiveClient,
-                                        final HiveConnectorInfoConverter hiveMetacatConverters) {
+    public HiveConnectorDatabaseService(
+        final IMetacatHiveClient metacatHiveClient,
+        final HiveConnectorInfoConverter hiveMetacatConverters
+    ) {
         this.metacatHiveClient = metacatHiveClient;
         this.hiveMetacatConverters = hiveMetacatConverters;
-        this.catalogName = catalogName;
     }
 
     /**
      * {@inheritDoc}.
      */
     @Override
-    public void create(final ConnectorRequestContext requestContext,
-                       final DatabaseInfo databaseInfo) {
+    public void create(final ConnectorRequestContext requestContext, final DatabaseInfo databaseInfo) {
         final QualifiedName databaseName = databaseInfo.getName();
         try {
             this.metacatHiveClient.createDatabase(hiveMetacatConverters.fromDatabaseInfo(databaseInfo));
@@ -91,9 +88,7 @@ public class HiveConnectorDatabaseService implements ConnectorDatabaseService {
      * {@inheritDoc}.
      */
     @Override
-    public void delete(final ConnectorRequestContext requestContext,
-                       final QualifiedName name) {
-
+    public void delete(final ConnectorRequestContext requestContext, final QualifiedName name) {
         try {
             this.metacatHiveClient.dropDatabase(name.getDatabaseName());
         } catch (NoSuchObjectException exception) {
@@ -111,8 +106,7 @@ public class HiveConnectorDatabaseService implements ConnectorDatabaseService {
      * {@inheritDoc}.
      */
     @Override
-    public void update(final ConnectorRequestContext context,
-                       final DatabaseInfo databaseInfo) {
+    public void update(final ConnectorRequestContext context, final DatabaseInfo databaseInfo) {
         final QualifiedName databaseName = databaseInfo.getName();
         try {
             this.metacatHiveClient.alterDatabase(databaseName.getDatabaseName(),
@@ -131,10 +125,7 @@ public class HiveConnectorDatabaseService implements ConnectorDatabaseService {
      * {@inheritDoc}.
      */
     @Override
-    public DatabaseInfo get(
-        final ConnectorRequestContext requestContext,
-        final QualifiedName name
-    ) {
+    public DatabaseInfo get(final ConnectorRequestContext requestContext, final QualifiedName name) {
         try {
             final Database database = metacatHiveClient.getDatabase(name.getDatabaseName());
             if (database != null) {
@@ -155,8 +146,7 @@ public class HiveConnectorDatabaseService implements ConnectorDatabaseService {
      * {@inheritDoc}.
      */
     @Override
-    public boolean exists(final ConnectorRequestContext requestContext,
-                          final QualifiedName name) {
+    public boolean exists(final ConnectorRequestContext requestContext, final QualifiedName name) {
         boolean result;
         try {
             result = metacatHiveClient.getDatabase(name.getDatabaseName()) != null;
@@ -217,7 +207,7 @@ public class HiveConnectorDatabaseService implements ConnectorDatabaseService {
             final List<DatabaseInfo> databaseInfos = Lists.newArrayList();
             for (String databaseName : metacatHiveClient.getAllDatabases()) {
                 final QualifiedName qualifiedName = QualifiedName.ofDatabase(name.getCatalogName(), databaseName);
-                if (!qualifiedName.toString().startsWith(prefix.toString())) {
+                if (prefix != null && !qualifiedName.toString().startsWith(prefix.toString())) {
                     continue;
                 }
                 databaseInfos.add(DatabaseInfo.builder().name(qualifiedName).build());

--- a/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/HiveConnectorPlugin.java
+++ b/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/HiveConnectorPlugin.java
@@ -31,13 +31,11 @@ import com.netflix.metacat.connector.hive.converters.HiveTypeConverter;
  * @since 1.0.0
  */
 public class HiveConnectorPlugin implements ConnectorPlugin {
-    /**
-     * Type of the connector.
-     */
-    public static final String CONNECTOR_TYPE = "hive";
+    private static final String CONNECTOR_TYPE = "hive";
     private static final HiveTypeConverter HIVE_TYPE_CONVERTER = new HiveTypeConverter();
-    private static final ConnectorInfoConverter INFO_CONVERTER_HIVE =
-            new HiveConnectorInfoConverter(HIVE_TYPE_CONVERTER);
+    private static final HiveConnectorInfoConverter INFO_CONVERTER_HIVE
+        = new HiveConnectorInfoConverter(HIVE_TYPE_CONVERTER);
+
     /**
      * {@inheritDoc}
      */
@@ -55,7 +53,9 @@ public class HiveConnectorPlugin implements ConnectorPlugin {
         final ConnectorContext connectorContext
     ) {
         return new HiveConnectorFactory(
-            catalogName, (HiveConnectorInfoConverter) INFO_CONVERTER_HIVE, connectorContext
+            catalogName,
+            INFO_CONVERTER_HIVE,
+            connectorContext
         );
     }
 

--- a/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/configs/HiveConnectorClientConfig.java
+++ b/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/configs/HiveConnectorClientConfig.java
@@ -28,12 +28,14 @@ import javax.sql.DataSource;
 
 /**
  * Hive Connector Client Config.
+ *
  * @author zhenl
  * @since 1.1.0
  */
 @Configuration
 @ConditionalOnProperty(value = "useThriftClient", havingValue = "false")
 public class HiveConnectorClientConfig {
+
     /**
      * create local hive client.
      *
@@ -41,21 +43,28 @@ public class HiveConnectorClientConfig {
      * @return IMetacatHiveClient
      * @throws Exception exception
      */
-
     @Bean
-    public IMetacatHiveClient createLocalClient(
-        final ConnectorContext connectorContext) throws Exception {
+    public IMetacatHiveClient createLocalClient(final ConnectorContext connectorContext) throws Exception {
         try {
-            final HiveConf conf = getDefaultConf();
+            final HiveConf conf = this.getDefaultConf();
             connectorContext.getConfiguration().forEach(conf::set);
-            DataSourceManager.get().load(connectorContext.getCatalogName(),
-                connectorContext.getConfiguration());
-            return new EmbeddedHiveClient(connectorContext.getCatalogName(),
-                HMSHandlerProxy.getProxy(conf), connectorContext.getRegistry());
+            DataSourceManager.get().load(
+                connectorContext.getCatalogName(),
+                connectorContext.getConfiguration()
+            );
+            return new EmbeddedHiveClient(
+                connectorContext.getCatalogName(),
+                HMSHandlerProxy.getProxy(conf),
+                connectorContext.getRegistry()
+            );
         } catch (Exception e) {
             throw new IllegalArgumentException(
-                String.format("Failed creating the hive metastore client for catalog: %s",
-                    connectorContext.getCatalogName()), e);
+                String.format(
+                    "Failed creating the hive metastore client for catalog: %s",
+                    connectorContext.getCatalogName()
+                ),
+                e
+            );
         }
     }
 
@@ -66,16 +75,17 @@ public class HiveConnectorClientConfig {
      * @return data source
      */
     @Bean
-    //@ConditionalOnProperty(value = "useThriftClient", havingValue = "false")
     public DataSource hiveDataSource(final ConnectorContext connectorContext) {
-        final HiveConf conf = getDefaultConf();
+        final HiveConf conf = this.getDefaultConf();
         connectorContext.getConfiguration().forEach(conf::set);
-        DataSourceManager.get().load(connectorContext.getCatalogName(),
-            connectorContext.getConfiguration());
+        DataSourceManager.get().load(
+            connectorContext.getCatalogName(),
+            connectorContext.getConfiguration()
+        );
         return DataSourceManager.get().get(connectorContext.getCatalogName());
     }
 
-    private static HiveConf getDefaultConf() {
+    private HiveConf getDefaultConf() {
         final HiveConf result = new HiveConf();
         result.setBoolean(HiveConfigConstants.USE_METASTORE_LOCAL, true);
         result.setInt(HiveConfigConstants.JAVAX_JDO_DATASTORETIMEOUT, 60000);
@@ -83,8 +93,10 @@ public class HiveConnectorClientConfig {
         result.setInt(HiveConfigConstants.JAVAX_JDO_DATASTOREWRITETIMEOUT, 60000);
         result.setInt(HiveConfigConstants.HIVE_METASTORE_DS_RETRY, 0);
         result.setInt(HiveConfigConstants.HIVE_HMSHANDLER_RETRY, 0);
-        result.set(HiveConfigConstants.JAVAX_JDO_PERSISTENCEMANAGER_FACTORY_CLASS,
-            HiveConfigConstants.JAVAX_JDO_PERSISTENCEMANAGER_FACTORY);
+        result.set(
+            HiveConfigConstants.JAVAX_JDO_PERSISTENCEMANAGER_FACTORY_CLASS,
+            HiveConfigConstants.JAVAX_JDO_PERSISTENCEMANAGER_FACTORY
+        );
         result.setBoolean(HiveConfigConstants.HIVE_STATS_AUTOGATHER, false);
         return result;
     }

--- a/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/configs/HiveConnectorFastServiceConfig.java
+++ b/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/configs/HiveConnectorFastServiceConfig.java
@@ -18,9 +18,10 @@ import com.netflix.metacat.common.server.util.ThreadServiceManager;
 import com.netflix.metacat.connector.hive.HiveConnectorDatabaseService;
 import com.netflix.metacat.connector.hive.HiveConnectorFastPartitionService;
 import com.netflix.metacat.connector.hive.HiveConnectorFastTableService;
+import com.netflix.metacat.connector.hive.HiveConnectorPartitionService;
+import com.netflix.metacat.connector.hive.HiveConnectorTableService;
 import com.netflix.metacat.connector.hive.IMetacatHiveClient;
 import com.netflix.metacat.connector.hive.converters.HiveConnectorInfoConverter;
-import com.netflix.metacat.connector.hive.util.HiveConfigConstants;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
@@ -44,22 +45,26 @@ public class HiveConnectorFastServiceConfig {
      * @param metacatHiveClient    hive client
      * @param hiveMetacatConverter metacat converter
      * @param threadServiceManager thread service manager
-     * @param connectorContext      connector config
+     * @param connectorContext     connector config
      * @param dataSource           data source
      * @return HiveConnectorPartitionService
      */
     @Bean
-    public HiveConnectorFastPartitionService fastHivePartitionService(
+    public HiveConnectorPartitionService fastHivePartitionService(
         final IMetacatHiveClient metacatHiveClient,
         final HiveConnectorInfoConverter hiveMetacatConverter,
         final ThreadServiceManager threadServiceManager,
         final ConnectorContext connectorContext,
         @Qualifier("hiveDataSource") final DataSource dataSource
     ) {
-        return new HiveConnectorFastPartitionService(connectorContext.getCatalogName(),
-            metacatHiveClient, hiveMetacatConverter,
-            connectorContext, threadServiceManager,
-            dataSource);
+        return new HiveConnectorFastPartitionService(
+            connectorContext.getCatalogName(),
+            metacatHiveClient,
+            hiveMetacatConverter,
+            connectorContext,
+            threadServiceManager,
+            dataSource
+        );
     }
 
     /**
@@ -68,27 +73,25 @@ public class HiveConnectorFastServiceConfig {
      * @param metacatHiveClient            metacat hive client
      * @param hiveMetacatConverters        hive metacat converters
      * @param hiveConnectorDatabaseService hive database service
-     * @param connectorContext              server context
+     * @param connectorContext             server context
      * @param dataSource                   data source
      * @return HiveConnectorFastTableService
      */
     @Bean
-    public HiveConnectorFastTableService fastHiveTableService(
+    public HiveConnectorTableService fastHiveTableService(
         final IMetacatHiveClient metacatHiveClient,
         final HiveConnectorInfoConverter hiveMetacatConverters,
         final HiveConnectorDatabaseService hiveConnectorDatabaseService,
         final ConnectorContext connectorContext,
         @Qualifier("hiveDataSource") final DataSource dataSource
-
     ) {
         return new HiveConnectorFastTableService(
-            connectorContext.getCatalogName(), metacatHiveClient,
-            hiveConnectorDatabaseService, hiveMetacatConverters,
-            Boolean.parseBoolean(
-                connectorContext.getConfiguration()
-                    .getOrDefault(HiveConfigConstants.ALLOW_RENAME_TABLE, "false")),
+            connectorContext.getCatalogName(),
+            metacatHiveClient,
+            hiveConnectorDatabaseService,
+            hiveMetacatConverters,
             connectorContext,
-            dataSource);
+            dataSource
+        );
     }
-
 }

--- a/metacat-connector-hive/src/test/groovy/com/netflix/metacat/connector/hive/HiveConnectorDatabaseSpec.groovy
+++ b/metacat-connector-hive/src/test/groovy/com/netflix/metacat/connector/hive/HiveConnectorDatabaseSpec.groovy
@@ -44,9 +44,9 @@ class HiveConnectorDatabaseSpec extends Specification {
     @Shared
     MetacatHiveClient metacatHiveClient = Mock(MetacatHiveClient)
     @Shared
-    HiveConnectorDatabaseService hiveConnectorDatabaseService = new HiveConnectorDatabaseService("testhive", metacatHiveClient, new HiveConnectorInfoConverter(new HiveTypeConverter()))
+    HiveConnectorDatabaseService hiveConnectorDatabaseService = new HiveConnectorDatabaseService(metacatHiveClient, new HiveConnectorInfoConverter(new HiveTypeConverter()))
     @Shared
-    ConnectorRequestContext connectorContext = new ConnectorRequestContext(1, null);
+    ConnectorRequestContext connectorContext = new ConnectorRequestContext(1, null)
 
     def setupSpec() {
         metacatHiveClient.getAllDatabases() >> ["test1", "test2", "dev1", "dev2"]
@@ -64,8 +64,8 @@ class HiveConnectorDatabaseSpec extends Specification {
 
     @Unroll
     def "Test for create database with Exceptions"() {
-        def client = Mock(MetacatHiveClient);
-        def hiveConnectorDatabaseService = new HiveConnectorDatabaseService("testhive", client, new HiveConnectorInfoConverter(new HiveTypeConverter()))
+        def client = Mock(MetacatHiveClient)
+        def hiveConnectorDatabaseService = new HiveConnectorDatabaseService(client, new HiveConnectorInfoConverter(new HiveTypeConverter()))
         when:
         hiveConnectorDatabaseService.create(connectorContext, DatabaseInfo.builder().name(QualifiedName.ofDatabase("testhive", "testdb2")).uri("file://temp/").build())
         then:
@@ -96,7 +96,7 @@ class HiveConnectorDatabaseSpec extends Specification {
     @Unroll
     def "Test for exist database"() {
         def client = Mock(MetacatHiveClient)
-        def hiveConnectorDatabaseService = new HiveConnectorDatabaseService("testhive", client, new HiveConnectorInfoConverter(new HiveTypeConverter()))
+        def hiveConnectorDatabaseService = new HiveConnectorDatabaseService(client, new HiveConnectorInfoConverter(new HiveTypeConverter()))
         when:
         def result = hiveConnectorDatabaseService.exists(connectorContext, QualifiedName.ofDatabase("testhive", "testdb"))
         then:
@@ -110,19 +110,19 @@ class HiveConnectorDatabaseSpec extends Specification {
 
     def "Test for exist database NoSuchObjectException"() {
         def client = Mock(MetacatHiveClient)
-        def hiveConnectorDatabaseService = new HiveConnectorDatabaseService("testhive", client, new HiveConnectorInfoConverter(new HiveTypeConverter()))
+        def hiveConnectorDatabaseService = new HiveConnectorDatabaseService(client, new HiveConnectorInfoConverter(new HiveTypeConverter()))
         when:
         def result = hiveConnectorDatabaseService.exists(connectorContext, QualifiedName.ofDatabase("testhive", "testdb"))
         then:
         client.getDatabase(_) >> { throw new NoSuchObjectException() }
-        result == false
+        !result
     }
 
     def "Test for exist database TException"() {
         def client = Mock(MetacatHiveClient)
-        def hiveConnectorDatabaseService = new HiveConnectorDatabaseService("testhive", client, new HiveConnectorInfoConverter(new HiveTypeConverter()))
+        def hiveConnectorDatabaseService = new HiveConnectorDatabaseService(client, new HiveConnectorInfoConverter(new HiveTypeConverter()))
         when:
-        def result = hiveConnectorDatabaseService.exists(connectorContext, QualifiedName.ofDatabase("testhive", "testdb"))
+        hiveConnectorDatabaseService.exists(connectorContext, QualifiedName.ofDatabase("testhive", "testdb"))
         then:
         client.getDatabase(_) >> { throw new TException() }
         thrown ConnectorException
@@ -131,10 +131,10 @@ class HiveConnectorDatabaseSpec extends Specification {
     @Unroll
     def "Test for listNames database with Exceptions"() {
         def client = Mock(MetacatHiveClient)
-        def hiveConnectorDatabaseService = new HiveConnectorDatabaseService("testhive", client, new HiveConnectorInfoConverter(new HiveTypeConverter()))
+        def hiveConnectorDatabaseService = new HiveConnectorDatabaseService(client, new HiveConnectorInfoConverter(new HiveTypeConverter()))
 
         when:
-        def dbs = hiveConnectorDatabaseService.listNames(connectorContext, QualifiedName.ofDatabase("testhive", "testdb"), null, new Sort(null, SortOrder.ASC), null)
+        hiveConnectorDatabaseService.listNames(connectorContext, QualifiedName.ofDatabase("testhive", "testdb"), null, new Sort(null, SortOrder.ASC), null)
         then:
         1 * client.getAllDatabases() >> { throw exception }
         thrown result
@@ -156,7 +156,7 @@ class HiveConnectorDatabaseSpec extends Specification {
     def "Test for get database"() {
         def dbName = "testdb"
         def localHiveClient = Mock(MetacatHiveClient)
-        def hiveDbService = new HiveConnectorDatabaseService("testhive", localHiveClient, new HiveConnectorInfoConverter(new HiveTypeConverter()))
+        def hiveDbService = new HiveConnectorDatabaseService(localHiveClient, new HiveConnectorInfoConverter(new HiveTypeConverter()))
 
         when:
         def dbInfo = hiveDbService.get(this.connectorContext, QualifiedName.ofDatabase("testhive", dbName))
@@ -169,7 +169,7 @@ class HiveConnectorDatabaseSpec extends Specification {
     @Unroll
     def "Test for get database with exceptions"() {
         def client = Mock(MetacatHiveClient)
-        def hiveConnectorDatabaseService = new HiveConnectorDatabaseService("testhive", client, new HiveConnectorInfoConverter(new HiveTypeConverter()))
+        def hiveConnectorDatabaseService = new HiveConnectorDatabaseService(client, new HiveConnectorInfoConverter(new HiveTypeConverter()))
         when:
         hiveConnectorDatabaseService.get(connectorContext, QualifiedName.ofDatabase("testhive", "testdb2"))
         then:
@@ -192,11 +192,11 @@ class HiveConnectorDatabaseSpec extends Specification {
 
     @Unroll
     def "Test for list database exceptions"() {
-        def client = Mock(MetacatHiveClient);
-        def hiveConnectorDatabaseService = new HiveConnectorDatabaseService("testhive", client, new HiveConnectorInfoConverter(new HiveTypeConverter()))
+        def client = Mock(MetacatHiveClient)
+        def hiveConnectorDatabaseService = new HiveConnectorDatabaseService(client, new HiveConnectorInfoConverter(new HiveTypeConverter()))
 
         when:
-        def dbs = hiveConnectorDatabaseService.list(connectorContext, QualifiedName.ofDatabase("testhive", ""), QualifiedName.ofDatabase("testhive", "test"), null, null)
+        hiveConnectorDatabaseService.list(connectorContext, QualifiedName.ofDatabase("testhive", ""), QualifiedName.ofDatabase("testhive", "test"), null, null)
         then:
         1 * client.getAllDatabases() >> { throw exception }
         thrown result

--- a/metacat-connector-hive/src/test/groovy/com/netflix/metacat/connector/hive/HiveConnectorTableSpec.groovy
+++ b/metacat-connector-hive/src/test/groovy/com/netflix/metacat/connector/hive/HiveConnectorTableSpec.groovy
@@ -16,31 +16,25 @@
 
 package com.netflix.metacat.connector.hive
 
+import com.google.common.collect.ImmutableMap
 import com.netflix.metacat.common.QualifiedName
 import com.netflix.metacat.common.dto.Pageable
 import com.netflix.metacat.common.dto.Sort
 import com.netflix.metacat.common.dto.SortOrder
+import com.netflix.metacat.common.server.connectors.ConnectorContext
 import com.netflix.metacat.common.server.connectors.ConnectorRequestContext
+import com.netflix.metacat.common.server.connectors.exception.*
 import com.netflix.metacat.common.server.connectors.model.AuditInfo
 import com.netflix.metacat.common.server.connectors.model.StorageInfo
 import com.netflix.metacat.common.server.connectors.model.TableInfo
-import com.netflix.metacat.common.server.connectors.exception.DatabaseNotFoundException
-import com.netflix.metacat.common.server.connectors.exception.InvalidMetaException
-import com.netflix.metacat.common.server.connectors.exception.TableAlreadyExistsException
-import com.netflix.metacat.common.server.connectors.exception.TableNotFoundException
+import com.netflix.metacat.common.server.properties.Config
+import com.netflix.metacat.connector.hive.client.thrift.MetacatHiveClient
 import com.netflix.metacat.connector.hive.converters.HiveConnectorInfoConverter
 import com.netflix.metacat.connector.hive.converters.HiveTypeConverter
-import com.netflix.metacat.common.server.connectors.exception.ConnectorException
-import com.netflix.metacat.connector.hive.client.thrift.MetacatHiveClient
+import com.netflix.metacat.connector.hive.util.HiveConfigConstants
 import com.netflix.metacat.testdata.provider.MetacatDataInfoProvider
-import org.apache.hadoop.hive.metastore.api.AlreadyExistsException
-import org.apache.hadoop.hive.metastore.api.FieldSchema
-import org.apache.hadoop.hive.metastore.api.InvalidObjectException
-import org.apache.hadoop.hive.metastore.api.MetaException
-import org.apache.hadoop.hive.metastore.api.NoSuchObjectException
-import org.apache.hadoop.hive.metastore.api.SerDeInfo
-import org.apache.hadoop.hive.metastore.api.StorageDescriptor
-import org.apache.hadoop.hive.metastore.api.Table
+import com.netflix.spectator.api.Registry
+import org.apache.hadoop.hive.metastore.api.*
 import org.apache.thrift.TException
 import spock.lang.Shared
 import spock.lang.Specification
@@ -53,28 +47,43 @@ import spock.lang.Unroll
  */
 class HiveConnectorTableSpec extends Specification {
     @Shared
-    MetacatHiveClient metacatHiveClient = Mock(MetacatHiveClient);
+    MetacatHiveClient metacatHiveClient = Mock(MetacatHiveClient)
     @Shared
-    HiveConnectorDatabaseService hiveConnectorDatabaseService = Mock(HiveConnectorDatabaseService);
+    HiveConnectorDatabaseService hiveConnectorDatabaseService = Mock(HiveConnectorDatabaseService)
     @Shared
-    HiveConnectorTableService hiveConnectorTableService = new HiveConnectorTableService("testhive", metacatHiveClient,
-            hiveConnectorDatabaseService, new HiveConnectorInfoConverter(new HiveTypeConverter()), true )
+    HiveConnectorTableService hiveConnectorTableService = new HiveConnectorTableService(
+        "testhive",
+        metacatHiveClient,
+        hiveConnectorDatabaseService,
+        new HiveConnectorInfoConverter(new HiveTypeConverter()),
+        new ConnectorContext(
+            "testHive",
+            Mock(Config),
+            Mock(Registry),
+            ImmutableMap.of(HiveConfigConstants.ALLOW_RENAME_TABLE, "true")
+        )
+    )
     @Shared
-    ConnectorRequestContext connectorContext = new ConnectorRequestContext(1, null);
+    ConnectorRequestContext connectorRequestContext = new ConnectorRequestContext(1, null)
     @Shared
-    HiveConnectorInfoConverter hiveConnectorInfoConverter = new HiveConnectorInfoConverter(new HiveTypeConverter())
+    ConnectorContext connectorContext = new ConnectorContext(
+        "testHive",
+        Mock(Config),
+        Mock(Registry),
+        ImmutableMap.of(HiveConfigConstants.ALLOW_RENAME_TABLE, "true")
+    )
 
     def setupSpec() {
         metacatHiveClient.createTable(_) >> {}
         metacatHiveClient.getAllTables("test1") >> MetacatDataInfoProvider.getTables()
-        metacatHiveClient.getTableByName("test1", "testtable3") >> { throw new TException()}
+        metacatHiveClient.getTableByName("test1", "testtable3") >> { throw new TException() }
         metacatHiveClient.rename("test1", "testtable1", "test2", "testtable2") >> {}
         metacatHiveClient.dropTable("test1", "testtable1") >> {}
-        metacatHiveClient.dropTable("test1", "testtable3") >> {throw new TException()}
-        metacatHiveClient.getTableByName("test1", "testtable1") >> { getTable("testtable1")}
+        metacatHiveClient.dropTable("test1", "testtable3") >> { throw new TException() }
+        metacatHiveClient.getTableByName("test1", "testtable1") >> { getTable("testtable1") }
     }
 
-    static getTable(String tableName){
+    static getTable(String tableName) {
         Table table = new Table()
         table.tableName = tableName
         table.owner = "test"
@@ -93,7 +102,7 @@ class HiveConnectorTableSpec extends Specification {
         return table
     }
 
-    static getPartitionTable(String tableName){
+    static getPartitionTable(String tableName) {
         Table table = new Table()
         table.dbName = "test1"
         table.tableName = tableName
@@ -116,206 +125,206 @@ class HiveConnectorTableSpec extends Specification {
         return table
     }
 
-    def "Test for create table" (){
+    def "Test for create table"() {
         when:
-        hiveConnectorTableService.create( connectorContext,
-                TableInfo.builder().name(QualifiedName.ofTable("testhive", "test1", "testingtable"))
-                        .serde(StorageInfo.builder().serializationLib('org.apache.hadoop.hive.ql.io.orc.OrcSerde').outputFormat('org.apache.hadoop.hive.ql.io.orc.OrcInputFormat').build()).build())
+        hiveConnectorTableService.create(connectorRequestContext,
+            TableInfo.builder().name(QualifiedName.ofTable("testhive", "test1", "testingtable"))
+                .serde(StorageInfo.builder().serializationLib('org.apache.hadoop.hive.ql.io.orc.OrcSerde').outputFormat('org.apache.hadoop.hive.ql.io.orc.OrcInputFormat').build()).build())
         then:
         noExceptionThrown()
     }
 
     @Unroll
-    def "Test for create table throw exception" (){
-        def client = Mock(MetacatHiveClient);
-        def hiveConnectorTableService = new HiveConnectorTableService("testhive", client, hiveConnectorDatabaseService, new HiveConnectorInfoConverter( new HiveTypeConverter()), true )
+    def "Test for create table throw exception"() {
+        def client = Mock(MetacatHiveClient)
+        def hiveConnectorTableService = new HiveConnectorTableService("testhive", client, hiveConnectorDatabaseService, new HiveConnectorInfoConverter(new HiveTypeConverter()), connectorContext)
 
         when:
-        hiveConnectorTableService.create( connectorContext,
-                TableInfo.builder().name(QualifiedName.ofTable("testhive", "test1", "testingtable"))
-                        .serde(StorageInfo.builder().serializationLib('org.apache.hadoop.hive.ql.io.orc.OrcSerde').outputFormat('org.apache.hadoop.hive.ql.io.orc.OrcInputFormat').build()).build())
+        hiveConnectorTableService.create(connectorRequestContext,
+            TableInfo.builder().name(QualifiedName.ofTable("testhive", "test1", "testingtable"))
+                .serde(StorageInfo.builder().serializationLib('org.apache.hadoop.hive.ql.io.orc.OrcSerde').outputFormat('org.apache.hadoop.hive.ql.io.orc.OrcInputFormat').build()).build())
         then:
-        1 * client.createTable(_) >> { throw exception}
+        1 * client.createTable(_) >> { throw exception }
         thrown result
 
         where:
-        exception                    | result
-        new TException()             |ConnectorException
-        new AlreadyExistsException() |TableAlreadyExistsException
-        new MetaException()          |InvalidMetaException
-        new InvalidObjectException() |DatabaseNotFoundException
+        exception                                                         | result
+        new TException()                                                  | ConnectorException
+        new org.apache.hadoop.hive.metastore.api.AlreadyExistsException() | TableAlreadyExistsException
+        new MetaException()                                               | InvalidMetaException
+        new InvalidObjectException()                                      | DatabaseNotFoundException
     }
 
     @Unroll
-    def "Test for update table" (){
+    def "Test for update table"() {
         given:
-            hiveConnectorTableService.updateTable( connectorContext, table, tableInfo)
+        hiveConnectorTableService.updateTable(connectorRequestContext, table, tableInfo)
         expect:
-            table.getParameters().get("EXTERNAL") == "TRUE"
-            table.getParameters() != null
-            table.getSd() != null
+        table.getParameters().get("EXTERNAL") == "TRUE"
+        table.getParameters() != null
+        table.getSd() != null
         where:
         table                           | tableInfo
         getPartitionTable("testtable")  | TableInfo.builder()
-                                          .name(QualifiedName.ofTable("testhive", "test1", "testtable1"))
-                                          .serde( StorageInfo.builder().owner("test").uri("s3://test/uri").build())
-                                          .metadata ( ['tp_k1': 'tp_v1'])
-                                          .auditInfo( AuditInfo.builder().build())
-                                          .build()
-        getPartitionTable("testtable2")  | TableInfo.builder()
-                .name(QualifiedName.ofTable("testhive", "test1", "testtable2"))
-                .serde( StorageInfo.builder().owner("test").uri("s3://test/uri").build())
-                .auditInfo( AuditInfo.builder().build())
-                .build()
-        getPartitionTable("testtable3")  | TableInfo.builder()
-                .name(QualifiedName.ofTable("testhive", "test1", "testtable3"))
-                .build()
+            .name(QualifiedName.ofTable("testhive", "test1", "testtable1"))
+            .serde(StorageInfo.builder().owner("test").uri("s3://test/uri").build())
+            .metadata(['tp_k1': 'tp_v1'])
+            .auditInfo(AuditInfo.builder().build())
+            .build()
+        getPartitionTable("testtable2") | TableInfo.builder()
+            .name(QualifiedName.ofTable("testhive", "test1", "testtable2"))
+            .serde(StorageInfo.builder().owner("test").uri("s3://test/uri").build())
+            .auditInfo(AuditInfo.builder().build())
+            .build()
+        getPartitionTable("testtable3") | TableInfo.builder()
+            .name(QualifiedName.ofTable("testhive", "test1", "testtable3"))
+            .build()
     }
 
-    def "Test for get table" (){
+    def "Test for get table"() {
         when:
         def name = QualifiedName.ofTable("testhive", "test1", "testtable1")
-        def tableInfo = hiveConnectorTableService.get( connectorContext, name)
+        def tableInfo = hiveConnectorTableService.get(connectorRequestContext, name)
         def expected = MetacatDataInfoProvider.getTableInfo("testtable1")
 
         then:
-            tableInfo == expected
+        tableInfo == expected
     }
 
     @Unroll
-    def "Test for get table with exceptions" (){
-        def client = Mock(MetacatHiveClient);
-        def hiveConnectorTableService = new HiveConnectorTableService("testhive", client, hiveConnectorDatabaseService, new HiveConnectorInfoConverter( new HiveTypeConverter()), true )
+    def "Test for get table with exceptions"() {
+        def client = Mock(MetacatHiveClient)
+        def hiveConnectorTableService = new HiveConnectorTableService("testhive", client, hiveConnectorDatabaseService, new HiveConnectorInfoConverter(new HiveTypeConverter()), connectorContext)
 
         when:
-        hiveConnectorTableService.get( connectorContext, QualifiedName.ofTable("testhive", "test1", "testtable3"))
+        hiveConnectorTableService.get(connectorRequestContext, QualifiedName.ofTable("testhive", "test1", "testtable3"))
         then:
-        1 * client.getTableByName(_,_) >> { throw exception}
+        1 * client.getTableByName(_, _) >> { throw exception }
         thrown result
 
         where:
-        exception                    | result
-        new TException()             |ConnectorException
-        new MetaException()          |InvalidMetaException
-        new NoSuchObjectException()  |TableNotFoundException
+        exception                   | result
+        new TException()            | ConnectorException
+        new MetaException()         | InvalidMetaException
+        new NoSuchObjectException() | TableNotFoundException
     }
 
-    def "Test for delete table" (){
+    def "Test for delete table"() {
         when:
         def name = QualifiedName.ofTable("testhive", "test1", "testtable1")
-        hiveConnectorTableService.delete( connectorContext, name)
+        hiveConnectorTableService.delete(connectorRequestContext, name)
         then:
         noExceptionThrown()
     }
 
     @Unroll
-    def "Test for delete table throw exceptions" (){
-        def client = Mock(MetacatHiveClient);
-        def hiveConnectorTableService = new HiveConnectorTableService("testhive", client, hiveConnectorDatabaseService, new HiveConnectorInfoConverter( new HiveTypeConverter()), true )
+    def "Test for delete table throw exceptions"() {
+        def client = Mock(MetacatHiveClient)
+        def hiveConnectorTableService = new HiveConnectorTableService("testhive", client, hiveConnectorDatabaseService, new HiveConnectorInfoConverter(new HiveTypeConverter()), connectorContext)
 
         when:
         def name = QualifiedName.ofTable("testhive", "test1", "testtable3")
-        hiveConnectorTableService.delete( connectorContext, name)
+        hiveConnectorTableService.delete(connectorRequestContext, name)
         then:
-        1 * client.dropTable(_,_) >> { throw exception}
+        1 * client.dropTable(_, _) >> { throw exception }
         thrown result
 
         where:
-        exception                    | result
-        new TException()             |ConnectorException
-        new MetaException()          |InvalidMetaException
-        new NoSuchObjectException()  |TableNotFoundException
+        exception                   | result
+        new TException()            | ConnectorException
+        new MetaException()         | InvalidMetaException
+        new NoSuchObjectException() | TableNotFoundException
     }
 
     @Unroll
-    def "Test for listNames tables"(){
+    def "Test for listNames tables"() {
         when:
-        def tables = hiveConnectorTableService.listNames(connectorContext, QualifiedName.ofDatabase("testhive","test1"), null, order, null )
+        def tables = hiveConnectorTableService.listNames(connectorRequestContext, QualifiedName.ofDatabase("testhive", "test1"), null, order, null)
         then:
         tables == result
         where:
-        order | result
-        new Sort(null, SortOrder.ASC) | MetacatDataInfoProvider.getAllTableNames()
-        new Sort(null, SortOrder.DESC)| MetacatDataInfoProvider.getAllTableNames().reverse()
+        order                          | result
+        new Sort(null, SortOrder.ASC)  | MetacatDataInfoProvider.getAllTableNames()
+        new Sort(null, SortOrder.DESC) | MetacatDataInfoProvider.getAllTableNames().reverse()
     }
 
     @Unroll
-    def "Test for listNames tables exceptions"(){
-        def client = Mock(MetacatHiveClient);
-        def hiveConnectorTableService = new HiveConnectorTableService("testhive", client, hiveConnectorDatabaseService, new HiveConnectorInfoConverter( new HiveTypeConverter()), true )
+    def "Test for listNames tables exceptions"() {
+        def client = Mock(MetacatHiveClient)
+        def hiveConnectorTableService = new HiveConnectorTableService("testhive", client, hiveConnectorDatabaseService, new HiveConnectorInfoConverter(new HiveTypeConverter()), connectorContext)
 
         when:
-        hiveConnectorTableService.listNames(connectorContext, QualifiedName.ofDatabase("testhive","test1"), null, null, null )
+        hiveConnectorTableService.listNames(connectorRequestContext, QualifiedName.ofDatabase("testhive", "test1"), null, null, null)
 
         then:
-        1 * client.getAllTables(_) >> { throw exception}
+        1 * client.getAllTables(_) >> { throw exception }
         thrown result
 
         where:
-        exception                    | result
-        new TException()             |ConnectorException
-        new MetaException()          |InvalidMetaException
-        new NoSuchObjectException()  |DatabaseNotFoundException
+        exception                   | result
+        new TException()            | ConnectorException
+        new MetaException()         | InvalidMetaException
+        new NoSuchObjectException() | DatabaseNotFoundException
     }
 
     @Unroll
-    def "Test for exist table"(){
-        def client = Mock(MetacatHiveClient);
-        def hiveConnectorTableService = new HiveConnectorTableService("testhive", client, hiveConnectorDatabaseService, new HiveConnectorInfoConverter( new HiveTypeConverter()), true )
+    def "Test for exist table"() {
+        def client = Mock(MetacatHiveClient)
+        def hiveConnectorTableService = new HiveConnectorTableService("testhive", client, hiveConnectorDatabaseService, new HiveConnectorInfoConverter(new HiveTypeConverter()), connectorContext)
         when:
-        def result = hiveConnectorTableService.exists(connectorContext, QualifiedName.ofTable("testhive","testdb", "testtable1"))
+        def result = hiveConnectorTableService.exists(connectorRequestContext, QualifiedName.ofTable("testhive", "testdb", "testtable1"))
         then:
         1 * client.getTableByName("testdb", "testtable1") >> resulttble
         result == ret
         where:
-        resulttble        | ret
-        new Table()       | true
-        null              | false
+        resulttble  | ret
+        new Table() | true
+        null        | false
     }
 
-    def "Test for exist table NoSuchObjectException"(){
+    def "Test for exist table NoSuchObjectException"() {
         def client = Mock(MetacatHiveClient)
-        def hiveConnectorTableService = new HiveConnectorTableService("testhive", client, hiveConnectorDatabaseService, new HiveConnectorInfoConverter( new HiveTypeConverter()), true )
+        def hiveConnectorTableService = new HiveConnectorTableService("testhive", client, hiveConnectorDatabaseService, new HiveConnectorInfoConverter(new HiveTypeConverter()), connectorContext)
         when:
-        def result = hiveConnectorTableService.exists(connectorContext, QualifiedName.ofTable("testhive","testdb", "testtable1"))
+        def result = hiveConnectorTableService.exists(connectorRequestContext, QualifiedName.ofTable("testhive", "testdb", "testtable1"))
         then:
-        1 * client.getTableByName("testdb", "testtable1") >> {throw new NoSuchObjectException()}
-        result == false
+        1 * client.getTableByName("testdb", "testtable1") >> { throw new NoSuchObjectException() }
+        !result
     }
 
-    def "Test for exist table TException"(){
+    def "Test for exist table TException"() {
         def client = Mock(MetacatHiveClient)
-        def hiveConnectorTableService = new HiveConnectorTableService("testhive", client, hiveConnectorDatabaseService, new HiveConnectorInfoConverter( new HiveTypeConverter()), true )
+        def hiveConnectorTableService = new HiveConnectorTableService("testhive", client, hiveConnectorDatabaseService, new HiveConnectorInfoConverter(new HiveTypeConverter()), connectorContext)
         when:
-        def result = hiveConnectorTableService.exists(connectorContext, QualifiedName.ofTable("testhive","testdb", "testtable1"))
+        hiveConnectorTableService.exists(connectorRequestContext, QualifiedName.ofTable("testhive", "testdb", "testtable1"))
         then:
-        client.getTableByName("testdb", "testtable1") >> {throw new TException() }
+        client.getTableByName("testdb", "testtable1") >> { throw new TException() }
         thrown ConnectorException
     }
 
     @Unroll
-    def "Test for listNames tables with page"(){
+    def "Test for listNames tables with page"() {
         given:
         def tbls = hiveConnectorTableService.listNames(
-            connectorContext, QualifiedName.ofDatabase("testhive", "test1"), prefix, null, pageable)
+            connectorRequestContext, QualifiedName.ofDatabase("testhive", "test1"), prefix, null, pageable)
 
         expect:
         tbls == result
 
         where:
-        prefix                                             | pageable          | result
-        null | new Pageable(2,1) |[QualifiedName.ofTable("testhive", "test1", "testtable2"),QualifiedName.ofTable("testhive", "test1", "devtable2")]
-        QualifiedName.ofDatabase("testhive", "test1") | new Pageable(2,1) |[QualifiedName.ofTable("testhive", "test1", "testtable2"),QualifiedName.ofTable("testhive", "test1", "devtable2")]
-        QualifiedName.ofTable("testhive", "test1", "test") | new Pageable(2,1) |[QualifiedName.ofTable("testhive", "test1", "testtable2")]
-        QualifiedName.ofTable("testhive", "test1", "test") | new Pageable(1,0) |[QualifiedName.ofTable("testhive", "test1", "testtable1")]
-        QualifiedName.ofTable("testhive", "test1", "test") | new Pageable(0,0) |[]
-        QualifiedName.ofTable("testhive", "test3", "test") | new Pageable(2,1) |[]
+        prefix                                             | pageable           | result
+        null                                               | new Pageable(2, 1) | [QualifiedName.ofTable("testhive", "test1", "testtable2"), QualifiedName.ofTable("testhive", "test1", "devtable2")]
+        QualifiedName.ofDatabase("testhive", "test1")      | new Pageable(2, 1) | [QualifiedName.ofTable("testhive", "test1", "testtable2"), QualifiedName.ofTable("testhive", "test1", "devtable2")]
+        QualifiedName.ofTable("testhive", "test1", "test") | new Pageable(2, 1) | [QualifiedName.ofTable("testhive", "test1", "testtable2")]
+        QualifiedName.ofTable("testhive", "test1", "test") | new Pageable(1, 0) | [QualifiedName.ofTable("testhive", "test1", "testtable1")]
+        QualifiedName.ofTable("testhive", "test1", "test") | new Pageable(0, 0) | []
+        QualifiedName.ofTable("testhive", "test3", "test") | new Pageable(2, 1) | []
     }
 
     def "Test for rename tables"() {
         when:
         hiveConnectorTableService.rename(
-            connectorContext, QualifiedName.ofTable("testhive", "test1","testtable1"),
+            connectorRequestContext, QualifiedName.ofTable("testhive", "test1", "testtable1"),
             QualifiedName.ofTable("testhive", "test1", "testtable2"))
         then:
         noExceptionThrown()
@@ -324,20 +333,20 @@ class HiveConnectorTableSpec extends Specification {
     @Unroll
     def "Test for rename tables exceptions"() {
         def client = Mock(MetacatHiveClient)
-        def hiveConnectorTableService = new HiveConnectorTableService("testhive", client, hiveConnectorDatabaseService, new HiveConnectorInfoConverter( new HiveTypeConverter()), true )
+        def hiveConnectorTableService = new HiveConnectorTableService("testhive", client, hiveConnectorDatabaseService, new HiveConnectorInfoConverter(new HiveTypeConverter()), connectorContext)
 
         when:
         hiveConnectorTableService.rename(
-                connectorContext, QualifiedName.ofTable("testhive", "test1","testtable1"),
-                QualifiedName.ofTable("testhive", "test1", "testtable2"))
+            connectorRequestContext, QualifiedName.ofTable("testhive", "test1", "testtable1"),
+            QualifiedName.ofTable("testhive", "test1", "testtable2"))
         then:
-        1 * client.rename(_,_,_,_) >> { throw exception}
+        1 * client.rename(_, _, _, _) >> { throw exception }
         thrown result
 
         where:
-        exception                    | result
-        new TException()             |ConnectorException
-        new MetaException()          |InvalidMetaException
-        new NoSuchObjectException()  |TableNotFoundException
+        exception                   | result
+        new TException()            | ConnectorException
+        new MetaException()         | InvalidMetaException
+        new NoSuchObjectException() | TableNotFoundException
     }
 }


### PR DESCRIPTION
Clean up warnings
Clean up code formatting
Clean up possible null pointer exceptions
Clean up missing `@Nullables`
Remove unnecessary shutdown calls for managed beans
Optimize constructor arguments for reuse and extensibility