### PR TITLE
Getting the docker-compose example working on Windows MinGW / MSys

### DIFF
--- a/codequality/checkstyle/checkstyle.xml
+++ b/codequality/checkstyle/checkstyle.xml
@@ -18,7 +18,9 @@
     </module>
 
     <!-- Checks that there is a newline at the end of each file. -->
-    <module name="NewlineAtEndOfFile"/>
+    <module name="NewlineAtEndOfFile">
+		<property name="lineSeparator" value="lf_cr_crlf"/>
+	</module>
 
     <!-- Implementation of a check that looks for a single line in any file type. -->
     <module name="RegexpSingleline">

--- a/metacat-functional-tests/build.gradle
+++ b/metacat-functional-tests/build.gradle
@@ -91,7 +91,7 @@ task expandWar(type: Copy) {
 task startMetacatCluster(type: Exec) {
     dependsOn 'expandWar'
     if (project.ext.startCluster) {
-        commandLine rootProject.file('scripts/start_metacat_test_cluster.sh'), project.file('metacat-test-cluster/docker-compose.yml')
+        commandLine 'sh', rootProject.file('scripts/start_metacat_test_cluster.sh'), project.file('metacat-test-cluster/docker-compose.yml')
     } else {
         commandLine '/bin/echo', 'skipping cluster start'
     }
@@ -99,7 +99,7 @@ task startMetacatCluster(type: Exec) {
 
 task stopMetacatCluster(type: Exec) {
     if (project.ext.stopCluster) {
-        commandLine rootProject.file('scripts/stop_metacat_test_cluster.sh'), project.file('metacat-test-cluster/docker-compose.yml')
+        commandLine 'sh', rootProject.file('scripts/stop_metacat_test_cluster.sh'), project.file('metacat-test-cluster/docker-compose.yml')
     } else {
         commandLine '/bin/echo', 'skipping cluster stop'
     }
@@ -119,7 +119,7 @@ task metacatPorts {
         def get_docker_port = { String label, int exposed_port ->
             new ByteArrayOutputStream().withStream { os ->
                 exec {
-                    commandLine rootProject.file('scripts/print_docker_port.sh'), "label=${label}", exposed_port
+                    commandLine 'sh', rootProject.file('scripts/print_docker_port.sh'), "label=${label}", exposed_port
                     standardOutput = os
                 }
                 return os.toString().trim()

--- a/metacat-functional-tests/metacat-test-cluster/datastores/postgres/docker-entrypoint-initdb.d/world.sql
+++ b/metacat-functional-tests/metacat-test-cluster/datastores/postgres/docker-entrypoint-initdb.d/world.sql
@@ -1,1 +1,1 @@
-world/world.sql
+\ir world/world.sql

--- a/scripts/start_metacat_test_cluster.sh
+++ b/scripts/start_metacat_test_cluster.sh
@@ -14,7 +14,7 @@ if [ $? -ne 0 ]; then
     exit 9
 fi
 
-docker-compose --file ${COMPOSE_FILE} exec -T cassandra cqlsh -f /init/init.cql #>> build/docker_compose.log 2>&1
+docker-compose --file ${COMPOSE_FILE} exec -T cassandra cqlsh -f ./init/init.cql #>> build/docker_compose.log 2>&1
 if [ $? -ne 0 ]; then
     echo "Unable to initialize Cassandra"
     exit 9


### PR DESCRIPTION
These are some changes I made in order to get the docker-compose example working on windows in a MinGW / MSys bash terminal.

The change to accept Lf / Cr / CrLf line-endings is nice to have when shutting auto-crlf conversion off in windows - which is a general practice when having projects build docker containers (script creation needs to have Lf line-endings when adding to linux-based containers).

Use of the 'sh' command tells MSys explicitly this is a shell-script and it can use the MSys local binary for that.

The other two changes (in world.sql and start_metacat_test_cluster.sh) were required within the container environment to get the example running - not sure why this was any different within Windows than *nix machines.

There is also a few groovy tests that are failing for the Hive connector build (within PartitionUtilSpec.groovy) that I see are not failing on *nix machines - I haven't fixed that yet though (just skipping tests on the build at this point).