### PR TITLE
Update README to more accurately reflect 1.1.0 state

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,24 +49,19 @@ user metadata. Please look at this [sample](https://github.com/Netflix/metacat/b
 
 ### Running Locally
 
-Take the build WAR in `metacat-war/build/libs` and deploy it to an existing Tomcat as `ROOT.war` with the following
-properties exposed in your Tomcat `setenv.sh` where `${SRC}` is the directory you've checkout the Metacat code:
+Take the build WAR in `metacat-war/build/libs` and deploy it to an existing Tomcat as `ROOT.war`.
 
-* metacat.plugin.config.location=${SRC}/metacat-functional-tests/metacat-test-cluster/etc-metacat/catalog
-* metacat.usermetadata.config.location=${SRC}/metacat-functional-tests/metacat-test-cluster/etc-metacat/usermetadata.properties
-
-Start Tomcat and you can go to the following locations:
-
-REST API can be accessed @ [http://localhost:8080/mds/v1/catalog](http://localhost:8080/mds/v1/catalog)
+The REST API can be accessed @ [http://localhost:8080/mds/v1/catalog](http://localhost:8080/mds/v1/catalog)
 
 Swagger API documentation can be accessed @ [http://localhost:8080/swagger-ui.html](http://localhost:8080/swagger-ui.html)
 
-### Using Docker
+### Docker Compose Example
 
 **Pre-requisite: Docker compose is installed**
 
-To start a self contained metacat environment, run the command below. This will start a `docker-compose` cluster 
-containing a Metacat container, a Hive Metastore Container, a Cassandra container and a PostgreSQL container.
+To start a self contained Metacat environment with some sample catalogs run the command below. 
+This will start a `docker-compose` cluster containing a Metacat container, a Hive Metastore Container, a Cassandra 
+container and a PostgreSQL container.
 
 ```
 ./gradlew metacatPorts

--- a/README.md
+++ b/README.md
@@ -7,13 +7,15 @@
 
 ## Introduction
 
-Metacat is a unified metadata exploration API service.  You can explore Hive, RDS, Teradata, Redshift, S3 and Aegisthus.
-Metacat is a metadata service that provides you information about what data you have, where it resides and how to process it.
-But metadata in the end is really data about the data.  And from that point of view, the purpose of Metacat is to give us a place to
-describe the data so that we could do more useful things with it.  So at the most simple, the desire for Metacat are these three concerns:
+Metacat is a unified metadata exploration API service. You can explore Hive, RDS, Teradata, Redshift, S3 and Cassandra.
+Metacat provides you information about what data you have, where it resides and how to process it. Metadata in the end 
+is really data about the data. So the primary purpose of Metacat is to give a place to describe the data so that we 
+could do more useful things with it. 
+
+Metacat focusses on solving these three problems:
 
 * Federate views of metadata systems.
-* Allow arbitrary metadata storage about datasets.
+* Allow arbitrary metadata storage about data sets.
 * Metadata discovery
 
 ## Documentation
@@ -30,39 +32,55 @@ Metacat builds are run on Travis CI [here](https://travis-ci.org/Netflix/metacat
 [![Build Status](https://travis-ci.org/Netflix/metacat.svg?branch=master)](https://travis-ci.org/Netflix/meatcat)
 
 ## Getting Started
+
 ```
 git clone git@github.com:Netflix/metacat.git
 cd metacat
 ./gradlew clean build
 ```
-Once the build is completed, the metacat WAR file is generated under `metacat-server/build/libs` directory. Metacat needs two basic configurations:
 
-* `metacat.plugin.config.location`: Path to the directory containing the catalog configuration. Please look at catalog [samples](https://github.com/Netflix/metacat/tree/master/metacat-functional-tests/metacat-test-cluster/etc-metacat/catalog) used by demo.
-* `metacat.usermetadata.config.location`: Path to the configuration file containing the connection properties to store user metadata. Please look at this [sample](https://github.com/Netflix/metacat/blob/master/metacat-functional-tests/metacat-test-cluster/etc-metacat/usermetadata.properties).
+Once the build is completed, the metacat WAR file is generated under `metacat-war/build/libs` directory. Metacat needs 
+two basic configurations:
 
-### Using Jetty locally
-```
-./gradlew -Dmetacat.plugin.config.location=./metacat-functional-tests/metacat-test-cluster/etc-metacat/catalog -Dmetacat.usermetadata.config.location=./metacat-functional-tests/metacat-test-cluster/etc-metacat/usermetadata.properties jettyRunWar
-```
+* `metacat.plugin.config.location`: Path to the directory containing the catalog configuration. Please look at 
+catalog [samples](https://github.com/Netflix/metacat/tree/master/metacat-functional-tests/metacat-test-cluster/etc-metacat/catalog) used for functional testing.
+* `metacat.usermetadata.config.location`: Path to the configuration file containing the connection properties to store 
+user metadata. Please look at this [sample](https://github.com/Netflix/metacat/blob/master/metacat-functional-tests/metacat-test-cluster/etc-metacat/usermetadata.properties).
+
+### Running Locally
+
+Take the build WAR in `metacat-war/build/libs` and deploy it to an existing Tomcat as `ROOT.war` with the following
+properties exposed in your Tomcat `setenv.sh` where `${SRC}` is the directory you've checkout the Metacat code:
+
+* metacat.plugin.config.location=${SRC}/metacat-functional-tests/metacat-test-cluster/etc-metacat/catalog
+* metacat.usermetadata.config.location=${SRC}/metacat-functional-tests/metacat-test-cluster/etc-metacat/usermetadata.properties
+
+Start Tomcat and you can go to the following locations:
+
 REST API can be accessed @ [http://localhost:8080/mds/v1/catalog](http://localhost:8080/mds/v1/catalog)
 
-Swagger API documentation can be accessed @ [http://localhost:8080/docs/api/index.html](http://localhost:8080/docs/api/index.html)
+Swagger API documentation can be accessed @ [http://localhost:8080/swagger-ui.html](http://localhost:8080/swagger-ui.html)
 
 ### Using Docker
-To start a docker demo, run the command below. This will start a container running the Metacat service, Hive Metastore and Mysql instance.
+
+**Pre-requisite: Docker compose is installed**
+
+To start a self contained metacat environment, run the command below. This will start a `docker-compose` cluster 
+containing a Metacat container, a Hive Metastore Container, a Cassandra container and a PostgreSQL container.
+
 ```
-./gradlew buildWarImage startMetacatCluster metacatPorts
+./gradlew metacatPorts
 ```
-* `buildWarImage` - Creates a tomcat war docker image that can be used to start a tomcat container
-* `startMetacatCluster` - Starts the hive metastore, MySql instance and the Metacat server
+
 * `metacatPorts` - Prints out what exposed ports are mapped to the internal container ports.
 Look for the mapped port (`MAPPED_PORT`) to port 8080.
 
 REST API can be accessed @ `http://localhost:<MAPPED_PORT>/mds/v1/catalog`
 
-Swagger API documentation can be accessed @ `http://localhost:<MAPPED_PORT>/docs/api/index.html`
+Swagger API documentation can be accessed @ `http://localhost:<MAPPED_PORT>/swagger-ui.html`
 
-To stop the docker demo:
+To stop the docker compose cluster:
+
 ```
 ./gradlew stopMetacatCluster
 ```


### PR DESCRIPTION
As pointed out in #175 the current README doesn't accurately reflect how to run the code locally. This PR attempts to fix most of that debt.