### PR TITLE
Fixed issue where thrift methods returning partitions were returning partitions with partition values escaped.

### DIFF
--- a/metacat-thrift/src/main/java/com/netflix/metacat/thrift/CatalogThriftHiveMetastore.java
+++ b/metacat-thrift/src/main/java/com/netflix/metacat/thrift/CatalogThriftHiveMetastore.java
@@ -299,7 +299,8 @@ public class CatalogThriftHiveMetastore extends FacebookBase
         throws TException {
         log.debug("Ignoring {} since metacat save partitions will do an update if it already exists", ifNotExists);
         final TableDto tableDto = v1.getTable(catalogName, dbName, tblName, true, false, false);
-        if (tableDto.getPartition_keys() == null || tableDto.getPartition_keys().isEmpty()) {
+        final List<String> partitionKeys = tableDto.getPartition_keys();
+        if (partitionKeys == null || partitionKeys.isEmpty()) {
             throw new MetaException("Unable to add partition to unpartitioned table: " + tableDto.getName());
         }
 

--- a/metacat-thrift/src/main/java/com/netflix/metacat/thrift/HiveConvertersImpl.java
+++ b/metacat-thrift/src/main/java/com/netflix/metacat/thrift/HiveConvertersImpl.java
@@ -328,10 +328,15 @@ public class HiveConvertersImpl implements HiveConverters {
         } catch (MetaException e) {
             throw new IllegalArgumentException("Invalid partition name", e);
         }
-
-        if (tableDto != null && tableDto.getPartition_keys() != null) {
-            final List<String> partVals = Lists.newArrayList();
-            for (String key : tableDto.getPartition_keys()) {
+        // Get the partition keys.
+        List<String> partitionKeys = null;
+        if (tableDto != null) {
+            partitionKeys = tableDto.getPartition_keys();
+        }
+        // If table has not been provided, return the values without validating.
+        if (partitionKeys != null) {
+            final List<String> partVals = Lists.newArrayListWithCapacity(partitionKeys.size());
+            for (String key : partitionKeys) {
                 final String val = hm.get(key);
                 if (val == null) {
                     throw new IllegalArgumentException("Invalid partition name - missing " + key);

--- a/metacat-thrift/src/test/groovy/com/netflix/metacat/thrift/HiveConvertersSpec.groovy
+++ b/metacat-thrift/src/test/groovy/com/netflix/metacat/thrift/HiveConvertersSpec.groovy
@@ -292,7 +292,7 @@ class HiveConvertersSpec extends Specification {
         def partition = converter.metacatToHivePartition(dto, tableDto)
 
         then:
-        partition.values == ['CAPS', 'lower', '3']
+        partition.values == ['CAPS', 'lower']
         partition.tableName == tableName
         partition.dbName == databaseName
         partition.createTime == Instant.parse('2016-02-25T14:47:27').getMillis() / 1000
@@ -315,7 +315,7 @@ class HiveConvertersSpec extends Specification {
         where:
         databaseName = 'database'
         tableName = 'table'
-        partitionName = 'key1=CAPS/key2=lower/key3=3'
+        partitionName = 'field_0=CAPS/field_1=lower'
         owner = 'owner'
         createDate = Instant.parse('2016-02-25T14:47:27').toDate()
         location = 'location'
@@ -352,21 +352,21 @@ class HiveConvertersSpec extends Specification {
         def partition = converter.metacatToHivePartition(dto, tableDto)
 
         then:
-        partition.values == ['weird=true', '', 'monk']
+        partition.values == ['true', 'monk']
 
         where:
         dto = new PartitionDto(
-            name: QualifiedName.ofPartition('c', 'd', 't', 'this=weird=true/bob=/someone=monk')
+            name: QualifiedName.ofPartition('c', 'd', 't', 'this=weird=true/someone=monk')
         )
         tableDto = new TableDto()
     }
 
-    def 'test metacatToHivePartition throws an error on invalid partition name'() {
+    def 'test metacatToHivePartition throws no error on invalid partition name'() {
         when:
         converter.metacatToHivePartition(dto, tableDto)
 
         then:
-        thrown(IllegalStateException)
+        noExceptionThrown()
 
         where:
         dto = new PartitionDto(


### PR DESCRIPTION
Hive partition names are escaped where as the partition values contain the original value.