### PR TITLE
Fixed an intermittent issue where saveMetadata was not getting commit ted before the notification events were published.

### DIFF
--- a/metacat-metadata-mysql/src/main/java/com/netflix/metacat/metadata/mysql/MysqlUserMetadataService.java
+++ b/metacat-metadata-mysql/src/main/java/com/netflix/metacat/metadata/mysql/MysqlUserMetadataService.java
@@ -77,6 +77,22 @@ public class MysqlUserMetadataService extends BaseUserMetadataService {
     }
 
     @Override
+    public void saveMetadata(final String userId, final HasMetadata holder, final boolean merge) {
+        super.saveMetadata(userId, holder, merge);
+    }
+
+    @Override
+    public void populateMetadata(final HasMetadata holder) {
+        super.populateMetadata(holder);
+    }
+
+    @Override
+    public void populateMetadata(final HasMetadata holder, final ObjectNode definitionMetadata,
+        final ObjectNode dataMetadata) {
+        super.populateMetadata(holder, definitionMetadata, dataMetadata);
+    }
+
+    @Override
     public void softDeleteDataMetadatas(
         final String user,
         @Nonnull final List<String> uris


### PR DESCRIPTION
We identified this where the TABLE_UPDATE events at times where showing no delta between the old and new TableDto value.