### PR TITLE
Added support to not delete definition metadata when dropping a table.

### DIFF
--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/Config.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/Config.java
@@ -16,6 +16,7 @@ package com.netflix.metacat.common.server.properties;
 import com.netflix.metacat.common.QualifiedName;
 
 import java.util.List;
+import java.util.Set;
 
 /**
  * Property configurations.
@@ -304,4 +305,18 @@ public interface Config {
      * @return Whether SNS notifications to partitions topic should be enabled
      */
     boolean isSnsNotificationTopicPartitionEnabled();
+
+    /**
+     * Whether or not to delete definition metadata for tables.
+     *
+     * @return Whether or not to delete definition metadata for tables.
+     */
+    boolean canDeleteTableDefinitionMetadata();
+
+    /**
+     * List of names for which the table definition metadata will be deleted.
+     *
+     * @return list of names
+     */
+    Set<QualifiedName> getNamesEnabledForDefinitionMetadataDelete();
 }

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/DefaultConfigImpl.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/DefaultConfigImpl.java
@@ -22,6 +22,7 @@ import lombok.NonNull;
 
 import javax.annotation.Nonnull;
 import java.util.List;
+import java.util.Set;
 
 /**
  * A default implementation of the config interface.
@@ -381,5 +382,15 @@ public class DefaultConfigImpl implements Config {
     @Override
     public boolean isSnsNotificationTopicPartitionEnabled() {
         return this.metacatProperties.getNotifications().getSns().getTopic().getPartition().isEnabled();
+    }
+
+    @Override
+    public boolean canDeleteTableDefinitionMetadata() {
+        return this.metacatProperties.getDefinition().getMetadata().getDelete().isEnableForTable();
+    }
+
+    @Override
+    public Set<QualifiedName> getNamesEnabledForDefinitionMetadataDelete() {
+        return this.metacatProperties.getDefinition().getMetadata().getDelete().getQualifiedNamesEnabledForDelete();
     }
 }

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/Definition.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/Definition.java
@@ -1,0 +1,73 @@
+/*
+ *
+ *  Copyright 2017 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.metacat.common.server.properties;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.netflix.metacat.common.QualifiedName;
+import lombok.NonNull;
+
+import java.util.Set;
+
+/**
+ * Definition metadata related properties.
+ *
+ * @author amajumdar
+ * @since 1.1.1
+ */
+@lombok.Data
+public class Definition {
+
+    @NonNull
+    private Metadata metadata = new Metadata();
+
+    /**
+     * Metadata related properties.
+     *
+     * @author amajumdar
+     * @since 1.1.1
+     */
+    @lombok.Data
+    public static class Metadata {
+
+        @NonNull
+        private Delete delete = new Delete();
+
+        /**
+         * Delete related properties.
+         *
+         * @author amajumdar
+         * @since 1.1.1
+         */
+        @lombok.Data
+        public static class Delete {
+            private boolean enableForTable = true;
+            private String enableDeleteForQualifiedNames;
+
+            /**
+             * Get the names stored in the variable as a List of fully qualified names.
+             *
+             * @return The names as a list or empty list if {@code enableDeleteForQualifiedNames} is null or empty
+             */
+            @JsonIgnore
+            public Set<QualifiedName> getQualifiedNamesEnabledForDelete() {
+                return PropertyUtils.delimitedStringsToQualifiedNamesSet(this.enableDeleteForQualifiedNames,
+                    ',');
+            }
+        }
+    }
+}

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/Definition.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/Definition.java
@@ -1,18 +1,18 @@
 /*
  *
- *  Copyright 2017 Netflix, Inc.
+ * Copyright 2018 Netflix, Inc.
  *
- *     Licensed under the Apache License, Version 2.0 (the "License");
- *     you may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *        http://www.apache.org/licenses/LICENSE-2.0
  *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
  *
  */
 package com.netflix.metacat.common.server.properties;
@@ -27,7 +27,7 @@ import java.util.Set;
  * Definition metadata related properties.
  *
  * @author amajumdar
