### PR TITLE
Setting timeouts for queries reading/writing hive partitions. 

### DIFF
--- a/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/configs/HiveConnectorFastServiceConfig.java
+++ b/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/configs/HiveConnectorFastServiceConfig.java
@@ -104,7 +104,7 @@ public class HiveConnectorFastServiceConfig {
     public DirectSqlGetPartition directSqlGetPartition(
         final ThreadServiceManager threadServiceManager,
         final ConnectorContext connectorContext,
-        @Qualifier("hiveJdbcTemplate") final JdbcTemplate hiveJdbcTemplate,
+        @Qualifier("hiveReadJdbcTemplate") final JdbcTemplate hiveJdbcTemplate,
         final HiveConnectorFastServiceMetric serviceMetric
     ) {
         return new DirectSqlGetPartition(
@@ -127,7 +127,7 @@ public class HiveConnectorFastServiceConfig {
     @Bean
     public DirectSqlSavePartition directSqlSavePartition(
         final ConnectorContext connectorContext,
-        @Qualifier("hiveJdbcTemplate") final JdbcTemplate hiveJdbcTemplate,
+        @Qualifier("hiveWriteJdbcTemplate") final JdbcTemplate hiveJdbcTemplate,
         final SequenceGeneration sequenceGeneration,
         final HiveConnectorFastServiceMetric serviceMetric
     ) {
@@ -147,7 +147,7 @@ public class HiveConnectorFastServiceConfig {
      */
     @Bean
     public SequenceGeneration sequenceGeneration(
-        @Qualifier("hiveJdbcTemplate") final JdbcTemplate hiveJdbcTemplate
+        @Qualifier("hiveWriteJdbcTemplate") final JdbcTemplate hiveJdbcTemplate
     ) {
         return new SequenceGeneration(hiveJdbcTemplate);
     }
@@ -164,7 +164,7 @@ public class HiveConnectorFastServiceConfig {
     @Bean
     public DirectSqlTable directSqlTable(
         final ConnectorContext connectorContext,
-        @Qualifier("hiveJdbcTemplate") final JdbcTemplate hiveJdbcTemplate,
+        @Qualifier("hiveWriteJdbcTemplate") final JdbcTemplate hiveJdbcTemplate,
         final HiveConnectorFastServiceMetric serviceMetric,
         final DirectSqlSavePartition directSqlSavePartition
     ) {

--- a/metacat-connector-hive/src/test/groovy/com/netflix/metacat/connector/hive/configs/HiveConnectorClientConfigSpec.groovy
+++ b/metacat-connector-hive/src/test/groovy/com/netflix/metacat/connector/hive/configs/HiveConnectorClientConfigSpec.groovy
@@ -34,17 +34,17 @@ class HiveConnectorClientConfigSpec extends Specification{
         when:
         def template = config.hiveReadJdbcTemplate(context, dataSource)
         then:
-        template.getQueryTimeout() == 60
-        1 * context.getConfiguration() >> ['javax.jdo.option.DatastoreTimeout':'invalid']
+        template.getQueryTimeout() == 120
+        1 * context.getConfiguration() >> ['javax.jdo.option.DatastoreReadTimeoutMillis':'invalid']
         when:
         template = config.hiveReadJdbcTemplate(context, dataSource)
         then:
         template.getQueryTimeout() == 10
-        1 * context.getConfiguration() >> ['javax.jdo.option.DatastoreTimeout':'10000']
+        1 * context.getConfiguration() >> ['javax.jdo.option.DatastoreReadTimeoutMillis':'10000']
         when:
         template = config.hiveReadJdbcTemplate(context, dataSource)
         then:
-        template.getQueryTimeout() == 60
+        template.getQueryTimeout() == 120
         1 * context.getConfiguration() >> [:]
     }
     def testGetDefaultConf(){
@@ -52,16 +52,16 @@ class HiveConnectorClientConfigSpec extends Specification{
         def conf = config.getDefaultConf(context)
         then:
         conf.get('javax.jdo.option.DatastoreTimeout') == '60000'
-        1 * context.getConfiguration() >> ['javax.jdo.option.DatastoreTimeout':'invalid']
+        2 * context.getConfiguration() >> ['javax.jdo.option.DatastoreTimeout':'invalid']
         when:
         conf = config.getDefaultConf(context)
         then:
         conf.get('javax.jdo.option.DatastoreTimeout') == '10000'
-        1 * context.getConfiguration() >> ['javax.jdo.option.DatastoreTimeout':'10000']
+        2 * context.getConfiguration() >> ['javax.jdo.option.DatastoreTimeout':'10000']
         when:
         conf = config.getDefaultConf(context)
         then:
         conf.get('javax.jdo.option.DatastoreTimeout') == '60000'
-        1 * context.getConfiguration() >> [:]
+        2 * context.getConfiguration() >> [:]
     }
 }


### PR DESCRIPTION
This change is needed to control long running queries.