### PR TITLE
Added support to have one catalog name pointing to multiple data store shards.

### DIFF
--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/connectors/ConnectorContext.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/connectors/ConnectorContext.java
@@ -35,7 +35,7 @@ public class ConnectorContext {
      */
     private final String catalogShardName;
     /**
-     * Catalog type.
+     * Connector type.
      */
     private final String connectorType;
     /**

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/connectors/ConnectorContext.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/connectors/ConnectorContext.java
@@ -31,6 +31,14 @@ public class ConnectorContext {
      */
     private final String catalogName;
     /**
+     * Catalog shard name.
+     */
+    private final String catalogShardName;
+    /**
+     * Catalog type.
+     */
+    private final String connectorType;
+    /**
      * Metacat config.
      */
     private final Config config;

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/connectors/ConnectorFactory.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/connectors/ConnectorFactory.java
@@ -61,7 +61,7 @@ public interface ConnectorFactory {
      *
      * @return Returns the name of the catalog.
      */
-    String getName();
+    String getCatalogName();
 
     /**
      * Returns the name of the catalog shard.

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/connectors/ConnectorFactory.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/connectors/ConnectorFactory.java
@@ -57,11 +57,18 @@ public interface ConnectorFactory {
     }
 
     /**
-     * Returns the name of the connector.
+     * Returns the name of the catalog.
      *
-     * @return Returns the name of the connector.
+     * @return Returns the name of the catalog.
      */
     String getName();
+
+    /**
+     * Returns the name of the catalog shard.
+     *
+     * @return Returns the name of the catalog shard.
+     */
+    String getCatalogShardName();
 
     /**
      * Shuts down the factory.

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/connectors/ConnectorPlugin.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/connectors/ConnectorPlugin.java
@@ -36,14 +36,10 @@ public interface ConnectorPlugin {
     /**
      * Returns the service implementation for the type.
      *
-     * @param connectorName connector name. This is also the catalog name.
      * @param connectorContext      registry for spectator
      * @return connector factory
      */
-    ConnectorFactory create(
-        String connectorName,
-        ConnectorContext connectorContext
-    );
+    ConnectorFactory create(ConnectorContext connectorContext);
 
     /**
      * Returns the type convertor of the connector.

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/connectors/DefaultConnectorFactory.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/connectors/DefaultConnectorFactory.java
@@ -34,20 +34,24 @@ import lombok.extern.slf4j.Slf4j;
 public class DefaultConnectorFactory implements ConnectorFactory {
 
     private final String name;
+    private final String catalogShardName;
     private final Injector injector;
 
     /**
      * Constructor.
      *
-     * @param name    The connector name
-     * @param modules The connector modules to create
+     * @param name              catalog name
+     * @param catalogShardName  catalog shard name
+     * @param modules           The connector modules to create
      */
     public DefaultConnectorFactory(
         final String name,
+        final String catalogShardName,
         final Iterable<? extends Module> modules
     ) {
         log.info("Creating connector factory for catalog {}", name);
         this.name = name;
+        this.catalogShardName = catalogShardName;
         this.injector = Guice.createInjector(modules);
     }
 
@@ -73,14 +77,6 @@ public class DefaultConnectorFactory implements ConnectorFactory {
     @Override
     public ConnectorPartitionService getPartitionService() {
         return this.getService(ConnectorPartitionService.class);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public String getName() {
-        return this.name;
     }
 
     /**

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/connectors/DefaultConnectorFactory.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/connectors/DefaultConnectorFactory.java
@@ -33,24 +33,24 @@ import lombok.extern.slf4j.Slf4j;
 @Getter
 public class DefaultConnectorFactory implements ConnectorFactory {
 
-    private final String name;
+    private final String catalogName;
     private final String catalogShardName;
     private final Injector injector;
 
     /**
      * Constructor.
      *
-     * @param name              catalog name
+     * @param catalogName       catalog name
      * @param catalogShardName  catalog shard name
      * @param modules           The connector modules to create
      */
     public DefaultConnectorFactory(
-        final String name,
+        final String catalogName,
         final String catalogShardName,
         final Iterable<? extends Module> modules
     ) {
-        log.info("Creating connector factory for catalog {}", name);
-        this.name = name;
+        log.info("Creating connector factory for catalog {}", catalogName);
+        this.catalogName = catalogName;
         this.catalogShardName = catalogShardName;
         this.injector = Guice.createInjector(modules);
     }

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/connectors/SpringConnectorFactory.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/connectors/SpringConnectorFactory.java
@@ -30,20 +30,24 @@ import org.springframework.core.env.StandardEnvironment;
  */
 
 public abstract class SpringConnectorFactory implements ConnectorFactory {
-    protected final String catalogName;
     protected final AnnotationConfigApplicationContext ctx;
+    private final String catalogName;
+    private final String catalogShardName;
 
     /**
      * Constructor.
      *
      * @param catalogName            catalog name
+     * @param catalogShardName       catalog shard name
      * @param connectorInfoConverter connector info converter
      * @param connectorContext       connector related config
      */
     public SpringConnectorFactory(final String catalogName,
+                                  final String catalogShardName,
                                   final ConnectorInfoConverter connectorInfoConverter,
                                   final ConnectorContext connectorContext) {
         this.catalogName = catalogName;
+        this.catalogShardName = catalogShardName;
         this.ctx = new AnnotationConfigApplicationContext();
         this.ctx.setEnvironment(new StandardEnvironment());
         this.ctx.getBeanFactory().registerSingleton("ConnectorContext", connectorContext);
@@ -89,5 +93,13 @@ public abstract class SpringConnectorFactory implements ConnectorFactory {
     @Override
     public String getName() {
         return this.catalogName;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getCatalogShardName() {
+        return catalogShardName;
     }
 }

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/connectors/SpringConnectorFactory.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/connectors/SpringConnectorFactory.java
@@ -91,7 +91,7 @@ public abstract class SpringConnectorFactory implements ConnectorFactory {
      * {@inheritDoc}
      */
     @Override
-    public String getName() {
+    public String getCatalogName() {
         return this.catalogName;
     }
 

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/connectors/SpringConnectorFactory.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/connectors/SpringConnectorFactory.java
@@ -37,17 +37,13 @@ public abstract class SpringConnectorFactory implements ConnectorFactory {
     /**
      * Constructor.
      *
-     * @param catalogName            catalog name
-     * @param catalogShardName       catalog shard name
      * @param connectorInfoConverter connector info converter
      * @param connectorContext       connector related config
      */
-    public SpringConnectorFactory(final String catalogName,
-                                  final String catalogShardName,
-                                  final ConnectorInfoConverter connectorInfoConverter,
+    public SpringConnectorFactory(final ConnectorInfoConverter connectorInfoConverter,
                                   final ConnectorContext connectorContext) {
-        this.catalogName = catalogName;
-        this.catalogShardName = catalogShardName;
+        this.catalogName = connectorContext.getCatalogName();
+        this.catalogShardName = connectorContext.getCatalogShardName();
         this.ctx = new AnnotationConfigApplicationContext();
         this.ctx.setEnvironment(new StandardEnvironment());
         this.ctx.getBeanFactory().registerSingleton("ConnectorContext", connectorContext);

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/spi/MetacatCatalogConfig.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/spi/MetacatCatalogConfig.java
@@ -15,6 +15,7 @@ package com.netflix.metacat.common.server.spi;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
+import lombok.Getter;
 
 import java.util.Collections;
 import java.util.List;
@@ -23,7 +24,7 @@ import java.util.Map;
 /**
  * Catalog config.
  */
-// TODO: Move/refactor into connectors?
+@Getter
 public final class MetacatCatalogConfig {
     private static final Splitter COMMA_LIST_SPLITTER = Splitter.on(',').trimResults().omitEmptyStrings();
     private final boolean includeViewsWithTables;
@@ -31,14 +32,17 @@ public final class MetacatCatalogConfig {
     private final List<String> schemaWhitelist;
     private final int thriftPort;
     private final String type;
+    private final String catalogName;
 
     private MetacatCatalogConfig(
         final String type,
+        final String catalogName,
         final boolean includeViewsWithTables,
         final List<String> schemaWhitelist,
         final List<String> schemaBlacklist,
         final int thriftPort) {
         this.type = type;
+        this.catalogName = catalogName;
         this.includeViewsWithTables = includeViewsWithTables;
         this.schemaBlacklist = schemaBlacklist;
         this.schemaWhitelist = schemaWhitelist;
@@ -49,10 +53,11 @@ public final class MetacatCatalogConfig {
      * Creates the config.
      *
      * @param type       type
+     * @param catalogName catalog name
      * @param properties properties
      * @return config
      */
-    public static MetacatCatalogConfig createFromMapAndRemoveProperties(final String type,
+    public static MetacatCatalogConfig createFromMapAndRemoveProperties(final String type, final String catalogName,
                                                                         final Map<String, String> properties) {
         Preconditions.checkArgument(!Strings.isNullOrEmpty(type), "type is required");
         final String catalogType =
@@ -72,28 +77,8 @@ public final class MetacatCatalogConfig {
             thriftPort = Integer.parseInt(properties.remove(Keys.THRIFT_PORT));
         }
 
-        return new MetacatCatalogConfig(catalogType, includeViewsWithTables, schemaWhitelist, schemaBlacklist,
-            thriftPort);
-    }
-
-    public List<String> getSchemaBlacklist() {
-        return schemaBlacklist;
-    }
-
-    public List<String> getSchemaWhitelist() {
-        return schemaWhitelist;
-    }
-
-    public int getThriftPort() {
-        return thriftPort;
-    }
-
-    public String getType() {
-        return type;
-    }
-
-    public boolean isIncludeViewsWithTables() {
-        return includeViewsWithTables;
+        return new MetacatCatalogConfig(catalogType, catalogName, includeViewsWithTables, schemaWhitelist,
+            schemaBlacklist, thriftPort);
     }
 
     public boolean isThriftInterfaceRequested() {
@@ -104,6 +89,17 @@ public final class MetacatCatalogConfig {
      * Properties in the catalog.
      */
     public static class Keys {
+        /**
+         * Catalog name. Usually catalog name is derived from the name of the catalog properties file.
+         * One could also specify it in the properties under the property name <code>catalog.name</code>.
+         * For example, if a catalog has two shards with catalog defined in two property files,
+         * then we can have the <code>catalog.name</code> set to one name.
+         */
+        public static final String CATALOG_NAME = "catalog.name";
+        /**
+         * Connector type.
+         */
+        public static final String CONNECTOR_NAME = "connector.name";
         /**
          * Catalog type.
          */

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/spi/MetacatCatalogConfig.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/spi/MetacatCatalogConfig.java
@@ -57,8 +57,10 @@ public final class MetacatCatalogConfig {
      * @param properties properties
      * @return config
      */
-    public static MetacatCatalogConfig createFromMapAndRemoveProperties(final String type, final String catalogName,
-                                                                        final Map<String, String> properties) {
+    public static MetacatCatalogConfig createFromMapAndRemoveProperties(
+        final String type,
+        final String catalogName,
+        final Map<String, String> properties) {
         Preconditions.checkArgument(!Strings.isNullOrEmpty(type), "type is required");
         final String catalogType =
             properties.containsKey(Keys.CATALOG_TYPE) ? properties.remove(Keys.CATALOG_TYPE) : type;

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/util/DataSourceManager.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/util/DataSourceManager.java
@@ -50,13 +50,13 @@ public final class DataSourceManager {
     /**
      * Initialize a data source and store it.
      *
-     * @param catalogName catalog name
+     * @param name catalog name
      * @param properties  properties
      * @return DataSourceManager
      */
-    public DataSourceManager load(final String catalogName, final Map<String, String> properties) {
-        if (dataSources.get(catalogName) == null) {
-            createDataSource(catalogName, properties);
+    public DataSourceManager load(final String name, final Map<String, String> properties) {
+        if (dataSources.get(name) == null) {
+            createDataSource(name, properties);
         }
         return this;
     }
@@ -78,15 +78,15 @@ public final class DataSourceManager {
     /**
      * Returns the data source loaded for the given catalog.
      *
-     * @param catalogName catalog name
+     * @param name catalog name
      * @return DataSource
      */
-    public DataSource get(final String catalogName) {
-        return dataSources.get(catalogName);
+    public DataSource get(final String name) {
+        return dataSources.get(name);
     }
 
-    private synchronized void createDataSource(final String catalogName, final Map props) {
-        if (dataSources.get(catalogName) == null) {
+    private synchronized void createDataSource(final String name, final Map props) {
+        if (dataSources.get(name) == null) {
             final Properties dataSourceProperties = new Properties();
             props.forEach((key, value) -> {
                 final String prop = String.valueOf(key);
@@ -101,11 +101,11 @@ public final class DataSourceManager {
                     // Explicitly registering the datasource with the JMX server bean.
                     //
                     ((org.apache.tomcat.jdbc.pool.DataSource) dataSource)
-                        .preRegister(null, new ObjectName(String.format("jdbc.pool:name=%s", catalogName)));
-                    dataSources.put(catalogName, dataSource);
+                        .preRegister(null, new ObjectName(String.format("jdbc.pool:name=%s", name)));
+                    dataSources.put(name, dataSource);
                 } catch (Exception e) {
                     throw new RuntimeException(String
-                        .format("Failed to load the data source for catalog %s with error [%s]", catalogName,
+                        .format("Failed to load the data source for catalog %s with error [%s]", name,
                             e.getMessage()), e);
                 }
             }

--- a/metacat-connector-cassandra/src/main/java/com/netflix/metacat/connector/cassandra/CassandraConnectorFactory.java
+++ b/metacat-connector-cassandra/src/main/java/com/netflix/metacat/connector/cassandra/CassandraConnectorFactory.java
@@ -36,14 +36,17 @@ class CassandraConnectorFactory extends DefaultConnectorFactory {
     /**
      * Constructor.
      *
-     * @param name          The catalog name
-     * @param configuration The catalog configuration
+     * @param name              The catalog name
+     * @param catalogShardName  The catalog shard name
+     * @param configuration     The catalog configuration
      */
     CassandraConnectorFactory(
         @Nonnull @NonNull final String name,
+        @Nonnull @NonNull final String catalogShardName,
         @Nonnull @NonNull final Map<String, String> configuration
     ) {
-        super(name, Lists.newArrayList(new CassandraConnectorModule(name, configuration)));
+        super(name, catalogShardName,
+            Lists.newArrayList(new CassandraConnectorModule(catalogShardName, configuration)));
     }
 
     /**

--- a/metacat-connector-cassandra/src/main/java/com/netflix/metacat/connector/cassandra/CassandraConnectorModule.java
+++ b/metacat-connector-cassandra/src/main/java/com/netflix/metacat/connector/cassandra/CassandraConnectorModule.java
@@ -47,20 +47,20 @@ public class CassandraConnectorModule extends AbstractModule {
     private static final String USERNAME_KEY = "cassandra.username";
     private static final String PASSWORD_KEY = "cassandra.password";
 
-    private final String name;
+    private final String catalogShardName;
     private final Map<String, String> configuration;
 
     /**
      * Constructor.
      *
-     * @param name          The name of the catalog this module is associated will be associated with
-     * @param configuration The connector configuration
+     * @param catalogShardName  catalog shard name
+     * @param configuration     connector configuration
      */
     CassandraConnectorModule(
-        @Nonnull @NonNull final String name,
+        @Nonnull @NonNull final String catalogShardName,
         @Nonnull @NonNull final Map<String, String> configuration
     ) {
-        this.name = name;
+        this.catalogShardName = catalogShardName;
         this.configuration = configuration;
     }
 
@@ -90,7 +90,7 @@ public class CassandraConnectorModule extends AbstractModule {
     @Provides
     @Singleton
     Cluster provideCluster() {
-        final Cluster.Builder builder = Cluster.builder().withClusterName(this.name);
+        final Cluster.Builder builder = Cluster.builder().withClusterName(this.catalogShardName);
 
         // Contact points are required
         final String contactPointsString = this.configuration.get(CONTACT_POINTS_KEY);

--- a/metacat-connector-cassandra/src/main/java/com/netflix/metacat/connector/cassandra/CassandraConnectorPlugin.java
+++ b/metacat-connector-cassandra/src/main/java/com/netflix/metacat/connector/cassandra/CassandraConnectorPlugin.java
@@ -48,11 +48,9 @@ public class CassandraConnectorPlugin implements ConnectorPlugin {
      * {@inheritDoc}
      */
     @Override
-    public ConnectorFactory create(
-        @Nonnull @NonNull final String connectorName,
-        @Nonnull @NonNull final ConnectorContext connectorContext
-    ) {
-        return new CassandraConnectorFactory(connectorName, connectorContext.getConfiguration());
+    public ConnectorFactory create(@Nonnull @NonNull final ConnectorContext connectorContext) {
+        return new CassandraConnectorFactory(connectorContext.getCatalogName(),
+            connectorContext.getCatalogShardName(), connectorContext.getConfiguration());
     }
 
     /**

--- a/metacat-connector-druid/src/main/java/com/netflix/metacat/connector/druid/DruidConnectorFactory.java
+++ b/metacat-connector-druid/src/main/java/com/netflix/metacat/connector/druid/DruidConnectorFactory.java
@@ -36,14 +36,16 @@ public class DruidConnectorFactory extends SpringConnectorFactory {
      * Constructor.
      *
      * @param catalogName      catalog name.
+     * @param catalogShardName catalog shard name
      * @param connectorContext connector config
      */
     DruidConnectorFactory(
         final String catalogName,
+        final String catalogShardName,
         final DruidConnectorInfoConverter druidConnectorInfoConverter,
         final ConnectorContext connectorContext
     ) {
-        super(catalogName, druidConnectorInfoConverter, connectorContext);
+        super(catalogName, catalogShardName, druidConnectorInfoConverter, connectorContext);
         super.registerClazz(DruidConnectorConfig.class, DruidHttpClientConfig.class);
         super.refresh();
     }

--- a/metacat-connector-druid/src/main/java/com/netflix/metacat/connector/druid/DruidConnectorFactory.java
+++ b/metacat-connector-druid/src/main/java/com/netflix/metacat/connector/druid/DruidConnectorFactory.java
@@ -35,17 +35,13 @@ public class DruidConnectorFactory extends SpringConnectorFactory {
     /**
      * Constructor.
      *
-     * @param catalogName      catalog name.
-     * @param catalogShardName catalog shard name
      * @param connectorContext connector config
      */
     DruidConnectorFactory(
-        final String catalogName,
-        final String catalogShardName,
         final DruidConnectorInfoConverter druidConnectorInfoConverter,
         final ConnectorContext connectorContext
     ) {
-        super(catalogName, catalogShardName, druidConnectorInfoConverter, connectorContext);
+        super(druidConnectorInfoConverter, connectorContext);
         super.registerClazz(DruidConnectorConfig.class, DruidHttpClientConfig.class);
         super.refresh();
     }

--- a/metacat-connector-druid/src/main/java/com/netflix/metacat/connector/druid/DruidConnectorPlugin.java
+++ b/metacat-connector-druid/src/main/java/com/netflix/metacat/connector/druid/DruidConnectorPlugin.java
@@ -44,7 +44,7 @@ public class DruidConnectorPlugin implements ConnectorPlugin {
      */
     @Override
     public ConnectorFactory create(final ConnectorContext connectorContext) {
-        return new DruidConnectorFactory(connectorContext.getCatalogName(), connectorContext.getCatalogShardName(),
+        return new DruidConnectorFactory(
             new DruidConnectorInfoConverter(connectorContext.getCatalogName()), connectorContext);
     }
 

--- a/metacat-connector-druid/src/main/java/com/netflix/metacat/connector/druid/DruidConnectorPlugin.java
+++ b/metacat-connector-druid/src/main/java/com/netflix/metacat/connector/druid/DruidConnectorPlugin.java
@@ -43,11 +43,9 @@ public class DruidConnectorPlugin implements ConnectorPlugin {
      * {@inheritDoc}
      */
     @Override
-    public ConnectorFactory create(
-        final String catalogName,
-        final ConnectorContext connectorContext
-    ) {
-        return new DruidConnectorFactory(catalogName, new DruidConnectorInfoConverter(catalogName), connectorContext);
+    public ConnectorFactory create(final ConnectorContext connectorContext) {
+        return new DruidConnectorFactory(connectorContext.getCatalogName(), connectorContext.getCatalogShardName(),
+            new DruidConnectorInfoConverter(connectorContext.getCatalogName()), connectorContext);
     }
 
     /**

--- a/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/HiveConnectorFactory.java
+++ b/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/HiveConnectorFactory.java
@@ -43,16 +43,18 @@ public class HiveConnectorFactory extends SpringConnectorFactory {
     /**
      * Constructor.
      *
-     * @param catalogName      connector name. Also the catalog name.
+     * @param catalogName      catalog name.
+     * @param catalogShardName catalog shard name
      * @param infoConverter    hive info converter
      * @param connectorContext connector config
      */
     HiveConnectorFactory(
         final String catalogName,
+        final String catalogShardName,
         final HiveConnectorInfoConverter infoConverter,
         final ConnectorContext connectorContext
     ) {
-        super(catalogName, infoConverter, connectorContext);
+        super(catalogName, catalogShardName, infoConverter, connectorContext);
         final boolean useLocalMetastore = Boolean.parseBoolean(
             connectorContext.getConfiguration()
                 .getOrDefault(HiveConfigConstants.USE_EMBEDDED_METASTORE, "false")

--- a/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/HiveConnectorFactory.java
+++ b/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/HiveConnectorFactory.java
@@ -43,18 +43,14 @@ public class HiveConnectorFactory extends SpringConnectorFactory {
     /**
      * Constructor.
      *
-     * @param catalogName      catalog name.
-     * @param catalogShardName catalog shard name
      * @param infoConverter    hive info converter
      * @param connectorContext connector config
      */
     HiveConnectorFactory(
-        final String catalogName,
-        final String catalogShardName,
         final HiveConnectorInfoConverter infoConverter,
         final ConnectorContext connectorContext
     ) {
-        super(catalogName, catalogShardName, infoConverter, connectorContext);
+        super(infoConverter, connectorContext);
         final boolean useLocalMetastore = Boolean.parseBoolean(
             connectorContext.getConfiguration()
                 .getOrDefault(HiveConfigConstants.USE_EMBEDDED_METASTORE, "false")

--- a/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/HiveConnectorPlugin.java
+++ b/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/HiveConnectorPlugin.java
@@ -48,12 +48,10 @@ public class HiveConnectorPlugin implements ConnectorPlugin {
      * {@inheritDoc}
      */
     @Override
-    public ConnectorFactory create(
-        final String catalogName,
-        final ConnectorContext connectorContext
-    ) {
+    public ConnectorFactory create(final ConnectorContext connectorContext) {
         return new HiveConnectorFactory(
-            catalogName,
+            connectorContext.getCatalogName(),
+            connectorContext.getCatalogShardName(),
             INFO_CONVERTER_HIVE,
             connectorContext
         );

--- a/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/HiveConnectorPlugin.java
+++ b/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/HiveConnectorPlugin.java
@@ -50,8 +50,6 @@ public class HiveConnectorPlugin implements ConnectorPlugin {
     @Override
     public ConnectorFactory create(final ConnectorContext connectorContext) {
         return new HiveConnectorFactory(
-            connectorContext.getCatalogName(),
-            connectorContext.getCatalogShardName(),
             INFO_CONVERTER_HIVE,
             connectorContext
         );

--- a/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/configs/HiveConnectorClientConfig.java
+++ b/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/configs/HiveConnectorClientConfig.java
@@ -53,7 +53,7 @@ public class HiveConnectorClientConfig {
             final HiveConf conf = this.getDefaultConf();
             connectorContext.getConfiguration().forEach(conf::set);
             DataSourceManager.get().load(
-                connectorContext.getCatalogName(),
+                connectorContext.getCatalogShardName(),
                 connectorContext.getConfiguration()
             );
             return new EmbeddedHiveClient(
@@ -107,10 +107,10 @@ public class HiveConnectorClientConfig {
         final HiveConf conf = this.getDefaultConf();
         connectorContext.getConfiguration().forEach(conf::set);
         DataSourceManager.get().load(
-            connectorContext.getCatalogName(),
+            connectorContext.getCatalogShardName(),
             connectorContext.getConfiguration()
         );
-        return DataSourceManager.get().get(connectorContext.getCatalogName());
+        return DataSourceManager.get().get(connectorContext.getCatalogShardName());
     }
 
     /**

--- a/metacat-connector-hive/src/test/groovy/com/netflix/metacat/connector/hive/HiveConnectorPartitionSpec.groovy
+++ b/metacat-connector-hive/src/test/groovy/com/netflix/metacat/connector/hive/HiveConnectorPartitionSpec.groovy
@@ -53,7 +53,7 @@ class HiveConnectorPartitionSpec extends Specification{
     @Shared
     MetacatHiveClient metacatHiveClient = Mock(MetacatHiveClient);
     @Shared
-    HiveConnectorPartitionService hiveConnectorPartitionService = new HiveConnectorPartitionService(new ConnectorContext("testhive", null, new NoopRegistry(), Maps.newHashMap()), metacatHiveClient, new HiveConnectorInfoConverter(new HiveTypeConverter()) )
+    HiveConnectorPartitionService hiveConnectorPartitionService = new HiveConnectorPartitionService(new ConnectorContext('testhive', 'testhive', 'hive', null, new NoopRegistry(), Maps.newHashMap()), metacatHiveClient, new HiveConnectorInfoConverter(new HiveTypeConverter()) )
     @Shared
     ConnectorRequestContext connectorContext = new ConnectorRequestContext(1, null);
     @Shared
@@ -110,7 +110,7 @@ class HiveConnectorPartitionSpec extends Specification{
     @Unroll
     def "Test for get partitions exceptions" (){
         def client = Mock(MetacatHiveClient)
-        def hiveConnectorPartitionService = new HiveConnectorPartitionService(new ConnectorContext("testhive", null, new NoopRegistry(), Maps.newHashMap()), client, new HiveConnectorInfoConverter( new HiveTypeConverter() ) )
+        def hiveConnectorPartitionService = new HiveConnectorPartitionService(new ConnectorContext('testhive', 'testhive', 'hive', null, new NoopRegistry(), Maps.newHashMap()), client, new HiveConnectorInfoConverter( new HiveTypeConverter() ) )
         when:
         PartitionListRequest partitionListRequest = new PartitionListRequest();
         partitionListRequest.partitionNames = [
@@ -165,7 +165,7 @@ class HiveConnectorPartitionSpec extends Specification{
     @Unroll
     def "Test for getNameOfPartitions exceptions" (){
         def client = Mock(MetacatHiveClient)
-        def hiveConnectorPartitionService = new HiveConnectorPartitionService(new ConnectorContext("testhive", null, new NoopRegistry(), Maps.newHashMap()), client, new HiveConnectorInfoConverter( new HiveTypeConverter() ) )
+        def hiveConnectorPartitionService = new HiveConnectorPartitionService(new ConnectorContext('testhive', 'testhive', 'hive',  null, new NoopRegistry(), Maps.newHashMap()), client, new HiveConnectorInfoConverter( new HiveTypeConverter() ) )
 
         when:
         PartitionListRequest partitionListRequest = new PartitionListRequest()
@@ -220,7 +220,7 @@ class HiveConnectorPartitionSpec extends Specification{
     @Unroll
     def "Test for getPartitionCount exceptions: #result" (){
         def client = Mock(MetacatHiveClient)
-        def hiveConnectorPartitionService = new HiveConnectorPartitionService(new ConnectorContext("testhive", null, new NoopRegistry(), Maps.newHashMap()), client, new HiveConnectorInfoConverter( new HiveTypeConverter() ) )
+        def hiveConnectorPartitionService = new HiveConnectorPartitionService(new ConnectorContext('testhive', 'testhive', 'hive',  null, new NoopRegistry(), Maps.newHashMap()), client, new HiveConnectorInfoConverter( new HiveTypeConverter() ) )
 
         when:
         hiveConnectorPartitionService.getPartitionCount( connectorContext, QualifiedName.ofTable("testhive", "test1", "testtable2"))
@@ -238,7 +238,7 @@ class HiveConnectorPartitionSpec extends Specification{
 
     def "Test for savePartition" (){
         def client = Mock(MetacatHiveClient)
-        def hiveConnectorPartitionService = new HiveConnectorPartitionService(new ConnectorContext("testhive", null, new NoopRegistry(), Maps.newHashMap()), client, new HiveConnectorInfoConverter( new HiveTypeConverter() ) )
+        def hiveConnectorPartitionService = new HiveConnectorPartitionService(new ConnectorContext('testhive', 'testhive', 'hive',  null, new NoopRegistry(), Maps.newHashMap()), client, new HiveConnectorInfoConverter( new HiveTypeConverter() ) )
         when:
         def saverequest = new PartitionsSaveRequest()
         saverequest.checkIfExists = true
@@ -257,7 +257,7 @@ class HiveConnectorPartitionSpec extends Specification{
     @Unroll
     def "Test for savePartition exceptions: #result" (){
         def client = Mock(MetacatHiveClient)
-        def hiveConnectorPartitionService = new HiveConnectorPartitionService(new ConnectorContext("testhive", null, new NoopRegistry(), Maps.newHashMap()), client, new HiveConnectorInfoConverter( new HiveTypeConverter() ) )
+        def hiveConnectorPartitionService = new HiveConnectorPartitionService(new ConnectorContext('testhive', 'testhive', 'hive',  null, new NoopRegistry(), Maps.newHashMap()), client, new HiveConnectorInfoConverter( new HiveTypeConverter() ) )
 
         when:
         def saverequest = new PartitionsSaveRequest()
@@ -280,7 +280,7 @@ class HiveConnectorPartitionSpec extends Specification{
 
     def "Test for savePartition partitionalreadyexist exception" (){
         def client = Mock(MetacatHiveClient)
-        def hiveConnectorPartitionService = new HiveConnectorPartitionService(new ConnectorContext("testhive", null, new NoopRegistry(), Maps.newHashMap()), client, new HiveConnectorInfoConverter( new HiveTypeConverter() ) )
+        def hiveConnectorPartitionService = new HiveConnectorPartitionService(new ConnectorContext('testhive', 'testhive', 'hive',   null, new NoopRegistry(), Maps.newHashMap()), client, new HiveConnectorInfoConverter( new HiveTypeConverter() ) )
         when:
         def saverequest = new PartitionsSaveRequest()
         saverequest.checkIfExists = true

--- a/metacat-connector-hive/src/test/groovy/com/netflix/metacat/connector/hive/HiveConnectorTableSpec.groovy
+++ b/metacat-connector-hive/src/test/groovy/com/netflix/metacat/connector/hive/HiveConnectorTableSpec.groovy
@@ -59,6 +59,8 @@ class HiveConnectorTableSpec extends Specification {
         new HiveConnectorInfoConverter(new HiveTypeConverter()),
         new ConnectorContext(
             "testHive",
+            "testHive",
+            "hive",
             Mock(Config),
             Mock(Registry),
             ImmutableMap.of(HiveConfigConstants.ALLOW_RENAME_TABLE, "true")
@@ -69,6 +71,8 @@ class HiveConnectorTableSpec extends Specification {
     @Shared
     ConnectorContext connectorContext = new ConnectorContext(
         "testHive",
+        "testHive",
+        "hive",
         Mock(Config),
         Mock(Registry),
         ImmutableMap.of(HiveConfigConstants.ALLOW_RENAME_TABLE, "true")

--- a/metacat-connector-hive/src/test/groovy/com/netflix/metacat/connector/hive/sql/DirectSqlGetPartitionSpec.groovy
+++ b/metacat-connector-hive/src/test/groovy/com/netflix/metacat/connector/hive/sql/DirectSqlGetPartitionSpec.groovy
@@ -34,7 +34,7 @@ class DirectSqlGetPartitionSpec extends Specification {
     def config = new DefaultConfigImpl(new MetacatProperties())
     def converter = new ConverterUtil(new DozerTypeConverter(new TypeConverterFactory(config)))
     def registry = new NoopRegistry()
-    def context = new ConnectorContext("test", config, registry, Maps.newHashMap())
+    def context = new ConnectorContext('test', 'test', 'hive', config, registry, Maps.newHashMap())
     def metric = new HiveConnectorFastServiceMetric(registry)
     def jdbcTemplate = Mock(JdbcTemplate)
     def service = new DirectSqlGetPartition(context, new ThreadServiceManager(registry, config), jdbcTemplate, metric)

--- a/metacat-connector-hive/src/test/groovy/com/netflix/metacat/connector/hive/sql/DirectSqlSavePartitionSpec.groovy
+++ b/metacat-connector-hive/src/test/groovy/com/netflix/metacat/connector/hive/sql/DirectSqlSavePartitionSpec.groovy
@@ -31,7 +31,7 @@ class DirectSqlSavePartitionSpec extends Specification {
     def config = new DefaultConfigImpl(new MetacatProperties())
     def converter = new ConverterUtil(new DozerTypeConverter(new TypeConverterFactory(config)))
     def registry = new NoopRegistry()
-    def context = new ConnectorContext("test", config, registry, Maps.newHashMap())
+    def context = new ConnectorContext('test', 'test', 'hive', config, registry, Maps.newHashMap())
     def metric = new HiveConnectorFastServiceMetric(registry)
     def jdbcTemplate = Mock(JdbcTemplate)
     def service = new DirectSqlSavePartition(context, jdbcTemplate, new SequenceGeneration(jdbcTemplate), metric)

--- a/metacat-connector-hive/src/test/groovy/com/netflix/metacat/connector/hive/sql/DirectSqlTableSpec.groovy
+++ b/metacat-connector-hive/src/test/groovy/com/netflix/metacat/connector/hive/sql/DirectSqlTableSpec.groovy
@@ -22,7 +22,7 @@ import java.util.function.Supplier
 class DirectSqlTableSpec extends Specification {
     def config = new DefaultConfigImpl(new MetacatProperties())
     def registry = new NoopRegistry()
-    def context = new ConnectorContext("test", config, registry, Maps.newHashMap())
+    def context = new ConnectorContext('test', 'test', 'hive', config, registry, Maps.newHashMap())
     def metric = new HiveConnectorFastServiceMetric(registry)
     def jdbcTemplate = Mock(JdbcTemplate)
     def service = new DirectSqlTable(context, jdbcTemplate, metric)

--- a/metacat-connector-mysql/src/main/java/com/netflix/metacat/connector/mysql/MySqlConnectorFactory.java
+++ b/metacat-connector-mysql/src/main/java/com/netflix/metacat/connector/mysql/MySqlConnectorFactory.java
@@ -35,13 +35,15 @@ class MySqlConnectorFactory extends DefaultConnectorFactory {
     /**
      * Constructor.
      *
-     * @param name          The catalog name
-     * @param configuration The catalog configuration
+     * @param name             catalog name
+     * @param catalogShardName catalog shard name
+     * @param configuration    catalog configuration
      */
     MySqlConnectorFactory(
         @Nonnull @NonNull final String name,
+        @Nonnull @NonNull final String catalogShardName,
         @Nonnull @NonNull final Map<String, String> configuration
     ) {
-        super(name, Lists.newArrayList(new MySqlConnectorModule(name, configuration)));
+        super(name, catalogShardName, Lists.newArrayList(new MySqlConnectorModule(catalogShardName, configuration)));
     }
 }

--- a/metacat-connector-mysql/src/main/java/com/netflix/metacat/connector/mysql/MySqlConnectorModule.java
+++ b/metacat-connector-mysql/src/main/java/com/netflix/metacat/connector/mysql/MySqlConnectorModule.java
@@ -42,20 +42,20 @@ import java.util.Map;
  */
 public class MySqlConnectorModule extends AbstractModule {
 
-    private final String name;
+    private final String catalogShardName;
     private final Map<String, String> configuration;
 
     /**
      * Constructor.
      *
-     * @param name          The name of the catalog this module is associated will be associated with
-     * @param configuration The connector configuration
+     * @param catalogShardName  catalog shard name
+     * @param configuration     connector configuration
      */
     MySqlConnectorModule(
-        @Nonnull @NonNull final String name,
+        @Nonnull @NonNull final String catalogShardName,
         @Nonnull @NonNull final Map<String, String> configuration
     ) {
-        this.name = name;
+        this.catalogShardName = catalogShardName;
         this.configuration = configuration;
     }
 
@@ -64,8 +64,8 @@ public class MySqlConnectorModule extends AbstractModule {
      */
     @Override
     protected void configure() {
-        this.bind(DataSource.class)
-            .toInstance(DataSourceManager.get().load(this.name, this.configuration).get(this.name));
+        this.bind(DataSource.class).toInstance(DataSourceManager.get()
+            .load(this.catalogShardName, this.configuration).get(this.catalogShardName));
         this.bind(JdbcTypeConverter.class).to(MySqlTypeConverter.class).in(Scopes.SINGLETON);
         this.bind(JdbcExceptionMapper.class).to(MySqlExceptionMapper.class).in(Scopes.SINGLETON);
         this.bind(ConnectorDatabaseService.class)

--- a/metacat-connector-mysql/src/main/java/com/netflix/metacat/connector/mysql/MySqlConnectorPlugin.java
+++ b/metacat-connector-mysql/src/main/java/com/netflix/metacat/connector/mysql/MySqlConnectorPlugin.java
@@ -48,11 +48,9 @@ public class MySqlConnectorPlugin implements ConnectorPlugin {
      * {@inheritDoc}
      */
     @Override
-    public ConnectorFactory create(
-        @Nonnull @NonNull final String connectorName,
-        @Nonnull @NonNull final ConnectorContext connectorContext
-    ) {
-        return new MySqlConnectorFactory(connectorName, connectorContext.getConfiguration());
+    public ConnectorFactory create(@Nonnull @NonNull final ConnectorContext connectorContext) {
+        return new MySqlConnectorFactory(connectorContext.getCatalogName(),
+            connectorContext.getCatalogShardName(), connectorContext.getConfiguration());
     }
 
     /**

--- a/metacat-connector-pig/src/main/java/com/netflix/metacat/connector/pig/PigConnectorPlugin.java
+++ b/metacat-connector-pig/src/main/java/com/netflix/metacat/connector/pig/PigConnectorPlugin.java
@@ -43,10 +43,7 @@ public class PigConnectorPlugin implements ConnectorPlugin {
     }
 
     @Override
-    public ConnectorFactory create(
-        @Nonnull final String connectorName,
-        @Nonnull @NonNull final ConnectorContext connectorContext
-    ) {
+    public ConnectorFactory create(@Nonnull @NonNull final ConnectorContext connectorContext) {
         return null;
     }
 

--- a/metacat-connector-postgresql/src/main/java/com/netflix/metacat/connector/postgresql/PostgreSqlConnectorFactory.java
+++ b/metacat-connector-postgresql/src/main/java/com/netflix/metacat/connector/postgresql/PostgreSqlConnectorFactory.java
@@ -35,13 +35,16 @@ class PostgreSqlConnectorFactory extends DefaultConnectorFactory {
     /**
      * Constructor.
      *
-     * @param name          The catalog name
-     * @param configuration The catalog configuration
+     * @param name             catalog name
+     * @param catalogShardName catalog shard name
+     * @param configuration    catalog configuration
      */
     PostgreSqlConnectorFactory(
         @Nonnull @NonNull final String name,
+        @Nonnull @NonNull final String catalogShardName,
         @Nonnull @NonNull final Map<String, String> configuration
     ) {
-        super(name, Lists.newArrayList(new PostgreSqlConnectorModule(name, configuration)));
+        super(name, catalogShardName,
+            Lists.newArrayList(new PostgreSqlConnectorModule(catalogShardName, configuration)));
     }
 }

--- a/metacat-connector-postgresql/src/main/java/com/netflix/metacat/connector/postgresql/PostgreSqlConnectorModule.java
+++ b/metacat-connector-postgresql/src/main/java/com/netflix/metacat/connector/postgresql/PostgreSqlConnectorModule.java
@@ -42,20 +42,20 @@ import java.util.Map;
  */
 public class PostgreSqlConnectorModule extends AbstractModule {
 
-    private final String name;
+    private final String catalogShardName;
     private final Map<String, String> configuration;
 
     /**
      * Constructor.
      *
-     * @param name          The name of the catalog this module is associated will be associated with
-     * @param configuration The connector configuration
+     * @param catalogShardName  catalog shard name
+     * @param configuration     connector configuration
      */
     PostgreSqlConnectorModule(
-        @Nonnull @NonNull final String name,
+        @Nonnull @NonNull final String catalogShardName,
         @Nonnull @NonNull final Map<String, String> configuration
     ) {
-        this.name = name;
+        this.catalogShardName = catalogShardName;
         this.configuration = configuration;
     }
 
@@ -64,8 +64,8 @@ public class PostgreSqlConnectorModule extends AbstractModule {
      */
     @Override
     protected void configure() {
-        this.bind(DataSource.class)
-            .toInstance(DataSourceManager.get().load(this.name, this.configuration).get(this.name));
+        this.bind(DataSource.class).toInstance(DataSourceManager.get()
+            .load(this.catalogShardName, this.configuration).get(this.catalogShardName));
         this.bind(JdbcTypeConverter.class).to(PostgreSqlTypeConverter.class).in(Scopes.SINGLETON);
         this.bind(JdbcExceptionMapper.class).to(PostgreSqlExceptionMapper.class).in(Scopes.SINGLETON);
         this.bind(ConnectorDatabaseService.class)

--- a/metacat-connector-postgresql/src/main/java/com/netflix/metacat/connector/postgresql/PostgreSqlConnectorPlugin.java
+++ b/metacat-connector-postgresql/src/main/java/com/netflix/metacat/connector/postgresql/PostgreSqlConnectorPlugin.java
@@ -48,11 +48,9 @@ public class PostgreSqlConnectorPlugin implements ConnectorPlugin {
      * {@inheritDoc}
      */
     @Override
-    public ConnectorFactory create(
-        @Nonnull @NonNull final String connectorName,
-        @Nonnull @NonNull final ConnectorContext connectorContext
-    ) {
-        return new PostgreSqlConnectorFactory(connectorName, connectorContext.getConfiguration());
+    public ConnectorFactory create(@Nonnull @NonNull final ConnectorContext connectorContext) {
+        return new PostgreSqlConnectorFactory(connectorContext.getCatalogName(),
+            connectorContext.getCatalogShardName(), connectorContext.getConfiguration());
     }
 
     /**

--- a/metacat-connector-redshift/src/main/java/com/netflix/metacat/connector/redshift/RedshiftConnectorFactory.java
+++ b/metacat-connector-redshift/src/main/java/com/netflix/metacat/connector/redshift/RedshiftConnectorFactory.java
@@ -33,13 +33,15 @@ class RedshiftConnectorFactory extends DefaultConnectorFactory {
     /**
      * Constructor.
      *
-     * @param name          The catalog name
-     * @param configuration The catalog configuration
+     * @param name              catalog name
+     * @param catalogShardName  catalog shard name
+     * @param configuration     catalog configuration
      */
     RedshiftConnectorFactory(
         final String name,
+        final String catalogShardName,
         final Map<String, String> configuration
     ) {
-        super(name, Lists.newArrayList(new RedshiftConnectorModule(name, configuration)));
+        super(name, catalogShardName, Lists.newArrayList(new RedshiftConnectorModule(catalogShardName, configuration)));
     }
 }

--- a/metacat-connector-redshift/src/main/java/com/netflix/metacat/connector/redshift/RedshiftConnectorModule.java
+++ b/metacat-connector-redshift/src/main/java/com/netflix/metacat/connector/redshift/RedshiftConnectorModule.java
@@ -40,20 +40,20 @@ import java.util.Map;
  */
 public class RedshiftConnectorModule extends AbstractModule {
 
-    private final String name;
+    private final String catalogShardName;
     private final Map<String, String> configuration;
 
     /**
      * Constructor.
      *
-     * @param name          The name of the catalog this module is associated will be associated with
-     * @param configuration The connector configuration
+     * @param catalogShardName  catalog shard name
+     * @param configuration     connector configuration
      */
     RedshiftConnectorModule(
-        final String name,
+        final String catalogShardName,
         final Map<String, String> configuration
     ) {
-        this.name = name;
+        this.catalogShardName = catalogShardName;
         this.configuration = configuration;
     }
 
@@ -62,8 +62,8 @@ public class RedshiftConnectorModule extends AbstractModule {
      */
     @Override
     protected void configure() {
-        this.bind(DataSource.class)
-            .toInstance(DataSourceManager.get().load(this.name, this.configuration).get(this.name));
+        this.bind(DataSource.class).toInstance(DataSourceManager.get()
+            .load(this.catalogShardName, this.configuration).get(this.catalogShardName));
         this.bind(JdbcTypeConverter.class).to(RedshiftTypeConverter.class).in(Scopes.SINGLETON);
         this.bind(JdbcExceptionMapper.class).to(RedshiftExceptionMapper.class).in(Scopes.SINGLETON);
         this.bind(ConnectorDatabaseService.class)

--- a/metacat-connector-redshift/src/main/java/com/netflix/metacat/connector/redshift/RedshiftConnectorPlugin.java
+++ b/metacat-connector-redshift/src/main/java/com/netflix/metacat/connector/redshift/RedshiftConnectorPlugin.java
@@ -48,11 +48,9 @@ public class RedshiftConnectorPlugin implements ConnectorPlugin {
      * {@inheritDoc}
      */
     @Override
-    public ConnectorFactory create(
-        @Nonnull @NonNull final String connectorName,
-        @Nonnull @NonNull final ConnectorContext connectorContext
-    ) {
-        return new RedshiftConnectorFactory(connectorName, connectorContext.getConfiguration());
+    public ConnectorFactory create(@Nonnull @NonNull final ConnectorContext connectorContext) {
+        return new RedshiftConnectorFactory(connectorContext.getCatalogName(),
+            connectorContext.getCatalogShardName(), connectorContext.getConfiguration());
     }
 
     /**

--- a/metacat-connector-s3/src/main/java/com/netflix/metacat/connector/s3/S3ConnectorFactory.java
+++ b/metacat-connector-s3/src/main/java/com/netflix/metacat/connector/s3/S3ConnectorFactory.java
@@ -33,6 +33,7 @@ import java.util.Map;
  */
 public class S3ConnectorFactory implements ConnectorFactory {
     private final String name;
+    private final String catalogShardName;
     private final Map<String, String> configuration;
     private final S3ConnectorInfoConverter infoConverter;
     private ConnectorDatabaseService databaseService;
@@ -44,14 +45,17 @@ public class S3ConnectorFactory implements ConnectorFactory {
     /**
      * Constructor.
      * @param name connector name. Also the catalog name.
+     * @param catalogShardName catalog shard name
      * @param configuration configuration properties
      * @param infoConverter S3 info converter
      */
-    public S3ConnectorFactory(final String name, final Map<String, String> configuration,
+    public S3ConnectorFactory(final String name, final String catalogShardName, final Map<String, String> configuration,
         final S3ConnectorInfoConverter infoConverter) {
         Preconditions.checkNotNull(name, "Catalog name is null");
+        Preconditions.checkNotNull(name, "Catalog shard name is null");
         Preconditions.checkNotNull(configuration, "Catalog connector configuration is null");
         this.name = name;
+        this.catalogShardName = catalogShardName;
         this.configuration = configuration;
         this.infoConverter = infoConverter;
         init();
@@ -61,7 +65,7 @@ public class S3ConnectorFactory implements ConnectorFactory {
         //JPA module
         final Map<String, Object> props = Maps.newHashMap(configuration);
         props.put("hibernate.connection.datasource",
-            DataSourceManager.get().load(name, configuration).get(name));
+            DataSourceManager.get().load(catalogShardName, configuration).get(catalogShardName));
         final Module jpaModule = new JpaPersistModule("s3").properties(props);
         final Module s3Module = new S3Module(name, configuration, infoConverter);
         final Injector injector = Guice.createInjector(jpaModule, s3Module);
@@ -90,6 +94,11 @@ public class S3ConnectorFactory implements ConnectorFactory {
     @Override
     public String getName() {
         return name;
+    }
+
+    @Override
+    public String getCatalogShardName() {
+        return catalogShardName;
     }
 
     @Override

--- a/metacat-connector-s3/src/main/java/com/netflix/metacat/connector/s3/S3ConnectorFactory.java
+++ b/metacat-connector-s3/src/main/java/com/netflix/metacat/connector/s3/S3ConnectorFactory.java
@@ -32,7 +32,7 @@ import java.util.Map;
  * s3 connector factory.
  */
 public class S3ConnectorFactory implements ConnectorFactory {
-    private final String name;
+    private final String catalogName;
     private final String catalogShardName;
     private final Map<String, String> configuration;
     private final S3ConnectorInfoConverter infoConverter;
@@ -44,17 +44,18 @@ public class S3ConnectorFactory implements ConnectorFactory {
 
     /**
      * Constructor.
-     * @param name connector name. Also the catalog name.
-     * @param catalogShardName catalog shard name
-     * @param configuration configuration properties
-     * @param infoConverter S3 info converter
+     * @param catalogName       catalog name.
+     * @param catalogShardName  catalog shard name
+     * @param configuration     configuration properties
+     * @param infoConverter     S3 info converter
      */
-    public S3ConnectorFactory(final String name, final String catalogShardName, final Map<String, String> configuration,
-        final S3ConnectorInfoConverter infoConverter) {
-        Preconditions.checkNotNull(name, "Catalog name is null");
-        Preconditions.checkNotNull(name, "Catalog shard name is null");
+    public S3ConnectorFactory(final String catalogName, final String catalogShardName,
+                              final Map<String, String> configuration,
+                              final S3ConnectorInfoConverter infoConverter) {
+        Preconditions.checkNotNull(catalogName, "Catalog name is null");
+        Preconditions.checkNotNull(catalogShardName, "Catalog shard name is null");
         Preconditions.checkNotNull(configuration, "Catalog connector configuration is null");
-        this.name = name;
+        this.catalogName = catalogName;
         this.catalogShardName = catalogShardName;
         this.configuration = configuration;
         this.infoConverter = infoConverter;
@@ -67,7 +68,7 @@ public class S3ConnectorFactory implements ConnectorFactory {
         props.put("hibernate.connection.datasource",
             DataSourceManager.get().load(catalogShardName, configuration).get(catalogShardName));
         final Module jpaModule = new JpaPersistModule("s3").properties(props);
-        final Module s3Module = new S3Module(name, configuration, infoConverter);
+        final Module s3Module = new S3Module(catalogName, configuration, infoConverter);
         final Injector injector = Guice.createInjector(jpaModule, s3Module);
         persistService = injector.getInstance(PersistService.class);
         persistService.start();
@@ -92,8 +93,8 @@ public class S3ConnectorFactory implements ConnectorFactory {
     }
 
     @Override
-    public String getName() {
-        return name;
+    public String getCatalogName() {
+        return catalogName;
     }
 
     @Override

--- a/metacat-connector-s3/src/main/java/com/netflix/metacat/connector/s3/S3ConnectorPlugin.java
+++ b/metacat-connector-s3/src/main/java/com/netflix/metacat/connector/s3/S3ConnectorPlugin.java
@@ -48,10 +48,8 @@ public class S3ConnectorPlugin implements ConnectorPlugin {
      * {@inheritDoc}
      */
     @Override
-    public ConnectorFactory create(
-        @Nonnull final String connectorName,
-        @Nonnull @NonNull final ConnectorContext connectorContext) {
-        return new S3ConnectorFactory(connectorName,
+    public ConnectorFactory create(@Nonnull @NonNull final ConnectorContext connectorContext) {
+        return new S3ConnectorFactory(connectorContext.getCatalogName(), connectorContext.getCatalogShardName(),
             connectorContext.getConfiguration(), (S3ConnectorInfoConverter) getInfoConverter());
     }
 

--- a/metacat-connector-snowflake/src/main/java/com/netflix/metacat/connector/snowflake/SnowflakeConnectorFactory.java
+++ b/metacat-connector-snowflake/src/main/java/com/netflix/metacat/connector/snowflake/SnowflakeConnectorFactory.java
@@ -33,13 +33,16 @@ class SnowflakeConnectorFactory extends DefaultConnectorFactory {
     /**
      * Constructor.
      *
-     * @param name          The catalog name
-     * @param configuration The catalog configuration
+     * @param name              catalog name
+     * @param catalogShardName  catalog shard name
+     * @param configuration     catalog configuration
      */
     SnowflakeConnectorFactory(
         final String name,
+        final String catalogShardName,
         final Map<String, String> configuration
     ) {
-        super(name, Lists.newArrayList(new SnowflakeConnectorModule(name, configuration)));
+        super(name, catalogShardName,
+            Lists.newArrayList(new SnowflakeConnectorModule(catalogShardName, configuration)));
     }
 }

--- a/metacat-connector-snowflake/src/main/java/com/netflix/metacat/connector/snowflake/SnowflakeConnectorModule.java
+++ b/metacat-connector-snowflake/src/main/java/com/netflix/metacat/connector/snowflake/SnowflakeConnectorModule.java
@@ -40,20 +40,20 @@ import java.util.Map;
  */
 public class SnowflakeConnectorModule extends AbstractModule {
 
-    private final String name;
+    private final String catalogShardName;
     private final Map<String, String> configuration;
 
     /**
      * Constructor.
      *
-     * @param name          The name of the catalog this module is associated will be associated with
-     * @param configuration The connector configuration
+     * @param catalogShardName unique catalog shard name
+     * @param configuration    connector configuration
      */
     public SnowflakeConnectorModule(
-        final String name,
+        final String catalogShardName,
         final Map<String, String> configuration
     ) {
-        this.name = name;
+        this.catalogShardName = catalogShardName;
         this.configuration = configuration;
     }
 
@@ -62,8 +62,8 @@ public class SnowflakeConnectorModule extends AbstractModule {
      */
     @Override
     protected void configure() {
-        this.bind(DataSource.class)
-            .toInstance(DataSourceManager.get().load(this.name, this.configuration).get(this.name));
+        this.bind(DataSource.class).toInstance(DataSourceManager.get()
+            .load(this.catalogShardName, this.configuration).get(this.catalogShardName));
         this.bind(JdbcTypeConverter.class).to(SnowflakeTypeConverter.class).in(Scopes.SINGLETON);
         this.bind(JdbcExceptionMapper.class).to(SnowflakeExceptionMapper.class).in(Scopes.SINGLETON);
         this.bind(ConnectorDatabaseService.class)

--- a/metacat-connector-snowflake/src/main/java/com/netflix/metacat/connector/snowflake/SnowflakeConnectorPlugin.java
+++ b/metacat-connector-snowflake/src/main/java/com/netflix/metacat/connector/snowflake/SnowflakeConnectorPlugin.java
@@ -48,11 +48,9 @@ public class SnowflakeConnectorPlugin implements ConnectorPlugin {
      * {@inheritDoc}
      */
     @Override
-    public ConnectorFactory create(
-        @Nonnull @NonNull final String connectorName,
-        @Nonnull @NonNull final ConnectorContext connectorContext
-    ) {
-        return new SnowflakeConnectorFactory(connectorName, connectorContext.getConfiguration());
+    public ConnectorFactory create(@Nonnull @NonNull final ConnectorContext connectorContext) {
+        return new SnowflakeConnectorFactory(connectorContext.getCatalogName(),
+            connectorContext.getCatalogShardName(), connectorContext.getConfiguration());
     }
 
     /**

--- a/metacat-functional-tests/metacat-test-cluster/etc-metacat/catalog/embedded-fast-hive-metastore-shard.properties
+++ b/metacat-functional-tests/metacat-test-cluster/etc-metacat/catalog/embedded-fast-hive-metastore-shard.properties
@@ -1,0 +1,98 @@
+#
+#
+# Copyright 2018 Netflix, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+#
+
+catalog.name=embedded-fast-hive-metastore
+connector.name=hive
+metacat.schema.whitelist=shard,shard1
+hive.use.embedded.metastore=true
+hive.use.embedded.fastservice=true
+hive.exec.compress.intermediate=true
+hive.exec.max.dynamic.partitions.pernode=10000
+hive.exec.max.dynamic.partitions=300000
+hive.exec.parallel=true
+hive.exec.reducers.max=200
+hive.exec.scratchdir=/tmp/metacat/scratch
+hive.hadoop.supports.splittable.combineinputformat=true
+hive.intermediate.compression.codec=org.apache.hadoop.io.compress.SnappyCodec
+hive.intermediate.compression.type=BLOCK
+hive.mapjoin.localtask.max.memory.usage=0.9
+hive.mapjoin.smalltable.filesize=100000000
+hive.mapred.mode=strict
+hive.optimize.s3.query=true
+hive.ppd.remove.duplicatefilters=false
+hive.security.authorization.createtable.owner.grants=ALL
+hive.security.authorization.enabled=true
+mapred.max.split.size=200000000
+webinterface.private.actions=true
+hive.metastore.warehouse.dir=file://tmp/hive/warehouse
+hive.metastore.checkForDefaultDb=true
+
+datanucleus.autoCreateSchema=true
+datanucleus.fixedDatastore=false
+datanucleus.autoCreateTables=true
+
+fs.s3.impl=org.apache.hadoop.fs.s3.S3FileSystem
+fs.s3n.impl=org.apache.hadoop.fs.s3native.NativeS3FileSystem
+fs.default.name=hdfs://10.155.133.15:9000
+hadoop.tmp.dir=/tmp/metacat/hadoop/tmp
+fs.s3.buffer.dir=/tmp/metacat/hadoop/s3,/tmp/metacat/hadoop/s3
+io.compression.codecs=org.apache.hadoop.io.compress.GzipCodec,org.apache.hadoop.io.compress.DefaultCodec,com.hadoop.compression.lzo.LzoCodec,com.hadoop.compression.lzo.LzopCodec,org.apache.hadoop.io.compress.BZip2Codec,org.apache.hadoop.io.compress.SnappyCodec
+fs.s3bfs.impl=org.apache.hadoop.fs.s3.S3FileSystem
+hadoop.metrics.defaultFile=/home/hadoop/conf/hadoopDefaultMetricsList
+hadoop.metrics.list=TotalLoad,CapacityTotalGB,UnderReplicatedBlocks,CapacityRemainingGB,PendingDeletionBlocks,PendingReplicationBlocks,CorruptBlocks,CapacityUsedGB,numLiveDataNodes,numDeadDataNodes,MissingBlocks
+io.compression.codec.lzo.class=com.hadoop.compression.lzo.LzoCodec
+ipc.client.connect.max.retries=50
+fs.s3n.endpoint=s3-external-1.amazonaws.com
+s3mper.disable=false
+s3mper.listing.recheck.count=15
+s3mper.listing.recheck.period=60000
+s3mper.metastore.retry=5
+s3mper.metastore.timeout=30000
+mapreduce.jobtracker.system.dir.permission=777
+hive.metastore.fs.handler.class=com.netflix.metacat.connector.hive.metastore.HiveMetaStoreFsImpl
+
+
+javax.jdo.option.name=embedded-fast-hive-metastore-shard
+javax.jdo.option.username=metacat_user
+javax.jdo.option.url=jdbc:mysql://hive-metastore-db:3306/shardfasthive?createDatabaseIfNotExist=true&useUnicode=true&characterEncoding=latin1&autoReconnect=true&sessionVariables=@@innodb_lock_wait_timeout=120&rewriteBatchedStatements=true
+javax.jdo.option.driverClassName=com.mysql.jdbc.Driver
+javax.jdo.option.password=metacat_user_password
+javax.jdo.option.jmxEnabled=true
+javax.jdo.option.maxActive=10
+javax.jdo.option.maxIdle=10
+javax.jdo.option.initialSize=2
+javax.jdo.option.minIdle=2
+javax.jdo.option.maxWait=60000
+javax.jdo.option.minEvictableIdleTimeMillis=180000
+javax.jdo.option.timeBetweenEvictionRunsMillis=10000
+javax.jdo.option.testOnBorrow=true
+javax.jdo.option.testWhileIdle=true
+javax.jdo.option.testOnReturn=false
+javax.jdo.option.removeAbandonedTimeout=1800
+javax.jdo.option.removeAbandoned=true
+javax.jdo.option.logAbandoned=true
+javax.jdo.option.validationQuery=SELECT 1
+javax.jdo.option.jdbcInterceptors=org.apache.tomcat.jdbc.pool.interceptor.ConnectionState;org.apache.tomcat.jdbc.pool.interceptor.StatementFinalizer;org.apache.tomcat.jdbc.pool.interceptor.SlowQueryReportJmx(threshold=30000)
+javax.jdo.option.defaultTransactionIsolation=READ_COMMITTED
+javax.jdo.option.defaultAutoCommit=false
+
+hive.allow-drop-table=true
+hive.allow-rename-table=true
+metacat.schema.blacklist=information_schema
+hive.use.embedded.sql.save.partitions=true
+hive.use.embedded.sql.delete.partitions=true

--- a/metacat-functional-tests/src/functionalTest/groovy/com/netflix/metacat/MetacatSmokeSpec.groovy
+++ b/metacat-functional-tests/src/functionalTest/groovy/com/netflix/metacat/MetacatSmokeSpec.groovy
@@ -200,6 +200,7 @@ class MetacatSmokeSpec extends Specification {
         catalogName                     | databaseName | error
         'embedded-hive-metastore'       | 'smoke_db0'  | null
         'embedded-fast-hive-metastore'  | 'fsmoke_db0' | null
+        'embedded-fast-hive-metastore'  | 'shard1'     | null
         'hive-metastore'                | 'hsmoke_db0' | null
         's3-mysql-db'                   | 'smoke_db0'  | null
         'invalid-catalog'               | 'smoke_db0'  | MetacatNotFoundException.class
@@ -254,6 +255,10 @@ class MetacatSmokeSpec extends Specification {
         'embedded-fast-hive-metastore'  | 'fsmoke_db1' | 'test_create_table' | false  | false   | null
         'embedded-fast-hive-metastore'  | 'fsmoke_db1' | 'test_create_table1'| false  | true    | null
         'embedded-fast-hive-metastore'  | 'fsmoke_db1' | 'test.create_table1'| false  | true    | InvalidMetaException.class
+        'embedded-fast-hive-metastore'  | 'shard'      | 'test_create_table' | true   | false   | null
+        'embedded-fast-hive-metastore'  | 'shard'      | 'test_create_table' | false  | false   | null
+        'embedded-fast-hive-metastore'  | 'shard'      | 'test_create_table1'| false  | true    | null
+        'embedded-fast-hive-metastore'  | 'shard'      | 'test.create_table1'| false  | true    | InvalidMetaException.class
         'hive-metastore'                | 'hsmoke_db1' | 'test_create_table' | true   | false   | null
         'hive-metastore'                | 'hsmoke_db1' | 'test_create_table' | false  | false   | null
         'hive-metastore'                | 'hsmoke_db1' | 'test_create_table1'| false  | true    | null
@@ -321,6 +326,7 @@ class MetacatSmokeSpec extends Specification {
         catalogName                     | databaseName  | tableName             | result
         'embedded-hive-metastore'       | 'smoke_ddb1'  | 'test_create_table'   | 0
         'embedded-fast-hive-metastore'  | 'fsmoke_ddb1' | 'test_create_table'   | 0
+        'embedded-fast-hive-metastore'  | 'shard'       | 'test_create_table'   | 0
         'hive-metastore'                | 'hsmoke_ddb'  | 'test_create_table'   | 0
         'hive-metastore'                | 'hsmoke_ddb1' | 'test_create_table1'  | 0
         'hive-metastore'                | 'hsmoke_ddb1' | 'test_create_table2'  | 1
@@ -344,6 +350,7 @@ class MetacatSmokeSpec extends Specification {
         catalogName                     | databaseName
         'embedded-hive-metastore'       | 'smoke_db1'
         'embedded-fast-hive-metastore'  | 'fsmoke_db1'
+        'embedded-fast-hive-metastore'  | 'shard'
         'hive-metastore'                | 'hsmoke_db1'
         's3-mysql-db'                   | 'smoke_db1'
     }
@@ -367,6 +374,8 @@ class MetacatSmokeSpec extends Specification {
         catalogName                     | databaseName | tableName
         'embedded-hive-metastore'       | 'smoke_db2'  | 'part'
         'embedded-fast-hive-metastore'  | 'fsmoke_db2' | 'part'
+        'embedded-fast-hive-metastore'  | 'shard'      | 'part'
+        'embedded-fast-hive-metastore'  | 'shard1'     | 'part'
         'hive-metastore'                | 'hsmoke_db2' | 'part'
         's3-mysql-db'                   | 'smoke_db2'  | 'part'
         's3-mysql-db'                   | 'smoke_db2'  | 'PART'
@@ -395,6 +404,7 @@ class MetacatSmokeSpec extends Specification {
         catalogName                     | databaseName | tableName           | error | newTableName
         'embedded-hive-metastore'       | 'smoke_db3'  | 'test_create_table' | null  | 'test_create_table1'
         'embedded-fast-hive-metastore'  | 'fsmoke_db3' | 'test_create_table' | null  | 'test_create_table1'
+        'embedded-fast-hive-metastore'  | 'shard'      | 'test_create_table' | null  | 'test_create_table1'
         'hive-metastore'                | 'hsmoke_db3' | 'test_create_table' | null  | 'test_create_table1'
     }
 
@@ -429,10 +439,13 @@ class MetacatSmokeSpec extends Specification {
         'embedded-hive-metastore'       | 'smoke_db4'  | 'part'              | 'part_view' | null                           | true
         'embedded-fast-hive-metastore'  | 'fsmoke_db4' | 'part'              | 'part_view' | null                           | false
         'embedded-fast-hive-metastore'  | 'fsmoke_db4' | 'part'              | 'part_view' | null                           | true
+        'embedded-fast-hive-metastore'  | 'shard'      | 'part'              | 'part_view' | null                           | false
+        'embedded-fast-hive-metastore'  | 'shard'      | 'part'              | 'part_view' | null                           | true
         'hive-metastore'                | 'hsmoke_db4' | 'part'              | 'part_view' | null                           | false
         'hive-metastore'                | 'hsmoke_db4' | 'part'              | 'part_view' | null                           | true
         'embedded-hive-metastore'       | 'smoke_db4'  | 'metacat_all_types' | 'part_view' | null                           | false
         'embedded-fast-hive-metastore'  | 'fsmoke_db4' | 'metacat_all_types' | 'part_view' | null                           | false
+        'embedded-fast-hive-metastore'  | 'shard'      | 'metacat_all_types' | 'part_view' | null                           | false
         's3-mysql-db'                   | 'smoke_db4'  | 'part'              | 'part_view' | null                           | false
         'xyz'                           | 'smoke_db4'  | 'z'                 | 'part_view' | MetacatNotFoundException.class | false
     }
@@ -467,6 +480,8 @@ class MetacatSmokeSpec extends Specification {
         'embedded-hive-metastore'       | 'smoke_db4'    | 'part'              | 'part_view' | null                           | true
         'embedded-fast-hive-metastore'  | 'fsmoke_db4'   | 'part'              | 'part_view' | null                           | false
         'embedded-fast-hive-metastore'  | 'fsmoke_db4'   | 'part'              | 'part_view' | null                           | true
+        'embedded-fast-hive-metastore'  | 'shard'        | 'part'              | 'part_view' | null                           | false
+        'embedded-fast-hive-metastore'  | 'shard'        | 'part'              | 'part_view' | null                           | true
         'hive-metastore'                | 'hsmoke_db4'   | 'part'              | 'part_view' | null                           | false
         'hive-metastore'                | 'hsmoke_db4'   | 'part'              | 'part_view' | null                           | true
         'embedded-hive-metastore'       | 'smoke_db4'    | 'metacat_all_types' | 'part_view' | null                           | false
@@ -485,6 +500,7 @@ class MetacatSmokeSpec extends Specification {
         catalogName                     | databaseName      | tableName
         'embedded-hive-metastore'       | 'smoke_db'        | 'part'
         'embedded-fast-hive-metastore'  | 'fsmoke_db'       | 'part'
+        'embedded-fast-hive-metastore'  | 'shard'           | 'part'
         'hive-metastore'                | 'hsmoke_db'       | 'part'
         's3-mysql-db'                   | 'smoke_db'        | 'part'
     }
@@ -649,6 +665,13 @@ class MetacatSmokeSpec extends Specification {
         'embedded-fast-hive-metastore'  | 'fsmoke_db'       | 'part'    | 'one=xyz'     | ''        | ''        | true   | true  | null
         'embedded-fast-hive-metastore'  | 'fsmoke_db'       | 'part'    | 'one=xyz'     | '/'       | ''        | true   | true  | null
         'embedded-fast-hive-metastore'  | 'fsmoke_db'       | 'part'    | 'two=xyz'     | ''        | ''        | false  | false | MetacatBadRequestException.class
+        'embedded-fast-hive-metastore'  | 'shard'           | 'part'    | 'one=xyz'     | ''        | ''        | false  | false | null
+        'embedded-fast-hive-metastore'  | 'shard'           | 'part'    | 'one=xyz'     | '/'       | ''        | false  | false | null
+        'embedded-fast-hive-metastore'  | 'shard'           | 'part'    | 'one=xyz'     | ''        | ''        | true   | false | null
+        'embedded-fast-hive-metastore'  | 'shard'           | 'part'    | 'one=xyz'     | '/'       | ''        | true   | false | null
+        'embedded-fast-hive-metastore'  | 'shard'           | 'part'    | 'one=xyz'     | ''        | ''        | true   | true  | null
+        'embedded-fast-hive-metastore'  | 'shard'           | 'part'    | 'one=xyz'     | '/'       | ''        | true   | true  | null
+        'embedded-fast-hive-metastore'  | 'shard'           | 'part'    | 'two=xyz'     | ''        | ''        | false  | false | MetacatBadRequestException.class
         'hive-metastore'                | 'hsmoke_db'       | 'part'    | 'one=xyz'     | ''        | ''        | false  | false | null
         'hive-metastore'                | 'hsmoke_db'       | 'part'    | 'one=xyz'     | ''        | ''        | true   | false | null
         'hive-metastore'                | 'hsmoke_db'       | 'part'    | 'one=xyz'     | ''        | ''        | true   | true  | null
@@ -687,6 +710,9 @@ class MetacatSmokeSpec extends Specification {
         'embedded-fast-hive-metastore'  | 'fsmoke_db7'      | 'part'    | 'one=xyz'     | true      | true
         'embedded-fast-hive-metastore'  | 'fsmoke_db7'      | 'part'    | 'one=xyz'     | true      | false
         'embedded-fast-hive-metastore'  | 'fsmoke_db7'      | 'part'    | 'one=xyz'     | false     | true
+        'embedded-fast-hive-metastore'  | 'shard'           | 'part'    | 'one=xyz'     | true      | true
+        'embedded-fast-hive-metastore'  | 'shard'           | 'part'    | 'one=xyz'     | true      | false
+        'embedded-fast-hive-metastore'  | 'shard'           | 'part'    | 'one=xyz'     | false     | true
         'hive-metastore'                | 'hsmoke_db7'      | 'part'    | 'one=xyz'     | true      | true
         'hive-metastore'                | 'hsmoke_db7'      | 'part'    | 'one=xyz'     | true      | false
         'hive-metastore'                | 'hsmoke_db7'      | 'part'    | 'one=xyz'     | false     | true
@@ -953,6 +979,8 @@ class MetacatSmokeSpec extends Specification {
         'embedded-hive-metastore'       | 'smoke_db6'  | 'part'    | ['test', 'unused'] as Set<String> | false
         'embedded-fast-hive-metastore'  | 'fsmoke_db6' | 'part'    | ['test'] as Set<String>           | true
         'embedded-fast-hive-metastore'  | 'fsmoke_db6' | 'part'    | ['test', 'unused'] as Set<String> | false
+        'embedded-fast-hive-metastore'  | 'shard'      | 'part'    | ['test'] as Set<String>           | true
+        'embedded-fast-hive-metastore'  | 'shard'      | 'part'    | ['test', 'unused'] as Set<String> | false
         'hive-metastore'                | 'hsmoke_db6' | 'part'    | ['test'] as Set<String>           | true
         'hive-metastore'                | 'hsmoke_db6' | 'part'    | ['test', 'unused'] as Set<String> | false
         's3-mysql-db'                   | 'smoke_db6'  | 'part'    | ['test'] as Set<String>           | true

--- a/metacat-main/src/main/java/com/netflix/metacat/main/manager/ConnectorManager.java
+++ b/metacat-main/src/main/java/com/netflix/metacat/main/manager/ConnectorManager.java
@@ -122,6 +122,7 @@ public class ConnectorManager {
         Preconditions.checkState(!stopped.get(), "ConnectorManager is stopped");
         final String connectorType = connectorContext.getConnectorType();
         final String catalogName = connectorContext.getCatalogName();
+        final String catalogShardName = connectorContext.getCatalogShardName();
         final ConnectorPlugin connectorPlugin = plugins.get(connectorType);
         if (connectorPlugin != null) {
             final MetacatCatalogConfig catalogConfig =
@@ -142,17 +143,18 @@ public class ConnectorManager {
             try {
                 databaseServices.add(connectorFactory.getDatabaseService());
             } catch (UnsupportedOperationException e) {
-                log.debug("Catalog {} doesn't support getDatabaseService. Ignoring.", catalogName);
+                log.debug("Catalog {}:{} doesn't support getDatabaseService. Ignoring.", catalogName, catalogShardName);
             }
             try {
                 tableServices.add(connectorFactory.getTableService());
             } catch (UnsupportedOperationException e) {
-                log.debug("Catalog {} doesn't support getTableService. Ignoring.", catalogName);
+                log.debug("Catalog {}:{} doesn't support getTableService. Ignoring.", catalogName, catalogShardName);
             }
             try {
                 partitionServices.add(connectorFactory.getPartitionService());
             } catch (UnsupportedOperationException e) {
-                log.debug("Catalog {} doesn't support getPartitionService. Ignoring.", catalogName);
+                log.debug("Catalog {}:{} doesn't support getPartitionService. Ignoring.",
+                    catalogName, catalogShardName);
             }
             final CatalogHolder catalogHolder = new CatalogHolder(catalogConfig, connectorFactory);
             if (databaseNames.isEmpty()) {

--- a/metacat-main/src/main/java/com/netflix/metacat/main/manager/ConnectorManager.java
+++ b/metacat-main/src/main/java/com/netflix/metacat/main/manager/ConnectorManager.java
@@ -99,7 +99,7 @@ public class ConnectorManager {
             try {
                 catalogHolder.getConnectorFactory().stop();
             } catch (Throwable t) {
-                log.error("Error shutting down connector: {}", catalogHolder.getConnectorFactory().getName(), t);
+                log.error("Error shutting down connector: {}", catalogHolder.getConnectorFactory().getCatalogName(), t);
             }
         });
     }

--- a/metacat-main/src/main/java/com/netflix/metacat/main/manager/PluginManager.java
+++ b/metacat-main/src/main/java/com/netflix/metacat/main/manager/PluginManager.java
@@ -24,7 +24,8 @@ import java.util.ServiceLoader;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
- * Plugin Manager.
+ * Plugin Manager. This loads the connector plugins using the ServiceLoader.
+ * Connector plugins need to be loaded before loading the catalogs.
  */
 @Slf4j
 public class PluginManager {

--- a/metacat-main/src/main/java/com/netflix/metacat/main/services/MetacatThriftService.java
+++ b/metacat-main/src/main/java/com/netflix/metacat/main/services/MetacatThriftService.java
@@ -12,6 +12,7 @@
  */
 package com.netflix.metacat.main.services;
 
+import com.netflix.metacat.common.server.spi.MetacatCatalogConfig;
 import com.netflix.metacat.main.manager.ConnectorManager;
 import com.netflix.metacat.thrift.CatalogThriftService;
 import com.netflix.metacat.thrift.CatalogThriftServiceFactory;
@@ -45,10 +46,9 @@ public class MetacatThriftService {
 
     protected List<CatalogThriftService> getCatalogThriftServices() {
         return connectorManager.getCatalogs()
-            .entrySet()
             .stream()
-            .filter(entry -> entry.getValue().isThriftInterfaceRequested())
-            .map(entry -> thriftServiceFactory.create(entry.getKey(), entry.getValue().getThriftPort()))
+            .filter(MetacatCatalogConfig::isThriftInterfaceRequested)
+            .map(catalog -> thriftServiceFactory.create(catalog.getCatalogName(), catalog.getThriftPort()))
             .collect(Collectors.toList());
     }
 

--- a/metacat-main/src/main/java/com/netflix/metacat/main/services/impl/DatabaseServiceImpl.java
+++ b/metacat-main/src/main/java/com/netflix/metacat/main/services/impl/DatabaseServiceImpl.java
@@ -89,7 +89,7 @@ public class DatabaseServiceImpl implements DatabaseService {
         final MetacatRequestContext metacatRequestContext = MetacatContextManager.getContext();
         eventBus.postSync(new MetacatCreateDatabasePreEvent(name, metacatRequestContext, this));
         final ConnectorRequestContext connectorRequestContext = converterUtil.toConnectorContext(metacatRequestContext);
-        connectorManager.getDatabaseService(name.getCatalogName()).create(connectorRequestContext,
+        connectorManager.getDatabaseService(name).create(connectorRequestContext,
             converterUtil.fromDatabaseDto(dto));
         if (dto.getDefinitionMetadata() != null) {
             log.info("Saving user metadata for schema {}", name);
@@ -113,7 +113,7 @@ public class DatabaseServiceImpl implements DatabaseService {
         try {
             final ConnectorRequestContext connectorRequestContext
                 = converterUtil.toConnectorContext(metacatRequestContext);
-            connectorManager.getDatabaseService(name.getCatalogName())
+            connectorManager.getDatabaseService(name)
                 .update(connectorRequestContext, converterUtil.fromDatabaseDto(dto));
         } catch (UnsupportedOperationException ignored) {
         }
@@ -145,7 +145,7 @@ public class DatabaseServiceImpl implements DatabaseService {
         final DatabaseDto dto = get(name, true, true);
         eventBus.postSync(new MetacatDeleteDatabasePreEvent(name, metacatRequestContext, this, dto));
         final ConnectorRequestContext connectorRequestContext = converterUtil.toConnectorContext(metacatRequestContext);
-        connectorManager.getDatabaseService(name.getCatalogName()).delete(connectorRequestContext, name);
+        connectorManager.getDatabaseService(name).delete(connectorRequestContext, name);
 
         // Delete definition metadata if it exists
         if (userMetadataService.getDefinitionMetadata(name).isPresent()) {
@@ -171,13 +171,13 @@ public class DatabaseServiceImpl implements DatabaseService {
         final boolean includeTableNames) {
         validate(name);
         final MetacatRequestContext metacatRequestContext = MetacatContextManager.getContext();
-        final MetacatCatalogConfig config = connectorManager.getCatalogConfig(name.getCatalogName());
-        final ConnectorDatabaseService service = connectorManager.getDatabaseService(name.getCatalogName());
-        final ConnectorTableService tableService = connectorManager.getTableService(name.getCatalogName());
+        final MetacatCatalogConfig config = connectorManager.getCatalogConfig(name);
+        final ConnectorDatabaseService service = connectorManager.getDatabaseService(name);
+        final ConnectorTableService tableService = connectorManager.getTableService(name);
         final ConnectorRequestContext connectorRequestContext = converterUtil.toConnectorContext(metacatRequestContext);
 
         final DatabaseDto dto = converterUtil.toDatabaseDto(service.get(connectorRequestContext, name));
-        dto.setType(connectorManager.getCatalogConfig(name).getType());
+        dto.setType(config.getType());
         if (includeTableNames) {
             final List<QualifiedName> tableNames = tableService
                 .listNames(connectorRequestContext, name, null, null, null);

--- a/metacat-main/src/main/java/com/netflix/metacat/main/services/impl/MViewServiceImpl.java
+++ b/metacat-main/src/main/java/com/netflix/metacat/main/services/impl/MViewServiceImpl.java
@@ -423,7 +423,7 @@ public class MViewServiceImpl implements MViewService {
     public List<NameDateDto> list(final QualifiedName name) {
         final MetacatRequestContext metacatRequestContext = MetacatContextManager.getContext();
         final QualifiedName viewDbName = QualifiedName.ofDatabase(name.getCatalogName(), VIEW_DB_NAME);
-        final ConnectorTableService service = connectorManager.getTableService(name.getCatalogName());
+        final ConnectorTableService service = connectorManager.getTableService(viewDbName);
 
         List<QualifiedName> tableNames = Lists.newArrayList();
         try {

--- a/metacat-main/src/main/java/com/netflix/metacat/main/services/impl/PartitionServiceImpl.java
+++ b/metacat-main/src/main/java/com/netflix/metacat/main/services/impl/PartitionServiceImpl.java
@@ -152,7 +152,7 @@ public class PartitionServiceImpl implements PartitionService {
         }
 
         final MetacatRequestContext metacatRequestContext = MetacatContextManager.getContext();
-        final ConnectorPartitionService service = connectorManager.getPartitionService(name.getCatalogName());
+        final ConnectorPartitionService service = connectorManager.getPartitionService(name);
 
         final ConnectorRequestContext connectorRequestContext = converterUtil.toConnectorContext(metacatRequestContext);
         final List<PartitionInfo> resultInfo = service
@@ -207,7 +207,7 @@ public class PartitionServiceImpl implements PartitionService {
         Integer result = 0;
         if (tableService.exists(name)) {
             final MetacatRequestContext metacatRequestContext = MetacatContextManager.getContext();
-            final ConnectorPartitionService service = connectorManager.getPartitionService(name.getCatalogName());
+            final ConnectorPartitionService service = connectorManager.getPartitionService(name);
             final ConnectorRequestContext connectorRequestContext
                 = converterUtil.toConnectorContext(metacatRequestContext);
             result = service.getPartitionCount(connectorRequestContext, name);
@@ -221,7 +221,7 @@ public class PartitionServiceImpl implements PartitionService {
     @Override
     public PartitionsSaveResponseDto save(final QualifiedName name, final PartitionsSaveRequestDto dto) {
         final MetacatRequestContext metacatRequestContext = MetacatContextManager.getContext();
-        final ConnectorPartitionService service = connectorManager.getPartitionService(name.getCatalogName());
+        final ConnectorPartitionService service = connectorManager.getPartitionService(name);
         final List<PartitionDto> partitionDtos = dto.getPartitions();
         // If no partitions are passed, then return
         if (partitionDtos == null || partitionDtos.isEmpty()) {
@@ -348,7 +348,7 @@ public class PartitionServiceImpl implements PartitionService {
             final PartitionsSaveRequestDto dto = new PartitionsSaveRequestDto();
             dto.setPartitionIdsForDeletes(partitionIds);
             eventBus.postSync(new MetacatDeleteTablePartitionPreEvent(name, metacatRequestContext, this, dto));
-            final ConnectorPartitionService service = connectorManager.getPartitionService(name.getCatalogName());
+            final ConnectorPartitionService service = connectorManager.getPartitionService(name);
             // Get the partitions before calling delete
             final GetPartitionsRequestDto requestDto = new GetPartitionsRequestDto(null, partitionIds, false, true);
             final ConnectorRequestContext connectorRequestContext
@@ -397,10 +397,8 @@ public class PartitionServiceImpl implements PartitionService {
         final Map<String, List<QualifiedName>> result = Maps.newConcurrentMap();
         final List<ListenableFuture<Void>> futures = Lists.newArrayList();
         final MetacatRequestContext metacatRequestContext = MetacatContextManager.getContext();
-        catalogService.getCatalogNames().forEach(catalog -> {
+        connectorManager.getPartitionServices().forEach(service -> {
             futures.add(threadServiceManager.getExecutor().submit(() -> {
-                final ConnectorPartitionService service =
-                    connectorManager.getPartitionService(catalog.getCatalogName());
                 final ConnectorRequestContext connectorRequestContext
                     = converterUtil.toConnectorContext(metacatRequestContext);
                 try {
@@ -415,7 +413,7 @@ public class PartitionServiceImpl implements PartitionService {
                         }
                     });
                 } catch (final UnsupportedOperationException uoe) {
-                    log.debug("Catalog {} doesn't support getPartitionNames. Ignoring.", catalog.getCatalogName());
+                    log.debug("Partition service doesn't support getPartitionNames. Ignoring.");
                 }
                 return null;
             }));
@@ -441,7 +439,7 @@ public class PartitionServiceImpl implements PartitionService {
         List<String> result = Lists.newArrayList();
         if (tableService.exists(name)) {
             final MetacatRequestContext metacatRequestContext = MetacatContextManager.getContext();
-            final ConnectorPartitionService service = connectorManager.getPartitionService(name.getCatalogName());
+            final ConnectorPartitionService service = connectorManager.getPartitionService(name);
             final ConnectorRequestContext connectorRequestContext
                 = converterUtil.toConnectorContext(metacatRequestContext);
             try {
@@ -470,7 +468,7 @@ public class PartitionServiceImpl implements PartitionService {
         List<String> result = Lists.newArrayList();
         if (tableService.exists(name)) {
             final MetacatRequestContext metacatRequestContext = MetacatContextManager.getContext();
-            final ConnectorPartitionService service = connectorManager.getPartitionService(name.getCatalogName());
+            final ConnectorPartitionService service = connectorManager.getPartitionService(name);
             final ConnectorRequestContext connectorRequestContext
                 = converterUtil.toConnectorContext(metacatRequestContext);
             try {

--- a/metacat-main/src/test/groovy/com/netflix/metacat/main/manager/CatalogManagerSpec.groovy
+++ b/metacat-main/src/test/groovy/com/netflix/metacat/main/manager/CatalogManagerSpec.groovy
@@ -22,6 +22,7 @@ import com.google.common.collect.Maps
 import com.netflix.metacat.common.server.properties.Config
 import com.netflix.metacat.common.server.spi.MetacatCatalogConfig
 import com.netflix.spectator.api.Registry
+import org.assertj.core.util.Sets
 import org.springframework.boot.actuate.health.Status
 import spock.lang.Specification
 
@@ -35,12 +36,12 @@ class CatalogManagerSpec extends Specification {
     def "can report health accurately based on whether catalogs are loaded or not"() {
         def connectorManager = Mock(ConnectorManager) {
             2 * getCatalogs() >>> [
-                Maps.newHashMap(),
-                ImmutableMap.of(
-                    "testhive", MetacatCatalogConfig.createFromMapAndRemoveProperties("hive", Maps.newHashMap()),
-                    "prodhive", MetacatCatalogConfig.createFromMapAndRemoveProperties("hive", Maps.newHashMap()),
-                    "finance", MetacatCatalogConfig.createFromMapAndRemoveProperties("mysql", Maps.newHashMap())
-                )
+                [],
+                [
+                    MetacatCatalogConfig.createFromMapAndRemoveProperties("hive", "testhive", Maps.newHashMap()),
+                    MetacatCatalogConfig.createFromMapAndRemoveProperties("hive", "prodhive", Maps.newHashMap()),
+                    MetacatCatalogConfig.createFromMapAndRemoveProperties("mysql", "finance", Maps.newHashMap())
+                ]
             ]
         }
         def config = Mock(Config) {

--- a/metacat-main/src/test/groovy/com/netflix/metacat/main/manager/ConnectorManagerSpec.groovy
+++ b/metacat-main/src/test/groovy/com/netflix/metacat/main/manager/ConnectorManagerSpec.groovy
@@ -1,0 +1,173 @@
+/*
+ *
+ * Copyright 2018 Netflix, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ */
+
+package com.netflix.metacat.main.manager
+
+import com.netflix.metacat.common.QualifiedName
+import com.netflix.metacat.common.server.connectors.ConnectorContext
+import com.netflix.metacat.common.server.connectors.ConnectorDatabaseService
+import com.netflix.metacat.common.server.connectors.ConnectorFactory
+import com.netflix.metacat.common.server.connectors.ConnectorInfoConverter
+import com.netflix.metacat.common.server.connectors.ConnectorPartitionService
+import com.netflix.metacat.common.server.connectors.ConnectorPlugin
+import com.netflix.metacat.common.server.connectors.ConnectorTableService
+import com.netflix.metacat.common.server.connectors.ConnectorTypeConverter
+import com.netflix.metacat.common.server.properties.Config
+import spock.lang.Specification
+
+/**
+ * Specification for ConnectorManager.
+ *
+ * @author amajumdar
+ * @since 1.2.0
+ */
+class ConnectorManagerSpec extends Specification {
+    def config = Mock(Config)
+    def plugin = Mock(ConnectorPlugin)
+
+    def setup() {
+        plugin.create(_) >> Mock(ConnectorFactory)
+        plugin.getInfoConverter() >> Mock(ConnectorInfoConverter)
+        plugin.getType() >> 'default'
+        plugin.getTypeConverter() >> Mock(ConnectorTypeConverter)
+    }
+
+    def testAddPlugin(){
+        given:
+        def connectorManager = new ConnectorManager(config)
+        when:
+        connectorManager.addPlugin(plugin)
+        then:
+        noExceptionThrown()
+    }
+
+    def testCreateConnection(){
+        given:
+        def connectorManager = new ConnectorManager(config)
+        def context = Mock(ConnectorContext)
+        connectorManager.addPlugin(plugin)
+        def hivePlugin = Mock(ConnectorPlugin)
+        def hiveConnectorFactory = Mock(ConnectorFactory)
+        def databaseService = Mock(ConnectorDatabaseService)
+        def tableService = Mock(ConnectorTableService)
+        def partitionService = Mock(ConnectorPartitionService)
+        hiveConnectorFactory.getDatabaseService() >> databaseService
+        hiveConnectorFactory.getTableService() >> tableService
+        hiveConnectorFactory.getPartitionService() >> partitionService
+        def hiveConnectorFactory1 = Mock(ConnectorFactory)
+        def databaseService1 = Mock(ConnectorDatabaseService)
+        def tableService1 = Mock(ConnectorTableService)
+        def partitionService1 = Mock(ConnectorPartitionService)
+        hiveConnectorFactory1.getDatabaseService() >> databaseService1
+        hiveConnectorFactory1.getTableService() >> tableService1
+        hiveConnectorFactory1.getPartitionService() >> partitionService1
+        def hiveConnectorFactory2 = Mock(ConnectorFactory)
+        def databaseService2 = Mock(ConnectorDatabaseService)
+        def tableService2 = Mock(ConnectorTableService)
+        def partitionService2 = Mock(ConnectorPartitionService)
+        hiveConnectorFactory2.getDatabaseService() >> databaseService2
+        hiveConnectorFactory2.getTableService() >> tableService2
+        hiveConnectorFactory2.getPartitionService() >> partitionService2
+        hivePlugin.create(_) >>> [hiveConnectorFactory, hiveConnectorFactory1, hiveConnectorFactory2]
+        def connectorInfoConverter = Mock(ConnectorInfoConverter)
+        def connectorTypeConverter = Mock(ConnectorTypeConverter)
+        hivePlugin.getInfoConverter() >> connectorInfoConverter
+        hivePlugin.getType() >> 'hive'
+        hivePlugin.getTypeConverter() >> connectorTypeConverter
+        connectorManager.addPlugin(hivePlugin)
+        when:
+        connectorManager.createConnection(context)
+        then:
+        1 * context.getConnectorType() >> 'invalid'
+        0 * context.getConfiguration()
+        noExceptionThrown()
+        when:
+        connectorManager.createConnection(context)
+        then:
+        1 * context.getConnectorType() >> 'default'
+        1 * context.getCatalogName() >> 'a'
+        1 * context.getConfiguration() >> [:]
+        noExceptionThrown()
+        when:
+        connectorManager.createConnection(context)
+        then:
+        1 * context.getConnectorType() >> 'hive'
+        1 * context.getCatalogName() >> 'h'
+        1 * context.getConfiguration() >> [:]
+        noExceptionThrown()
+        when:
+        connectorManager.createConnection(context)
+        then:
+        1 * context.getConnectorType() >> 'default'
+        1 * context.getCatalogName() >> 'a'
+        1 * context.getConfiguration() >> [:]
+        thrown(IllegalStateException)
+        when:
+        connectorManager.createConnection(context)
+        then:
+        1 * context.getConnectorType() >> 'default'
+        1 * context.getCatalogName() >> 'a1'
+        1 * context.getConfiguration() >> [:]
+        noExceptionThrown()
+        when:
+        connectorManager.createConnection(context)
+        then:
+        1 * context.getConnectorType() >> 'default'
+        1 * context.getCatalogName() >> 'a'
+        1 * context.getConfiguration() >> ['metacat.schema.whitelist':'d1']
+        noExceptionThrown()
+        when:
+        connectorManager.createConnection(context)
+        then:
+        1 * context.getConnectorType() >> 'default'
+        1 * context.getCatalogName() >> 'a'
+        1 * context.getConfiguration() >> ['metacat.schema.whitelist':'d1']
+        thrown(IllegalStateException)
+        when:
+        connectorManager.createConnection(context)
+        then:
+        1 * context.getConnectorType() >> 'default'
+        1 * context.getCatalogName() >> 'a'
+        1 * context.getConfiguration() >> ['metacat.schema.whitelist':'d2,d3']
+        noExceptionThrown()
+        when:
+        connectorManager.createConnection(context)
+        then:
+        1 * context.getConnectorType() >> 'hive'
+        1 * context.getCatalogName() >> 'h'
+        1 * context.getConfiguration() >> ['metacat.schema.whitelist':'d1,d2']
+        noExceptionThrown()
+        when:
+        connectorManager.createConnection(context)
+        then:
+        1 * context.getConnectorType() >> 'hive'
+        1 * context.getCatalogName() >> 'h1'
+        1 * context.getConfiguration() >> [:]
+        noExceptionThrown()
+        expect:
+        connectorManager.getCatalogs().size() == 7
+        connectorManager.getTypeConverter('hive') == connectorTypeConverter
+        connectorManager.getInfoConverter('hive') == connectorInfoConverter
+        connectorManager.getDatabaseService(QualifiedName.fromString('h/d1')) == databaseService1
+        connectorManager.getTableService(QualifiedName.fromString('h/d1')) == tableService1
+        connectorManager.getPartitionService(QualifiedName.fromString('h/d1')) == partitionService1
+        connectorManager.getDatabaseServices().size() == 4
+        connectorManager.getTableServices().size() == 4
+        connectorManager.getPartitionServices().size() == 4
+    }
+}


### PR DESCRIPTION
Example: We can add multiple catalogs, referencing multiple datasources, addressed by the same catalog name.