### PR TITLE
 Table create/update in hive should use the source_type of the field if provided.

### DIFF
--- a/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/converters/HiveConnectorInfoConverter.java
+++ b/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/converters/HiveConnectorInfoConverter.java
@@ -31,6 +31,7 @@ import com.netflix.metacat.common.server.connectors.model.StorageInfo;
 import com.netflix.metacat.common.server.connectors.model.TableInfo;
 import com.netflix.metacat.connector.hive.util.HiveTableUtil;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.Partition;
@@ -317,7 +318,11 @@ public class HiveConnectorInfoConverter implements ConnectorInfoConverter<Databa
     public FieldSchema metacatToHiveField(final FieldInfo fieldInfo) {
         final FieldSchema result = new FieldSchema();
         result.setName(fieldInfo.getName());
-        result.setType(hiveTypeConverter.fromMetacatType(fieldInfo.getType()));
+        if (StringUtils.isBlank(fieldInfo.getSourceType())) {
+            result.setType(hiveTypeConverter.fromMetacatType(fieldInfo.getType()));
+        } else {
+            result.setType(fieldInfo.getSourceType());
+        }
         result.setComment(fieldInfo.getComment());
         return result;
     }

--- a/metacat-functional-tests/src/functionalTest/groovy/com/netflix/metacat/MetacatSmokeSpec.groovy
+++ b/metacat-functional-tests/src/functionalTest/groovy/com/netflix/metacat/MetacatSmokeSpec.groovy
@@ -304,7 +304,7 @@ class MetacatSmokeSpec extends Specification {
     }
 
     @Unroll
-    def "Test copy table as #catalogName/#databaseName/#tableName"() {
+    def "Test copy table as #catalogName/#databaseName/metacat_all_types_copy"() {
         given:
         createTable(catalogName, databaseName, 'metacat_all_types')
         def table = api.getTable(catalogName, databaseName, 'metacat_all_types', true, true, false)

--- a/metacat-functional-tests/src/functionalTest/groovy/com/netflix/metacat/MetacatSmokeSpec.groovy
+++ b/metacat-functional-tests/src/functionalTest/groovy/com/netflix/metacat/MetacatSmokeSpec.groovy
@@ -303,6 +303,27 @@ class MetacatSmokeSpec extends Specification {
         'invalid-catalog'               | 'smoke_db1'  | 'z'                 | true   | false   | MetacatNotFoundException.class
     }
 
+    @Unroll
+    def "Test copy table as #catalogName/#databaseName/#tableName"() {
+        given:
+        createTable(catalogName, databaseName, 'metacat_all_types')
+        def table = api.getTable(catalogName, databaseName, 'metacat_all_types', true, true, false)
+        table.setName(QualifiedName.ofTable(catalogName, databaseName, 'metacat_all_types_copy'))
+        api.createTable(catalogName, databaseName, 'metacat_all_types_copy', table)
+        def copyTable = api.getTable(catalogName, databaseName, 'metacat_all_types_copy', true, true, false)
+        expect:
+        table.fields == copyTable.fields
+        cleanup:
+        api.deleteTable(catalogName, databaseName, 'metacat_all_types')
+        api.deleteTable(catalogName, databaseName, 'metacat_all_types_copy')
+        where:
+        catalogName                     | databaseName
+        'embedded-hive-metastore'       | 'smoke_db1'
+        'embedded-fast-hive-metastore'  | 'fsmoke_db1'
+        'hive-metastore'                | 'hsmoke_db1'
+        's3-mysql-db'                   | 'smoke_db1'
+    }
+
     /**
      * This test case validates the mixed case of definition names in user metadata. Added after we came across
      * a regression issue with Aegisthus job.


### PR DESCRIPTION
At times, using the type of the field loses the right type during the type conversion. For example, a field of type date will be created as datetime because of the type conversion.