### PR TITLE
fixing hiveMetric timerId and renaming hive config parameter 

### DIFF
--- a/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/HiveConnectorFactory.java
+++ b/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/HiveConnectorFactory.java
@@ -74,7 +74,7 @@ public class HiveConnectorFactory implements ConnectorFactory {
         final MutablePropertySources propertySources = standardEnvironment.getPropertySources();
         final Map<String, Object> properties = new HashMap<>();
         properties.put("useHiveFastService", useFastHiveService);
-        properties.put("useThriftClient", !useLocalMetastore);
+        properties.put("useEmbeddedClient", useLocalMetastore);
         propertySources.addFirst(new MapPropertySource("HIVE_CONNECTOR", properties));
         this.ctx.setEnvironment(standardEnvironment);
         //TODO scan the package, which is not working

--- a/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/client/embedded/EmbeddedHiveClient.java
+++ b/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/client/embedded/EmbeddedHiveClient.java
@@ -90,7 +90,7 @@ public class EmbeddedHiveClient implements IMetacatHiveClient {
                               final Registry registry) {
         this.handler = handler;
         this.registry = registry;
-        this.requestTimerId = registry.createId(HiveMetrics.TimerHiveRequest.name());
+        this.requestTimerId = registry.createId(HiveMetrics.TimerHiveRequest.getMetricName());
         this.hiveSqlErrorCounter =
             registry.counter(HiveMetrics.CounterHiveSqlLockError.getMetricName() + "." + catalogName);
     }

--- a/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/configs/HiveConnectorClientConfig.java
+++ b/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/configs/HiveConnectorClientConfig.java
@@ -33,7 +33,7 @@ import javax.sql.DataSource;
  * @since 1.1.0
  */
 @Configuration
-@ConditionalOnProperty(value = "useThriftClient", havingValue = "false")
+@ConditionalOnProperty(value = "useEmbeddedClient", havingValue = "true")
 public class HiveConnectorClientConfig {
 
     /**


### PR DESCRIPTION
fixing the name of embedded hiveMetric timerId and renaming hive config parameter to avoid confusion.