- * @since 1.1.1
+ * @since 1.2.0
  */
 @lombok.Data
 public class Definition {
@@ -39,7 +39,7 @@ public class Definition {
      * Metadata related properties.
      *
      * @author amajumdar
-     * @since 1.1.1
+     * @since 1.2.0
      */
     @lombok.Data
     public static class Metadata {
@@ -51,7 +51,7 @@ public class Definition {
          * Delete related properties.
          *
          * @author amajumdar
-         * @since 1.1.1
+         * @since 1.2.0
          */
         @lombok.Data
         public static class Delete {

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/MetacatProperties.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/MetacatProperties.java
@@ -30,6 +30,8 @@ public class MetacatProperties {
     @NonNull
     private Data data = new Data();
     @NonNull
+    private Definition definition = new Definition();
+    @NonNull
     private ElasticsearchProperties elasticsearch = new ElasticsearchProperties();
     @NonNull
     private EventProperties event = new EventProperties();

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/PropertyUtils.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/PropertyUtils.java
@@ -19,12 +19,14 @@ package com.netflix.metacat.common.server.properties;
 
 import com.google.common.base.Splitter;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import com.netflix.metacat.common.QualifiedName;
 import lombok.NonNull;
 import org.apache.commons.lang3.StringUtils;
 
 import javax.annotation.Nonnull;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -60,6 +62,28 @@ public final class PropertyUtils {
                 .collect(Collectors.toList());
         } else {
             return Lists.newArrayList();
+        }
+    }
+
+    /**
+     * Convert a delimited string into a Set of {@code QualifiedName}.
+     *
+     * @param names     The list of names to split
+     * @param delimiter The delimiter to use for splitting
+     * @return The list of qualified names
+     */
+    static Set<QualifiedName> delimitedStringsToQualifiedNamesSet(
+        @Nonnull @NonNull final String names,
+        final char delimiter
+    ) {
+        if (StringUtils.isNotBlank(names)) {
+            return Splitter.on(delimiter)
+                .omitEmptyStrings()
+                .splitToList(names).stream()
+                .map(QualifiedName::fromString)
+                .collect(Collectors.toSet());
+        } else {
+            return Sets.newHashSet();
         }
     }
 }

--- a/metacat-functional-tests/metacat-test-cluster/docker-compose.yml
+++ b/metacat-functional-tests/metacat-test-cluster/docker-compose.yml
@@ -51,6 +51,8 @@ services:
                 -Dmetacat.plugin.config.location=/etc/metacat/catalog
                 -Dmetacat.mysqlmetadataservice.enabled=true
                 -Dmetacat.type.converter=com.netflix.metacat.connector.pig.converters.PigTypeConverter
+                -Dmetacat.definition.metadata.delete.enableForTable=false
+                -Dmetacat.definition.metadata.delete.enableDeleteForQualifiedNames=hive-metastore/hsmoke_ddb,hive-metastore/hsmoke_ddb1/test_create_table1,cassandra-310,embedded-hive-metastore,embedded-fast-hive-metastore,s3-mysql-db,mysql-56-db
                 -Dmetacat.usermetadata.config.location=/etc/metacat/usermetadata.properties'
         labels:
           - "com.netflix.metacat.oss.test"

--- a/metacat-functional-tests/src/functionalTest/groovy/com/netflix/metacat/MetacatSmokeSpec.groovy
+++ b/metacat-functional-tests/src/functionalTest/groovy/com/netflix/metacat/MetacatSmokeSpec.groovy
@@ -305,6 +305,27 @@ class MetacatSmokeSpec extends Specification {
     }
 
     @Unroll
+    def "Test delete table #catalogName/#databaseName/#tableName"() {
+        given:
+        def name = catalogName + '/' + databaseName + '/' + tableName
+        createTable(catalogName, databaseName, tableName)
+        api.deleteTable(catalogName, databaseName, tableName)
+        def definitions = metadataApi.getDefinitionMetadataList(null, null, null, null, null, null, name,null)
+        expect:
+        definitions.size() == result
+        cleanup:
+        metadataApi.deleteDefinitionMetadata(name, true)
+        where:
+        catalogName                     | databaseName  | tableName             | result
+        'embedded-hive-metastore'       | 'smoke_ddb1'  | 'test_create_table'   | 0
+        'embedded-fast-hive-metastore'  | 'fsmoke_ddb1' | 'test_create_table'   | 0
+        'hive-metastore'                | 'hsmoke_ddb'  | 'test_create_table'   | 0
+        'hive-metastore'                | 'hsmoke_ddb1' | 'test_create_table1'  | 0
+        'hive-metastore'                | 'hsmoke_ddb1' | 'test_create_table2'  | 1
+        's3-mysql-db'                   | 'smoke_ddb1'  | 'test_create_table'   | 0
+    }
+
+    @Unroll
     def "Test copy table as #catalogName/#databaseName/metacat_all_types_copy"() {
         given:
         createTable(catalogName, databaseName, 'metacat_all_types')

--- a/metacat-main/src/main/java/com/netflix/metacat/main/configs/ServicesConfig.java
+++ b/metacat-main/src/main/java/com/netflix/metacat/main/configs/ServicesConfig.java
@@ -147,6 +147,7 @@ public class ServicesConfig {
      * @param eventBus            Internal event bus
      * @param converterUtil       utility to convert to/from Dto to connector resources
      * @param registry             registry handle
+     * @param config               configurations
      * @return The table service bean
      */
     @Bean
@@ -157,7 +158,8 @@ public class ServicesConfig {
         final UserMetadataService userMetadataService,
         final MetacatEventBus eventBus,
         final ConverterUtil converterUtil,
-        final Registry registry
+        final Registry registry,
+        final Config config
     ) {
         return new TableServiceImpl(
             connectorManager,
@@ -166,7 +168,8 @@ public class ServicesConfig {
             userMetadataService,
             eventBus,
             converterUtil,
-            registry
+            registry,
+            config
         );
     }
 

--- a/metacat-main/src/test/groovy/com/netflix/metacat/main/services/impl/TableServiceImplSpec.groovy
+++ b/metacat-main/src/test/groovy/com/netflix/metacat/main/services/impl/TableServiceImplSpec.groovy
@@ -1,0 +1,112 @@
+/*
+ *
+ * Copyright 2018 Netflix, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ */
+
+package com.netflix.metacat.main.services.impl
+
+import com.netflix.metacat.common.QualifiedName
+import com.netflix.metacat.common.server.connectors.ConnectorTableService
+import com.netflix.metacat.common.server.converter.ConverterUtil
+import com.netflix.metacat.common.server.events.MetacatEventBus
+import com.netflix.metacat.common.server.properties.Config
+import com.netflix.metacat.common.server.usermetadata.TagService
+import com.netflix.metacat.common.server.usermetadata.UserMetadataService
+import com.netflix.metacat.main.manager.ConnectorManager
+import com.netflix.metacat.main.services.DatabaseService
+import com.netflix.metacat.main.services.TableService
+import com.netflix.metacat.testdata.provider.DataDtoProvider
+import com.netflix.spectator.api.NoopRegistry
+import spock.lang.Specification
+
+/**
+ * Tests for the TableServiceImpl.
+ *
+ * @author amajumdar
+ * @since 1.2.0
+ */
+class TableServiceImplSpec extends Specification {
+    def connectorManager = Mock(ConnectorManager)
+    def connectorTableService = Mock(ConnectorTableService)
+    def databaseService = Mock(DatabaseService)
+    def tagService = Mock(TagService)
+    def usermetadataService = Mock(UserMetadataService)
+    def eventBus = Mock(MetacatEventBus)
+    def converterUtil = Mock(ConverterUtil)
+    def registry = new NoopRegistry()
+    def config = Mock(Config)
+    def tableDto = DataDtoProvider.getTable('a', 'b', 'c', "amajumdar", "s3:/a/b")
+    def name = tableDto.name
+    TableService service
+    def setup() {
+        connectorManager.getTableService(_) >> connectorTableService
+        converterUtil.toTableDto(_) >> tableDto
+        usermetadataService.getDefinitionMetadata(_) >> Optional.empty()
+        usermetadataService.getDataMetadata(_) >> Optional.empty()
+        service = new TableServiceImpl(connectorManager, databaseService, tagService, usermetadataService, eventBus, converterUtil, registry, config)
+    }
+    def testDeleteAndReturn() {
+        when:
+        service.deleteAndReturn(name, false)
+        then:
+        1 * config.canDeleteTableDefinitionMetadata() >> true
+        1 * usermetadataService.deleteMetadatas(_,_)
+        0 * usermetadataService.softDeleteDataMetadatas(_,_)
+        noExceptionThrown()
+        when:
+        service.deleteAndReturn(name, false)
+        then:
+        1 * config.canDeleteTableDefinitionMetadata() >> false
+        1 * config.getNamesEnabledForDefinitionMetadataDelete() >> [QualifiedName.fromString('a')]
+        1 * usermetadataService.deleteMetadatas(_,_)
+        0 * usermetadataService.softDeleteDataMetadatas(_,_)
+        noExceptionThrown()
+        when:
+        service.deleteAndReturn(name, false)
+        then:
+        1 * config.canDeleteTableDefinitionMetadata() >> false
+        1 * config.getNamesEnabledForDefinitionMetadataDelete() >> [QualifiedName.fromString('a/b')]
+        1 * usermetadataService.deleteMetadatas(_,_)
+        0 * usermetadataService.softDeleteDataMetadatas(_,_)
+        noExceptionThrown()
+        when:
+        service.deleteAndReturn(name, false)
+        then:
+        1 * config.canDeleteTableDefinitionMetadata() >> false
+        1 * config.getNamesEnabledForDefinitionMetadataDelete() >> [QualifiedName.fromString('a/b/c')]
+        1 * usermetadataService.deleteMetadatas(_,_)
+        0 * usermetadataService.softDeleteDataMetadatas(_,_)
+        noExceptionThrown()
+        when:
+        service.deleteAndReturn(name, false)
+        then:
+        1 * config.canDeleteTableDefinitionMetadata() >> false
+        1 * config.getNamesEnabledForDefinitionMetadataDelete() >> []
+        1 * config.canSoftDeleteDataMetadata() >> true
+        0 * usermetadataService.deleteMetadatas(_,_)
+        1 * usermetadataService.softDeleteDataMetadatas(_,_)
+        noExceptionThrown()
+        when:
+        service.deleteAndReturn(name, false)
+        then:
+        1 * config.canDeleteTableDefinitionMetadata() >> false
+        1 * config.getNamesEnabledForDefinitionMetadataDelete() >> [QualifiedName.fromString('a/c')]
+        1 * config.canSoftDeleteDataMetadata() >> true
+        0 * usermetadataService.deleteMetadatas(_,_)
+        1 * usermetadataService.softDeleteDataMetadatas(_,_)
+        noExceptionThrown()
+    }
+}


### PR DESCRIPTION
Action to delete definition metadata now depends on a configuration. When a whitelist is defined, definition metadata for those tables should be deleted.