### PR TITLE
Add health indicators for internal services and catalogs

### DIFF
--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/spi/MetacatCatalogConfig.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/spi/MetacatCatalogConfig.java
@@ -10,8 +10,6 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-
-
 package com.netflix.metacat.common.server.spi;
 
 import com.google.common.base.Preconditions;

--- a/metacat-main/src/main/java/com/netflix/metacat/main/manager/CatalogManager.java
+++ b/metacat-main/src/main/java/com/netflix/metacat/main/manager/CatalogManager.java
@@ -1,28 +1,19 @@
 /*
- * Copyright 2016 Netflix, Inc.
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *        http://www.apache.org/licenses/LICENSE-2.0
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
-
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *  Copyright 2017 Netflix, Inc.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
  */
 package com.netflix.metacat.main.manager;
 
@@ -30,10 +21,13 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
 import com.google.common.io.Files;
-import com.netflix.metacat.common.server.properties.Config;
 import com.netflix.metacat.common.server.connectors.ConnectorContext;
+import com.netflix.metacat.common.server.properties.Config;
+import com.netflix.metacat.common.server.spi.MetacatCatalogConfig;
 import com.netflix.spectator.api.Registry;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -47,7 +41,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * Catalog manager.
  */
 @Slf4j
-public class CatalogManager {
+public class CatalogManager implements HealthIndicator {
     private final ConnectorManager connectorManager;
     private final File catalogConfigurationDir;
     private final AtomicBoolean catalogsLoading = new AtomicBoolean();
@@ -62,9 +56,11 @@ public class CatalogManager {
      * @param config           config
      * @param registry         registry of spectator
      */
-    public CatalogManager(final ConnectorManager connectorManager,
-                          final Config config,
-                          final Registry registry) {
+    public CatalogManager(
+        final ConnectorManager connectorManager,
+        final Config config,
+        final Registry registry
+    ) {
         this.connectorManager = connectorManager;
         this.config = config;
         this.catalogConfigurationDir = new File(config.getPluginConfigLocation());
@@ -77,7 +73,22 @@ public class CatalogManager {
      * @return true if all catalogs are loaded
      */
     public boolean areCatalogsLoaded() {
-        return catalogsLoaded.get();
+        return this.catalogsLoaded.get();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Health health() {
+        // If catalogs are loaded we'll just report up
+        final Health.Builder builder = this.catalogsLoaded.get() ? Health.up() : Health.outOfService();
+
+        for (final Map.Entry<String, MetacatCatalogConfig> entry : this.connectorManager.getCatalogs().entrySet()) {
+            builder.withDetail(entry.getKey(), entry.getValue().getType());
+        }
+
+        return builder.build();
     }
 
     /**
@@ -85,39 +96,38 @@ public class CatalogManager {
      *
      * @throws Exception error
      */
-    public void loadCatalogs()
-        throws Exception {
-        if (!catalogsLoading.compareAndSet(false, true)) {
+    public void loadCatalogs() throws Exception {
+        if (!this.catalogsLoading.compareAndSet(false, true)) {
             return;
         }
 
-        for (File file : listFiles(catalogConfigurationDir)) {
+        for (final File file : this.listFiles(this.catalogConfigurationDir)) {
             if (file.isFile() && file.getName().endsWith(".properties")) {
-                loadCatalog(file);
+                this.loadCatalog(file);
             }
         }
 
-        catalogsLoaded.set(true);
+        this.catalogsLoaded.set(true);
     }
 
-    private void loadCatalog(final File file)
-        throws Exception {
+    private void loadCatalog(final File file) throws Exception {
         log.info("-- Loading catalog {} --", file);
-        final Map<String, String> properties = new HashMap<>(loadProperties(file));
+        final Map<String, String> properties = new HashMap<>(this.loadProperties(file));
 
         final String connectorType = properties.remove("connector.name");
-        Preconditions.checkState(connectorType != null, "Catalog configuration %s does not contain conector.name",
-            file.getAbsoluteFile());
+        Preconditions.checkState(
+            connectorType != null,
+            "Catalog configuration %s does not contain connector.name",
+            file.getAbsoluteFile()
+        );
 
         final String catalogName = Files.getNameWithoutExtension(file.getName());
-        final ConnectorContext connectorContext =
-            new ConnectorContext(catalogName, config, registry, properties);
-        connectorManager.createConnection(catalogName,
-            connectorType, connectorContext);
+        final ConnectorContext connectorContext = new ConnectorContext(catalogName, config, registry, properties);
+        this.connectorManager.createConnection(catalogName, connectorType, connectorContext);
         log.info("-- Added catalog {} using connector {} --", catalogName, connectorType);
     }
 
-    private static List<File> listFiles(final File installedPluginsDir) {
+    private List<File> listFiles(final File installedPluginsDir) {
         if (installedPluginsDir.isDirectory()) {
             final File[] files = installedPluginsDir.listFiles();
             if (files != null) {
@@ -127,7 +137,7 @@ public class CatalogManager {
         return ImmutableList.of();
     }
 
-    private static Map<String, String> loadProperties(final File file)
+    private Map<String, String> loadProperties(final File file)
         throws Exception {
         Preconditions.checkNotNull(file, "file is null");
 

--- a/metacat-main/src/main/java/com/netflix/metacat/main/services/MetacatInitializationService.java
+++ b/metacat-main/src/main/java/com/netflix/metacat/main/services/MetacatInitializationService.java
@@ -1,16 +1,20 @@
 /*
- * Copyright 2016 Netflix, Inc.
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *        http://www.apache.org/licenses/LICENSE-2.0
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
+ *
+ *  Copyright 2017 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
  */
-
 package com.netflix.metacat.main.services;
 
 import com.google.common.base.Throwables;
@@ -21,16 +25,27 @@ import com.netflix.metacat.main.manager.PluginManager;
 import lombok.AllArgsConstructor;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
 import org.springframework.context.event.ContextClosedEvent;
 import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.context.event.EventListener;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+
 /**
  * Metacat initialization service.
+ *
+ * @author tgianos
+ * @since 1.1.0
  */
 @Slf4j
 @AllArgsConstructor
-public class MetacatInitializationService {
+public class MetacatInitializationService implements HealthIndicator {
+    protected static final String PLUGIN_KEY = "pluginsLoaded";
+    protected static final String CATALOG_KEY = "catalogsLoaded";
+    protected static final String THRIFT_KEY = "thriftStarted";
+
     @NonNull
     private final PluginManager pluginManager;
     @NonNull
@@ -41,6 +56,28 @@ public class MetacatInitializationService {
     private final ThreadServiceManager threadServiceManager;
     @NonNull
     private final MetacatThriftService metacatThriftService;
+    // Initial values are false
+    private final AtomicBoolean pluginsLoaded = new AtomicBoolean();
+    private final AtomicBoolean catalogsLoaded = new AtomicBoolean();
+    private final AtomicBoolean thriftStarted = new AtomicBoolean();
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Health health() {
+        final boolean plugins = this.pluginsLoaded.get();
+        final boolean catalogs = this.catalogsLoaded.get();
+        final boolean thrift = this.thriftStarted.get();
+
+        final Health.Builder builder = plugins && catalogs && thrift ? Health.up() : Health.outOfService();
+
+        builder.withDetail(PLUGIN_KEY, plugins);
+        builder.withDetail(CATALOG_KEY, catalogs);
+        builder.withDetail(THRIFT_KEY, thrift);
+
+        return builder.build();
+    }
 
     /**
      * Metacat service initialization.
@@ -51,9 +88,14 @@ public class MetacatInitializationService {
     public void start(final ContextRefreshedEvent event) {
         log.info("Metacat application started per {}. Starting services.", event);
         try {
+            // TODO: Rather than doing this statically why don't we have things that need to be started implement
+            //       some interface/order?
             this.pluginManager.loadPlugins();
+            this.pluginsLoaded.set(true);
             this.catalogManager.loadCatalogs();
+            this.catalogsLoaded.set(true);
             this.metacatThriftService.start();
+            this.thriftStarted.set(true);
         } catch (final Exception e) {
             log.error("Unable to init services due to {}", e.getMessage(), e);
             Throwables.propagate(e);
@@ -70,9 +112,12 @@ public class MetacatInitializationService {
     public void stop(final ContextClosedEvent event) {
         log.info("Metacat application is stopped per {}. Stopping services.", event);
         try {
+            this.pluginsLoaded.set(false);
             this.connectorManager.stop();
+            this.catalogsLoaded.set(false);
             this.threadServiceManager.stop();
             this.metacatThriftService.stop();
+            this.thriftStarted.set(false);
         } catch (final Exception e) {
             // Just log it since we're shutting down anyway shouldn't matter to propagate it
             log.error("Unable to properly shutdown services due to {}", e.getMessage(), e);

--- a/metacat-main/src/main/java/com/netflix/metacat/main/services/MetacatThriftService.java
+++ b/metacat-main/src/main/java/com/netflix/metacat/main/services/MetacatThriftService.java
@@ -22,6 +22,7 @@ import java.util.stream.Collectors;
 
 /**
  * Metacat thrift service.
+ *
  * @author zhenl
  * @since 1.1.0
  */

--- a/metacat-main/src/test/groovy/com/netflix/metacat/main/manager/CatalogManagerSpec.groovy
+++ b/metacat-main/src/test/groovy/com/netflix/metacat/main/manager/CatalogManagerSpec.groovy
@@ -1,0 +1,70 @@
+/*
+ *
+ *  Copyright 2017 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.metacat.main.manager
+
+import com.google.common.collect.ImmutableMap
+import com.google.common.collect.Maps
+import com.netflix.metacat.common.server.properties.Config
+import com.netflix.metacat.common.server.spi.MetacatCatalogConfig
+import com.netflix.spectator.api.Registry
+import org.springframework.boot.actuate.health.Status
+import spock.lang.Specification
+
+/**
+ * Specifications for the CatalogManager class.
+ *
+ * @author tgianos
+ * @since 1.1.0
+ */
+class CatalogManagerSpec extends Specification {
+    def "can report health accurately based on whether catalogs are loaded or not"() {
+        def connectorManager = Mock(ConnectorManager) {
+            2 * getCatalogs() >>> [
+                Maps.newHashMap(),
+                ImmutableMap.of(
+                    "testhive", MetacatCatalogConfig.createFromMapAndRemoveProperties("hive", Maps.newHashMap()),
+                    "prodhive", MetacatCatalogConfig.createFromMapAndRemoveProperties("hive", Maps.newHashMap()),
+                    "finance", MetacatCatalogConfig.createFromMapAndRemoveProperties("mysql", Maps.newHashMap())
+                )
+            ]
+        }
+        def config = Mock(Config) {
+            1 * getPluginConfigLocation() >> File.createTempFile("not", ".aDirectory").getAbsolutePath()
+        }
+        def registry = Mock(Registry)
+        def catalogManager = new CatalogManager(connectorManager, config, registry)
+
+        when:
+        def health = catalogManager.health()
+
+        then:
+        health.getStatus() == Status.OUT_OF_SERVICE
+        health.getDetails().size() == 0
+
+        when:
+        catalogManager.loadCatalogs()
+        health = catalogManager.health()
+
+        then:
+        health.getStatus() == Status.UP
+        health.getDetails().size() == 3
+        health.getDetails().get("testhive") == "hive"
+        health.getDetails().get("prodhive") == "hive"
+        health.getDetails().get("finance") == "mysql"
+    }
+}

--- a/metacat-main/src/test/groovy/com/netflix/metacat/main/services/MetacatInitializationServiceSpec.groovy
+++ b/metacat-main/src/test/groovy/com/netflix/metacat/main/services/MetacatInitializationServiceSpec.groovy
@@ -1,0 +1,116 @@
+/*
+ *
+ *  Copyright 2017 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.metacat.main.services
+
+import com.netflix.metacat.common.server.util.ThreadServiceManager
+import com.netflix.metacat.main.manager.CatalogManager
+import com.netflix.metacat.main.manager.ConnectorManager
+import com.netflix.metacat.main.manager.PluginManager
+import org.springframework.boot.actuate.health.Status
+import org.springframework.context.event.ContextRefreshedEvent
+import spock.lang.Specification
+
+/**
+ * Specifications for the Initialization service.
+ *
+ * @author tgianos
+ * @since 1.1.0
+ */
+class MetacatInitializationServiceSpec extends Specification {
+
+    def "can start and stop services"() {
+        def pluginManager = Mock(PluginManager)
+        def catalogManager = Mock(CatalogManager)
+        def connectorManager = Mock(ConnectorManager)
+        def threadServiceManager = Mock(ThreadServiceManager)
+        def thriftService = Mock(MetacatThriftService)
+
+        def initializationService = new MetacatInitializationService(
+            pluginManager,
+            catalogManager,
+            connectorManager,
+            threadServiceManager,
+            thriftService
+        )
+
+        when:
+        def health = initializationService.health()
+
+        then:
+        health.getStatus() == Status.OUT_OF_SERVICE
+        health.getDetails().size() == 3
+        health.getDetails().get(MetacatInitializationService.PLUGIN_KEY) == false
+        health.getDetails().get(MetacatInitializationService.CATALOG_KEY) == false
+        health.getDetails().get(MetacatInitializationService.THRIFT_KEY) == false
+
+        when:
+        initializationService.start(Mock(ContextRefreshedEvent))
+        health = initializationService.health()
+
+        then:
+        health.getStatus() == Status.UP
+        health.getDetails().size() == 3
+        health.getDetails().get(MetacatInitializationService.PLUGIN_KEY) == true
+        health.getDetails().get(MetacatInitializationService.CATALOG_KEY) == true
+        health.getDetails().get(MetacatInitializationService.THRIFT_KEY) == true
+    }
+
+    def "can't start services on exception"() {
+        def pluginManager = Mock(PluginManager)
+        def catalogManager = Mock(CatalogManager)
+        def connectorManager = Mock(ConnectorManager)
+        def threadServiceManager = Mock(ThreadServiceManager)
+        def thriftService = Mock(MetacatThriftService) {
+            1 * start() >> { throw new RuntimeException("uh oh") }
+        }
+
+        def initializationService = new MetacatInitializationService(
+            pluginManager,
+            catalogManager,
+            connectorManager,
+            threadServiceManager,
+            thriftService
+        )
+
+        when:
+        def health = initializationService.health()
+
+        then:
+        health.getStatus() == Status.OUT_OF_SERVICE
+        health.getDetails().size() == 3
+        health.getDetails().get(MetacatInitializationService.PLUGIN_KEY) == false
+        health.getDetails().get(MetacatInitializationService.CATALOG_KEY) == false
+        health.getDetails().get(MetacatInitializationService.THRIFT_KEY) == false
+
+        when:
+        try {
+            initializationService.start(Mock(ContextRefreshedEvent))
+            assert false
+        } catch (final Exception e) {
+            assert e != null
+        }
+        health = initializationService.health()
+
+        then:
+        health.getStatus() == Status.OUT_OF_SERVICE
+        health.getDetails().size() == 3
+        health.getDetails().get(MetacatInitializationService.PLUGIN_KEY) == true
+        health.getDetails().get(MetacatInitializationService.CATALOG_KEY) == true
+        health.getDetails().get(MetacatInitializationService.THRIFT_KEY) == false
+    }
+}


### PR DESCRIPTION
This PR adds implementations of the `HealthIndicator` interface for the `MetacatInititializationService` and `CatalogManager`. This way the system won't report `UP` via the actuator `/health` endpoint until these services are considered up.

This will also control whether the node is up or down in discovery if there is Eureka integration.