### PR TITLE
Fix HTTP OK no-content edge case in client body handler

### DIFF
--- a/metacat-client/src/main/java/com/netflix/metacat/client/module/JacksonDecoder.java
+++ b/metacat-client/src/main/java/com/netflix/metacat/client/module/JacksonDecoder.java
@@ -17,6 +17,7 @@
  */
 package com.netflix.metacat.client.module;
 
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.RuntimeJsonMappingException;
 import feign.Response;
@@ -25,8 +26,9 @@ import lombok.NonNull;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
-import java.io.InputStream;
+import java.io.Reader;
 import java.lang.reflect.Type;
+import java.net.HttpURLConnection;
 
 /**
  * Decoder for Metacat response.
@@ -34,6 +36,7 @@ import java.lang.reflect.Type;
  * @author amajumdar
  */
 public class JacksonDecoder implements Decoder {
+    private static final String NO_CONTENT_MESSAGE = "No content to map due to end-of-input";
     private final ObjectMapper mapper;
 
     /**
@@ -51,16 +54,25 @@ public class JacksonDecoder implements Decoder {
     @Override
     public Object decode(final Response response, final Type type) throws IOException {
         if (
-            response.body() == null
-                || response.status() == 204
+            response.status() == HttpURLConnection.HTTP_NO_CONTENT
+                || response.body() == null
                 || (response.body().length() != null && response.body().length() == 0)
             ) {
             return null;
         }
-        final InputStream inputStream = response.body().asInputStream();
-        try {
-            return mapper.readValue(inputStream, mapper.constructType(type));
-        } catch (RuntimeJsonMappingException e) {
+
+        try (final Reader reader = response.body().asReader()) {
+            return this.mapper.readValue(reader, this.mapper.constructType(type));
+        } catch (final JsonMappingException jme) {
+            // The case where for whatever reason (most likely bad design) where the server returned OK and
+            // trying to de-serialize the content had no content (e.g. the return status should have been no-content)
+            if (response.status() == HttpURLConnection.HTTP_OK
+                && jme.getMessage().startsWith(NO_CONTENT_MESSAGE)) {
+                return null;
+            }
+
+            throw jme;
+        } catch (final RuntimeJsonMappingException e) {
             if (e.getCause() != null && e.getCause() instanceof IOException) {
                 throw IOException.class.cast(e.getCause());
             }


### PR DESCRIPTION
This shouldn't be necessary but due to API's returning `OK` instead of `NO-CONTENT` in V0 and differences between Spring and Jersey in response body handling the client needs to handle this edge case to work as it did previously