### PR TITLE
Fixed issue with SQL save partitions where trailing '/' was not getting removed from the partition uri.

### DIFF
--- a/metacat-common/src/main/java/com/netflix/metacat/common/MetacatRequestContext.java
+++ b/metacat-common/src/main/java/com/netflix/metacat/common/MetacatRequestContext.java
@@ -108,6 +108,22 @@ public class MetacatRequestContext {
         this.scheme = scheme;
     }
 
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("MetacatRequestContext{");
+        sb.append("id='").append(id).append('\'');
+        sb.append(", timestamp=").append(timestamp);
+        sb.append(", userName='").append(userName).append('\'');
+        sb.append(", clientAppName='").append(clientAppName).append('\'');
+        sb.append(", clientId='").append(clientId).append('\'');
+        sb.append(", jobId='").append(jobId).append('\'');
+        sb.append(", dataTypeContext='").append(dataTypeContext).append('\'');
+        sb.append(", apiUri='").append(apiUri).append('\'');
+        sb.append(", scheme='").append(scheme).append('\'');
+        sb.append('}');
+        return sb.toString();
+    }
+
     /**
      * builder class for MetacatRequestContext.
      * @return the builder class for MetacatRequestContext

--- a/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/monitoring/HiveMetrics.java
+++ b/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/monitoring/HiveMetrics.java
@@ -34,6 +34,7 @@ public enum HiveMetrics {
     CounterHiveSqlLockError(Type.counter, "hiveSqlLockError"),
     CounterHiveExperimentGetTablePartitionsFailure(Type.counter,"experimentGetPartitionsFailure"),
     CounterHivePartitionPathIsNotDir(Type.counter,"partitionPathIsNotDir"),
+    CounterHivePartitionFileSystemCall(Type.counter,"partitionFileSystemCall"),
 
     /**
      * Gauge.

--- a/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/sql/HiveConnectorFastPartitionService.java
+++ b/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/sql/HiveConnectorFastPartitionService.java
@@ -169,6 +169,7 @@ public class HiveConnectorFastPartitionService extends HiveConnectorPartitionSer
     private void createLocationForPartition(final QualifiedName tableQName,
         final PartitionInfo partitionInfo, final Table table, final boolean doFileSystemCalls) {
         String location = partitionInfo.getSerde().getUri();
+        Path path = null;
         if (StringUtils.isBlank(location)) {
             if (table.getSd() == null || table.getSd().getLocation() == null) {
                 throw new InvalidMetaException(tableQName, null);
@@ -177,18 +178,27 @@ public class HiveConnectorFastPartitionService extends HiveConnectorPartitionSer
             final List<String> partValues = PartitionUtil
                 .getPartValuesFromPartName(tableQName, table, partitionName);
             final String escapedPartName = PartitionUtil.makePartName(table.getPartitionKeys(), partValues);
-            location =  new Path(table.getSd().getLocation(), escapedPartName).toString();
-            partitionInfo.getSerde().setUri(location);
-        }
-        if (doFileSystemCalls && StringUtils.isNotBlank(location)) {
+            path =  new Path(table.getSd().getLocation(), escapedPartName);
+        } else {
             try {
-                final Path path = new Path(location);
-                if (!warehouse.mkdirs(path, false)) {
+                path = warehouse.getDnsPath(new Path(location));
+            } catch (Exception e) {
+                throw new InvalidMetaException(String.format("Failed forming partition location; %s", location), e);
+            }
+        }
+        if (path != null) {
+            location = path.toString();
+            partitionInfo.getSerde().setUri(location);
+            if (doFileSystemCalls) {
+                try {
+                    if (!warehouse.mkdirs(path, false)) {
                         throw new InvalidMetaException(String
                             .format("%s is not a directory or unable to create one", location), null);
+                    }
+                } catch (Exception e) {
+                    throw new InvalidMetaException(String.format("Failed creating partition location; %s", location),
+                        e);
                 }
-            } catch (Exception e) {
-                throw new InvalidMetaException(String.format("Failed creating partition location; %s", location), e);
             }
         }
     }

--- a/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/sql/HiveConnectorFastPartitionService.java
+++ b/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/sql/HiveConnectorFastPartitionService.java
@@ -25,6 +25,7 @@ import com.netflix.metacat.common.server.connectors.model.StorageInfo;
 import com.netflix.metacat.connector.hive.HiveConnectorPartitionService;
 import com.netflix.metacat.connector.hive.IMetacatHiveClient;
 import com.netflix.metacat.connector.hive.converters.HiveConnectorInfoConverter;
+import com.netflix.metacat.connector.hive.monitoring.HiveMetrics;
 import com.netflix.metacat.connector.hive.util.PartitionUtil;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang.StringUtils;
@@ -190,6 +191,8 @@ public class HiveConnectorFastPartitionService extends HiveConnectorPartitionSer
             location = path.toString();
             partitionInfo.getSerde().setUri(location);
             if (doFileSystemCalls) {
+                getContext().getRegistry().counter(HiveMetrics.CounterHivePartitionFileSystemCall.getMetricName(),
+                    "database", table.getDbName(), "table", table.getTableName()).increment();
                 try {
                     if (!warehouse.mkdirs(path, false)) {
                         throw new InvalidMetaException(String


### PR DESCRIPTION
 In Hive, partition uri with trailing '/' is removed for new partitions but for altered partitions, it does not. With the new SQL save partitions logic, trailing '/' is removed in both cases.