### PR TITLE
Added cache support

### DIFF
--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/CacheProperties.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/CacheProperties.java
@@ -1,0 +1,30 @@
+/*
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
+package com.netflix.metacat.common.server.properties;
+
+import lombok.Data;
+
+/**
+ * Properties related to cache configuration.
+ *
+ * @author amajumdar
+ * @since 1.2.0
+ */
+@Data
+public class CacheProperties {
+    private boolean enabled;
+    private String name;
+}

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/Config.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/Config.java
@@ -341,4 +341,11 @@ public interface Config {
      * @return list of names
      */
     Set<QualifiedName> getNamesEnabledForDefinitionMetadataDelete();
+
+    /**
+     * Enable cache.
+     *
+     * @return true if cache is enabled
+     */
+    boolean isCacheEnabled();
 }

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/DefaultConfigImpl.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/DefaultConfigImpl.java
@@ -414,4 +414,9 @@ public class DefaultConfigImpl implements Config {
     public Set<QualifiedName> getNamesEnabledForDefinitionMetadataDelete() {
         return this.metacatProperties.getDefinition().getMetadata().getDelete().getQualifiedNamesEnabledForDelete();
     }
+
+    @Override
+    public boolean isCacheEnabled() {
+        return this.metacatProperties.getCache().isEnabled();
+    }
 }

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/MetacatProperties.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/MetacatProperties.java
@@ -59,4 +59,6 @@ public class MetacatProperties {
     private User user = new User();
     @NonNull
     private UserMetadata usermetadata = new UserMetadata();
+    @NonNull
+    private CacheProperties cache = new CacheProperties();
 }

--- a/metacat-common/src/main/java/com/netflix/metacat/common/dto/PartitionDto.java
+++ b/metacat-common/src/main/java/com/netflix/metacat/common/dto/PartitionDto.java
@@ -48,11 +48,11 @@ public class PartitionDto extends BaseDto implements HasDataMetadata, HasDefinit
     @ApiModelProperty(value = "audit information about the partition")
     private AuditDto audit;
     // Marked as transient because we serialize it manually, however as a JsonProperty because Jackson does serialize it
-    @ApiModelProperty(value = "metadata attached to this partition")
+    @ApiModelProperty(value = "metadata attached to the physical data")
     @JsonProperty
     private transient ObjectNode dataMetadata;
     // Marked as transient because we serialize it manually, however as a JsonProperty because Jackson does serialize it
-    @ApiModelProperty(value = "metadata attached to the physical data")
+    @ApiModelProperty(value = "metadata attached to this partition")
     @JsonProperty
     private transient ObjectNode definitionMetadata;
     @ApiModelProperty(value = "the name of this entity", required = true)

--- a/metacat-common/src/main/java/com/netflix/metacat/common/dto/PartitionDto.java
+++ b/metacat-common/src/main/java/com/netflix/metacat/common/dto/PartitionDto.java
@@ -48,11 +48,11 @@ public class PartitionDto extends BaseDto implements HasDataMetadata, HasDefinit
     @ApiModelProperty(value = "audit information about the partition")
     private AuditDto audit;
     // Marked as transient because we serialize it manually, however as a JsonProperty because Jackson does serialize it
-    @ApiModelProperty(value = "metadata attached to the physical data")
+    @ApiModelProperty(value = "Physical metadata: metadata about the physical data referred by the partition.")
     @JsonProperty
     private transient ObjectNode dataMetadata;
     // Marked as transient because we serialize it manually, however as a JsonProperty because Jackson does serialize it
-    @ApiModelProperty(value = "metadata attached to this partition")
+    @ApiModelProperty(value = "Logical metadata: metadata about the logical construct of the partition.")
     @JsonProperty
     private transient ObjectNode definitionMetadata;
     @ApiModelProperty(value = "the name of this entity", required = true)

--- a/metacat-connector-hive/src/test/groovy/com/netflix/metacat/connector/hive/converters/HiveTypeConverterSpec.groovy
+++ b/metacat-connector-hive/src/test/groovy/com/netflix/metacat/connector/hive/converters/HiveTypeConverterSpec.groovy
@@ -80,4 +80,17 @@ class HiveTypeConverterSpec extends Specification {
         ]
     }
 
+    @Unroll
+    def 'fail to convert "#typeString" to a presto type and back'(String typeString) {
+        when:
+        converter.toMetacatType(typeString)
+        then:
+        thrown(Exception)
+        where:
+        typeString << [
+            'list<string>',
+            'struct<s: string>'
+        ]
+    }
+
 }

--- a/metacat-functional-tests/metacat-test-cluster/docker-compose.yml
+++ b/metacat-functional-tests/metacat-test-cluster/docker-compose.yml
@@ -54,7 +54,8 @@ services:
                 -Dmetacat.definition.metadata.delete.enableForTable=false
                 -Dmetacat.definition.metadata.delete.enableDeleteForQualifiedNames=hive-metastore/hsmoke_ddb,hive-metastore/hsmoke_ddb1/test_create_table1,embedded-hive-metastore,embedded-fast-hive-metastore/fsmoke_db1,embedded-fast-hive-metastore/fsmoke_ddb1,embedded-fast-hive-metastore/shard,embedded-fast-hive-metastore/fsmoke_db4,s3-mysql-db,mysql-56-db
                 -Dmetacat.hive.metastore.batchSize=10
-                -Dmetacat.usermetadata.config.location=/etc/metacat/usermetadata.properties'
+                -Dmetacat.usermetadata.config.location=/etc/metacat/usermetadata.properties
+                -Dmetacat.cache.enabled=true'
         labels:
           - "com.netflix.metacat.oss.test"
           - "com.netflix.metacat.oss.test.war"

--- a/metacat-functional-tests/src/functionalTest/groovy/com/netflix/metacat/MetacatSmokeSpec.groovy
+++ b/metacat-functional-tests/src/functionalTest/groovy/com/netflix/metacat/MetacatSmokeSpec.groovy
@@ -824,7 +824,7 @@ class MetacatSmokeSpec extends Specification {
         then:
         thrown(MetacatNotFoundException)
         when:
-        api.getTable('invalid', 'invalid', 'invalid', false, false, false)
+        api.getTable('invalid', 'invalid', 'invalid', true, false, false)
         then:
         thrown(MetacatNotFoundException)
         when:
@@ -842,7 +842,7 @@ class MetacatSmokeSpec extends Specification {
         when:
         api.deleteTable('invalid', 'invalid', 'invalid')
         then:
-        thrown(MetacatNotFoundException)
+        noExceptionThrown()
         when:
         partitionApi.getPartitionCount('invalid', 'invalid', 'invalid')
         then:

--- a/metacat-main/src/main/java/com/netflix/metacat/main/api/v1/MetacatController.java
+++ b/metacat-main/src/main/java/com/netflix/metacat/main/api/v1/MetacatController.java
@@ -655,6 +655,7 @@ public class MetacatController implements MetacatV1 {
                         .includeDefinitionMetadata(includeDefinitionMetadata)
                         .includeDataMetadata(includeDataMetadata)
                         .disableOnReadMetadataIntercetor(false)
+                        .useCache(true)
                         .build()
                 );
                 return table.orElseThrow(() -> new TableNotFoundException(name));

--- a/metacat-main/src/main/java/com/netflix/metacat/main/configs/CacheConfig.java
+++ b/metacat-main/src/main/java/com/netflix/metacat/main/configs/CacheConfig.java
@@ -1,0 +1,32 @@
+/*
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
+package com.netflix.metacat.main.configs;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Spring configuration for cache.
+ *
+ * @author amajumdar
+ * @since 1.2.0
+ */
+@Configuration
+@ConditionalOnProperty(value = "metacat.cache.enabled", havingValue = "true")
+@EnableCaching
+public class CacheConfig {
+}

--- a/metacat-main/src/main/java/com/netflix/metacat/main/configs/ServicesConfig.java
+++ b/metacat-main/src/main/java/com/netflix/metacat/main/configs/ServicesConfig.java
@@ -40,6 +40,7 @@ import com.netflix.metacat.main.services.MetadataService;
 import com.netflix.metacat.main.services.PartitionService;
 import com.netflix.metacat.main.services.TableService;
 import com.netflix.metacat.main.services.impl.CatalogServiceImpl;
+import com.netflix.metacat.main.services.impl.ConnectorTableServiceProxy;
 import com.netflix.metacat.main.services.impl.DatabaseServiceImpl;
 import com.netflix.metacat.main.services.impl.MViewServiceImpl;
 import com.netflix.metacat.main.services.impl.PartitionServiceImpl;
@@ -140,36 +141,51 @@ public class ServicesConfig {
     /**
      * The table service bean.
      *
-     * @param connectorManager    connector manager
+     * @param connectorTableServiceProxy   connector table service proxy
      * @param databaseService     database service
      * @param tagService          tag service
      * @param userMetadataService user metadata service
      * @param eventBus            Internal event bus
-     * @param converterUtil       utility to convert to/from Dto to connector resources
      * @param registry             registry handle
      * @param config               configurations
      * @return The table service bean
      */
     @Bean
     public TableService tableService(
-        final ConnectorManager connectorManager,
+        final ConnectorTableServiceProxy connectorTableServiceProxy,
         final DatabaseService databaseService,
         final TagService tagService,
         final UserMetadataService userMetadataService,
         final MetacatEventBus eventBus,
-        final ConverterUtil converterUtil,
         final Registry registry,
         final Config config
     ) {
         return new TableServiceImpl(
-            connectorManager,
+            connectorTableServiceProxy,
             databaseService,
             tagService,
             userMetadataService,
             eventBus,
-            converterUtil,
             registry,
             config
+        );
+    }
+
+    /**
+     * The connector table service proxy bean.
+     *
+     * @param connectorManager    Connector manager to use
+     * @param converterUtil       Converter utilities
+     * @return The connector table service proxy bean
+     */
+    @Bean
+    public ConnectorTableServiceProxy connectorTableServiceProxy(
+        final ConnectorManager connectorManager,
+        final ConverterUtil converterUtil
+    ) {
+        return new ConnectorTableServiceProxy(
+            connectorManager,
+            converterUtil
         );
     }
 

--- a/metacat-main/src/main/java/com/netflix/metacat/main/services/GetTableServiceParameters.java
+++ b/metacat-main/src/main/java/com/netflix/metacat/main/services/GetTableServiceParameters.java
@@ -33,4 +33,5 @@ public class GetTableServiceParameters {
     private final boolean includeDefinitionMetadata;
     private final boolean includeDataMetadata;
     private final boolean disableOnReadMetadataIntercetor;
+    private final boolean useCache;
 }

--- a/metacat-main/src/main/java/com/netflix/metacat/main/services/impl/ConnectorTableServiceProxy.java
+++ b/metacat-main/src/main/java/com/netflix/metacat/main/services/impl/ConnectorTableServiceProxy.java
@@ -1,0 +1,229 @@
+/*
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
+
+package com.netflix.metacat.main.services.impl;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.netflix.metacat.common.MetacatRequestContext;
+import com.netflix.metacat.common.QualifiedName;
+import com.netflix.metacat.common.dto.TableDto;
+import com.netflix.metacat.common.server.connectors.ConnectorRequestContext;
+import com.netflix.metacat.common.server.connectors.ConnectorTableService;
+import com.netflix.metacat.common.server.converter.ConverterUtil;
+import com.netflix.metacat.common.server.util.MetacatContextManager;
+import com.netflix.metacat.main.manager.ConnectorManager;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheConfig;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Handles calls to the connector table service.
+ */
+@Slf4j
+@CacheConfig(cacheNames = "metacat")
+public class ConnectorTableServiceProxy {
+    private final ConnectorManager connectorManager;
+    private final ConverterUtil converterUtil;
+
+    /**
+     * Constructor.
+     *
+     * @param connectorManager    connector manager
+     * @param converterUtil       utility to convert to/from Dto to connector resources
+     */
+    public ConnectorTableServiceProxy(
+        final ConnectorManager connectorManager,
+        final ConverterUtil converterUtil
+    ) {
+        this.connectorManager = connectorManager;
+        this.converterUtil = converterUtil;
+    }
+
+    /**
+     * Calls the connector table service create method.
+     * @param name table name
+     * @param tableDto table object
+     */
+    public void create(final QualifiedName name, final TableDto tableDto) {
+        final MetacatRequestContext metacatRequestContext = MetacatContextManager.getContext();
+        final ConnectorTableService service = connectorManager.getTableService(name);
+        final ConnectorRequestContext connectorRequestContext = converterUtil.toConnectorContext(metacatRequestContext);
+        service.create(connectorRequestContext, converterUtil.fromTableDto(tableDto));
+    }
+
+    /**
+     * Calls the connector table service delete method.
+     * @param name table name
+     */
+    @CacheEvict(key = "'table.' + #name")
+    public void delete(final QualifiedName name) {
+        final MetacatRequestContext metacatRequestContext = MetacatContextManager.getContext();
+        final ConnectorTableService service = connectorManager.getTableService(name);
+
+        log.info("Drop table {}", name);
+        final ConnectorRequestContext connectorRequestContext = converterUtil.toConnectorContext(metacatRequestContext);
+        service.delete(connectorRequestContext, name);
+    }
+
+
+    /**
+     *
+     * Returns table if <code>useCache</code> is true and object exists in the cache. If <code>useCache</code> is false
+     * or object does not exists in the cache, it is retrieved from the store.
+     * @param name table name
+     * @param useCache true, if table can be retrieved from cache
+     * @return table dto
+     */
+    @Cacheable(key = "'table.' + #name", condition = "#useCache")
+    public TableDto get(final QualifiedName name, final boolean useCache) {
+        final MetacatRequestContext metacatRequestContext = MetacatContextManager.getContext();
+        final ConnectorRequestContext connectorRequestContext = converterUtil.toConnectorContext(metacatRequestContext);
+        final ConnectorTableService service = connectorManager.getTableService(name);
+        return converterUtil.toTableDto(service.get(connectorRequestContext, name));
+    }
+
+    /**
+     * Calls the connector table service rename method.
+     * @param oldName old table name
+     * @param newName new table name
+     * @param isMView true, if the object is a view
+     */
+    @CacheEvict(key = "'table.' + #oldName")
+    public void rename(
+        final QualifiedName oldName,
+        final QualifiedName newName,
+        final boolean isMView
+    ) {
+        final MetacatRequestContext metacatRequestContext = MetacatContextManager.getContext();
+        final ConnectorTableService service = connectorManager.getTableService(oldName);
+
+        try {
+            log.info("Renaming {} {} to {}", isMView ? "view" : "table", oldName, newName);
+            final ConnectorRequestContext connectorRequestContext
+                = converterUtil.toConnectorContext(metacatRequestContext);
+            service.rename(connectorRequestContext, oldName, newName);
+        } catch (UnsupportedOperationException ignored) {
+        }
+    }
+
+    /**
+     * Calls the connector table service update method.
+     * @param name table name
+     * @param tableDto table object
+     */
+    @CacheEvict(key = "'table.' + #name")
+    public void update(final QualifiedName name, final TableDto tableDto) {
+        final MetacatRequestContext metacatRequestContext = MetacatContextManager.getContext();
+        final ConnectorTableService service = connectorManager.getTableService(name);
+        //Ignore if the operation is not supported, so that we can at least go ahead and save the user metadata
+        if (isTableInfoProvided(tableDto)) {
+            try {
+                log.info("Updating table {}", name);
+                final ConnectorRequestContext connectorRequestContext
+                    = converterUtil.toConnectorContext(metacatRequestContext);
+                service.update(connectorRequestContext, converterUtil.fromTableDto(tableDto));
+            } catch (UnsupportedOperationException ignored) {
+            }
+        }
+    }
+
+    private boolean isTableInfoProvided(final TableDto tableDto) {
+        boolean result = false;
+        if ((tableDto.getFields() != null && !tableDto.getFields().isEmpty())
+            || tableDto.getSerde() != null
+            || (tableDto.getMetadata() != null && !tableDto.getMetadata().isEmpty())
+            || tableDto.getAudit() != null) {
+            result = true;
+        }
+        return result;
+    }
+
+    /**
+     * Calls the connector table service getTableNames method.
+     * @param uri location
+     * @param prefixSearch if false, the method looks for exact match for the uri
+     * @return list of table names
+     */
+    public List<QualifiedName> getQualifiedNames(final String uri, final boolean prefixSearch) {
+        final List<QualifiedName> result = Lists.newArrayList();
+
+        connectorManager.getTableServices().forEach(service -> {
+            final MetacatRequestContext metacatRequestContext = MetacatContextManager.getContext();
+            final ConnectorRequestContext connectorRequestContext
+                = converterUtil.toConnectorContext(metacatRequestContext);
+            try {
+                final Map<String, List<QualifiedName>> names =
+                    service.getTableNames(connectorRequestContext, Lists.newArrayList(uri), prefixSearch);
+                final List<QualifiedName> qualifiedNames = names.values().stream().flatMap(Collection::stream)
+                    .collect(Collectors.toList());
+                result.addAll(qualifiedNames);
+            } catch (final UnsupportedOperationException uoe) {
+                log.debug("Table service doesn't support getting table names by URI. Skipping");
+            }
+        });
+        return result;
+    }
+
+    /**
+     * Calls the connector table service getTableNames method.
+     * @param uris list of locations
+     * @param prefixSearch if false, the method looks for exact match for the uri
+     * @return list of table names
+     */
+    public Map<String, List<QualifiedName>> getQualifiedNames(final List<String> uris, final boolean prefixSearch) {
+        final Map<String, List<QualifiedName>> result = Maps.newHashMap();
+
+        connectorManager.getTableServices().forEach(service -> {
+            final MetacatRequestContext metacatRequestContext = MetacatContextManager.getContext();
+            final ConnectorRequestContext connectorRequestContext
+                = converterUtil.toConnectorContext(metacatRequestContext);
+            try {
+                final Map<String, List<QualifiedName>> names =
+                    service.getTableNames(connectorRequestContext, uris, prefixSearch);
+                names.forEach((uri, qNames) -> {
+                    final List<QualifiedName> existingNames = result.get(uri);
+                    if (existingNames == null) {
+                        result.put(uri, qNames);
+                    } else {
+                        existingNames.addAll(qNames);
+                    }
+                });
+            } catch (final UnsupportedOperationException uoe) {
+                log.debug("Table service doesn't support getting table names by URI. Skipping");
+            }
+        });
+        return result;
+    }
+
+    /**
+     * Calls the connector table service exists method.
+     * @param name table name
+     * @return true, if the object exists.
+     */
+    public boolean exists(final QualifiedName name) {
+        final MetacatRequestContext metacatRequestContext = MetacatContextManager.getContext();
+        final ConnectorTableService service = connectorManager.getTableService(name);
+        final ConnectorRequestContext connectorRequestContext = converterUtil.toConnectorContext(metacatRequestContext);
+        return service.exists(connectorRequestContext, name);
+    }
+}

--- a/metacat-main/src/main/java/com/netflix/metacat/main/services/impl/ConnectorTableServiceProxy.java
+++ b/metacat-main/src/main/java/com/netflix/metacat/main/services/impl/ConnectorTableServiceProxy.java
@@ -135,27 +135,13 @@ public class ConnectorTableServiceProxy {
     public void update(final QualifiedName name, final TableDto tableDto) {
         final MetacatRequestContext metacatRequestContext = MetacatContextManager.getContext();
         final ConnectorTableService service = connectorManager.getTableService(name);
-        //Ignore if the operation is not supported, so that we can at least go ahead and save the user metadata
-        if (isTableInfoProvided(tableDto)) {
-            try {
-                log.info("Updating table {}", name);
-                final ConnectorRequestContext connectorRequestContext
-                    = converterUtil.toConnectorContext(metacatRequestContext);
-                service.update(connectorRequestContext, converterUtil.fromTableDto(tableDto));
-            } catch (UnsupportedOperationException ignored) {
-            }
+        try {
+            log.info("Updating table {}", name);
+            final ConnectorRequestContext connectorRequestContext
+                = converterUtil.toConnectorContext(metacatRequestContext);
+            service.update(connectorRequestContext, converterUtil.fromTableDto(tableDto));
+        } catch (UnsupportedOperationException ignored) {
         }
-    }
-
-    private boolean isTableInfoProvided(final TableDto tableDto) {
-        boolean result = false;
-        if ((tableDto.getFields() != null && !tableDto.getFields().isEmpty())
-            || tableDto.getSerde() != null
-            || (tableDto.getMetadata() != null && !tableDto.getMetadata().isEmpty())
-            || tableDto.getAudit() != null) {
-            result = true;
-        }
-        return result;
     }
 
     /**

--- a/metacat-main/src/main/java/com/netflix/metacat/main/services/impl/TableServiceImpl.java
+++ b/metacat-main/src/main/java/com/netflix/metacat/main/services/impl/TableServiceImpl.java
@@ -18,7 +18,6 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.netflix.metacat.common.MetacatRequestContext;
 import com.netflix.metacat.common.QualifiedName;
@@ -26,11 +25,8 @@ import com.netflix.metacat.common.dto.DatabaseDto;
 import com.netflix.metacat.common.dto.StorageDto;
 import com.netflix.metacat.common.dto.TableDto;
 import com.netflix.metacat.common.exception.MetacatNotSupportedException;
-import com.netflix.metacat.common.server.connectors.ConnectorRequestContext;
-import com.netflix.metacat.common.server.connectors.ConnectorTableService;
 import com.netflix.metacat.common.server.connectors.exception.NotFoundException;
 import com.netflix.metacat.common.server.connectors.exception.TableNotFoundException;
-import com.netflix.metacat.common.server.converter.ConverterUtil;
 import com.netflix.metacat.common.server.events.MetacatCreateTablePostEvent;
 import com.netflix.metacat.common.server.events.MetacatCreateTablePreEvent;
 import com.netflix.metacat.common.server.events.MetacatDeleteTablePostEvent;
@@ -46,20 +42,17 @@ import com.netflix.metacat.common.server.usermetadata.GetMetadataInterceptorPara
 import com.netflix.metacat.common.server.usermetadata.TagService;
 import com.netflix.metacat.common.server.usermetadata.UserMetadataService;
 import com.netflix.metacat.common.server.util.MetacatContextManager;
-import com.netflix.metacat.main.manager.ConnectorManager;
 import com.netflix.metacat.main.services.DatabaseService;
 import com.netflix.metacat.main.services.GetTableServiceParameters;
 import com.netflix.metacat.main.services.TableService;
 import com.netflix.spectator.api.Registry;
 import lombok.extern.slf4j.Slf4j;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 /**
  * Table service implementation.
@@ -67,43 +60,39 @@ import java.util.stream.Collectors;
 @Slf4j
 public class TableServiceImpl implements TableService {
     private static final String NAME_TAGS = "tags";
-    private final ConnectorManager connectorManager;
     private final DatabaseService databaseService;
     private final TagService tagService;
     private final UserMetadataService userMetadataService;
     private final MetacatEventBus eventBus;
-    private final ConverterUtil converterUtil;
     private final Registry registry;
     private final Config config;
+    private final ConnectorTableServiceProxy connectorTableServiceProxy;
 
     /**
      * Constructor.
      *
-     * @param connectorManager    connector manager
+     * @param connectorTableServiceProxy connector table service proxy
      * @param databaseService     database service
      * @param tagService          tag service
      * @param userMetadataService user metadata service
      * @param eventBus            Internal event bus
-     * @param converterUtil       utility to convert to/from Dto to connector resources
      * @param registry            registry handle
      * @param config              configurations
      */
     public TableServiceImpl(
-        final ConnectorManager connectorManager,
+        final ConnectorTableServiceProxy connectorTableServiceProxy,
         final DatabaseService databaseService,
         final TagService tagService,
         final UserMetadataService userMetadataService,
         final MetacatEventBus eventBus,
-        final ConverterUtil converterUtil,
         final Registry registry,
         final Config config
     ) {
-        this.connectorManager = connectorManager;
+        this.connectorTableServiceProxy = connectorTableServiceProxy;
         this.databaseService = databaseService;
         this.tagService = tagService;
         this.userMetadataService = userMetadataService;
         this.eventBus = eventBus;
-        this.converterUtil = converterUtil;
         this.registry = registry;
         this.config = config;
     }
@@ -121,9 +110,7 @@ public class TableServiceImpl implements TableService {
         setOwnerIfNull(tableDto, metacatRequestContext.getUserName());
         log.info("Creating table {}", name);
         eventBus.post(new MetacatCreateTablePreEvent(name, metacatRequestContext, this, tableDto));
-        final ConnectorTableService service = connectorManager.getTableService(name);
-        final ConnectorRequestContext connectorRequestContext = converterUtil.toConnectorContext(metacatRequestContext);
-        service.create(connectorRequestContext, converterUtil.fromTableDto(tableDto));
+        connectorTableServiceProxy.create(name, tableDto);
 
         if (tableDto.getDataMetadata() != null || tableDto.getDefinitionMetadata() != null) {
             log.info("Saving user metadata for table {}", name);
@@ -180,7 +167,6 @@ public class TableServiceImpl implements TableService {
         final MetacatRequestContext metacatRequestContext = MetacatContextManager.getContext();
         eventBus.post(new MetacatDeleteTablePreEvent(name, metacatRequestContext, this));
         validate(name);
-        final ConnectorTableService service = connectorManager.getTableService(name);
         final Optional<TableDto> oTable = get(name,
             GetTableServiceParameters.builder()
                 .includeInfo(true)
@@ -189,10 +175,7 @@ public class TableServiceImpl implements TableService {
                 .includeDataMetadata(true)
                 .build());
         if (oTable.isPresent()) {
-            log.info("Drop table {}", name);
-            final ConnectorRequestContext connectorRequestContext
-                = converterUtil.toConnectorContext(metacatRequestContext);
-            service.delete(connectorRequestContext, name);
+            connectorTableServiceProxy.delete(name);
         }
 
         final TableDto tableDto = oTable.orElseGet(() -> {
@@ -252,17 +235,17 @@ public class TableServiceImpl implements TableService {
     @Override
     public Optional<TableDto> get(final QualifiedName name, final GetTableServiceParameters getTableServiceParameters) {
         validate(name);
-        final MetacatRequestContext metacatRequestContext = MetacatContextManager.getContext();
-        final ConnectorRequestContext connectorRequestContext = converterUtil.toConnectorContext(metacatRequestContext);
-        final ConnectorTableService service = connectorManager.getTableService(name);
-        final TableDto tableInternal;
+        TableDto tableInternal = null;
         final TableDto table;
-        try {
-            tableInternal = converterUtil.toTableDto(service.get(connectorRequestContext, name));
-        } catch (NotFoundException ignored) {
-            return Optional.empty();
-        }
-        if (getTableServiceParameters.isIncludeInfo()) {
+        if (getTableServiceParameters.isIncludeInfo()
+            || (getTableServiceParameters.isIncludeDefinitionMetadata()
+            && !getTableServiceParameters.isDisableOnReadMetadataIntercetor())) {
+            try {
+                tableInternal = connectorTableServiceProxy
+                    .get(name, getTableServiceParameters.isUseCache() && config.isCacheEnabled());
+            } catch (NotFoundException ignored) {
+                return Optional.empty();
+            }
             table = tableInternal;
         } else {
             table = new TableDto();
@@ -280,9 +263,10 @@ public class TableServiceImpl implements TableService {
 
         if (getTableServiceParameters.isIncludeDataMetadata()) {
             TableDto dto = table;
-            if (!getTableServiceParameters.isIncludeInfo()) {
+            if (tableInternal == null && !getTableServiceParameters.isIncludeInfo()) {
                 try {
-                    dto = converterUtil.toTableDto(service.get(connectorRequestContext, name));
+                    dto = connectorTableServiceProxy
+                        .get(name, getTableServiceParameters.isUseCache() && config.isCacheEnabled());
                 } catch (NotFoundException ignored) {
                 }
             }
@@ -306,7 +290,6 @@ public class TableServiceImpl implements TableService {
     ) {
         validate(oldName);
         final MetacatRequestContext metacatRequestContext = MetacatContextManager.getContext();
-        final ConnectorTableService service = connectorManager.getTableService(oldName);
 
         final TableDto oldTable = get(oldName, GetTableServiceParameters.builder()
             .includeInfo(true)
@@ -317,13 +300,7 @@ public class TableServiceImpl implements TableService {
         if (oldTable != null) {
             //Ignore if the operation is not supported, so that we can at least go ahead and save the user metadata
             eventBus.post(new MetacatRenameTablePreEvent(oldName, metacatRequestContext, this, newName));
-            try {
-                log.info("Renaming {} {} to {}", isMView ? "view" : "table", oldName, newName);
-                final ConnectorRequestContext connectorRequestContext
-                    = converterUtil.toConnectorContext(metacatRequestContext);
-                service.rename(connectorRequestContext, oldName, newName);
-            } catch (UnsupportedOperationException ignored) {
-            }
+            connectorTableServiceProxy.rename(oldName, newName, isMView);
             userMetadataService.renameDefinitionMetadataKey(oldName, newName);
             tagService.renameTableTags(oldName, newName.getTableName());
 
@@ -354,7 +331,6 @@ public class TableServiceImpl implements TableService {
     public TableDto updateAndReturn(final QualifiedName name, final TableDto tableDto) {
         validate(name);
         final MetacatRequestContext metacatRequestContext = MetacatContextManager.getContext();
-        final ConnectorTableService service = connectorManager.getTableService(name);
         final TableDto oldTable = get(name, GetTableServiceParameters.builder()
             .disableOnReadMetadataIntercetor(false)
             .includeInfo(true)
@@ -362,16 +338,7 @@ public class TableServiceImpl implements TableService {
             .includeDefinitionMetadata(true)
             .build()).orElseThrow(() -> new TableNotFoundException(name));
         eventBus.post(new MetacatUpdateTablePreEvent(name, metacatRequestContext, this, oldTable, tableDto));
-        //Ignore if the operation is not supported, so that we can at least go ahead and save the user metadata
-        if (isTableInfoProvided(tableDto)) {
-            try {
-                log.info("Updating table {}", name);
-                final ConnectorRequestContext connectorRequestContext
-                    = converterUtil.toConnectorContext(metacatRequestContext);
-                service.update(connectorRequestContext, converterUtil.fromTableDto(tableDto));
-            } catch (UnsupportedOperationException ignored) {
-            }
-        }
+        connectorTableServiceProxy.update(name, tableDto);
 
         // Merge in metadata if the user sent any
         if (tableDto.getDataMetadata() != null || tableDto.getDefinitionMetadata() != null) {
@@ -392,17 +359,6 @@ public class TableServiceImpl implements TableService {
                 .build()).orElseThrow(() -> new IllegalStateException("should exist"));
         eventBus.post(new MetacatUpdateTablePostEvent(name, metacatRequestContext, this, oldTable, updatedDto));
         return updatedDto;
-    }
-
-    private boolean isTableInfoProvided(final TableDto tableDto) {
-        boolean result = false;
-        if ((tableDto.getFields() != null && !tableDto.getFields().isEmpty())
-            || tableDto.getSerde() != null
-            || (tableDto.getMetadata() != null && !tableDto.getMetadata().isEmpty())
-            || tableDto.getAudit() != null) {
-            result = true;
-        }
-        return result;
     }
 
     /**
@@ -521,23 +477,7 @@ public class TableServiceImpl implements TableService {
      */
     @Override
     public List<QualifiedName> getQualifiedNames(final String uri, final boolean prefixSearch) {
-        final List<QualifiedName> result = Lists.newArrayList();
-
-        connectorManager.getTableServices().forEach(service -> {
-            final MetacatRequestContext metacatRequestContext = MetacatContextManager.getContext();
-            final ConnectorRequestContext connectorRequestContext
-                = converterUtil.toConnectorContext(metacatRequestContext);
-            try {
-                final Map<String, List<QualifiedName>> names =
-                    service.getTableNames(connectorRequestContext, Lists.newArrayList(uri), prefixSearch);
-                final List<QualifiedName> qualifiedNames = names.values().stream().flatMap(Collection::stream)
-                    .collect(Collectors.toList());
-                result.addAll(qualifiedNames);
-            } catch (final UnsupportedOperationException uoe) {
-                log.debug("Table service doesn't support getting table names by URI. Skipping");
-            }
-        });
-        return result;
+        return connectorTableServiceProxy.getQualifiedNames(uri, prefixSearch);
     }
 
     /**
@@ -545,28 +485,7 @@ public class TableServiceImpl implements TableService {
      */
     @Override
     public Map<String, List<QualifiedName>> getQualifiedNames(final List<String> uris, final boolean prefixSearch) {
-        final Map<String, List<QualifiedName>> result = Maps.newHashMap();
-
-        connectorManager.getTableServices().forEach(service -> {
-            final MetacatRequestContext metacatRequestContext = MetacatContextManager.getContext();
-            final ConnectorRequestContext connectorRequestContext
-                = converterUtil.toConnectorContext(metacatRequestContext);
-            try {
-                final Map<String, List<QualifiedName>> names =
-                    service.getTableNames(connectorRequestContext, uris, prefixSearch);
-                names.forEach((uri, qNames) -> {
-                    final List<QualifiedName> existingNames = result.get(uri);
-                    if (existingNames == null) {
-                        result.put(uri, qNames);
-                    } else {
-                        existingNames.addAll(qNames);
-                    }
-                });
-            } catch (final UnsupportedOperationException uoe) {
-                log.debug("Table service doesn't support getting table names by URI. Skipping");
-            }
-        });
-        return result;
+        return connectorTableServiceProxy.getQualifiedNames(uris, prefixSearch);
     }
 
     /**
@@ -574,10 +493,7 @@ public class TableServiceImpl implements TableService {
      */
     @Override
     public boolean exists(final QualifiedName name) {
-        final MetacatRequestContext metacatRequestContext = MetacatContextManager.getContext();
-        final ConnectorTableService service = connectorManager.getTableService(name);
-        final ConnectorRequestContext connectorRequestContext = converterUtil.toConnectorContext(metacatRequestContext);
-        return service.exists(connectorRequestContext, name);
+        return connectorTableServiceProxy.exists(name);
     }
 
     private void validate(final QualifiedName name) {

--- a/metacat-main/src/test/groovy/com/netflix/metacat/main/services/impl/ConnectorTableServiceProxySpec.groovy
+++ b/metacat-main/src/test/groovy/com/netflix/metacat/main/services/impl/ConnectorTableServiceProxySpec.groovy
@@ -1,0 +1,125 @@
+/*
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
+
+package com.netflix.metacat.main.services.impl
+
+import com.netflix.metacat.common.server.connectors.ConnectorRequestContext
+import com.netflix.metacat.common.server.connectors.ConnectorTableService
+import com.netflix.metacat.common.server.connectors.exception.ConnectorException
+import com.netflix.metacat.common.server.converter.ConverterUtil
+import com.netflix.metacat.main.manager.ConnectorManager
+import com.netflix.metacat.testdata.provider.DataDtoProvider
+import spock.lang.Specification
+
+/**
+ * Tests for the ConnectorTableServiceProxy.
+ *
+ * @author amajumdar
+ * @since 1.2.0
+ */
+class ConnectorTableServiceProxySpec extends Specification {
+    def connectorManager = Mock(ConnectorManager)
+    def connectorTableService = Mock(ConnectorTableService)
+    def converterUtil = Mock(ConverterUtil)
+    def tableDto = DataDtoProvider.getTable('a', 'b', 'c', "amajumdar", "s3:/a/b")
+    def name = tableDto.name
+    ConnectorTableServiceProxy service
+
+    def setup() {
+        connectorManager.getTableService(_) >> connectorTableService
+        converterUtil.toTableDto(_) >> tableDto
+        converterUtil.toConnectorContext(_) >> Mock(ConnectorRequestContext)
+        service = new ConnectorTableServiceProxy(connectorManager, converterUtil)
+    }
+
+    def testCreate() {
+        when:
+        service.create(name, tableDto)
+        then:
+        noExceptionThrown()
+        1 * connectorTableService.create(_,_)
+        when:
+        service.create(name, tableDto)
+        then:
+        thrown(ConnectorException)
+        1 * connectorTableService.create(_,_) >> { throw new ConnectorException("Exception") }
+    }
+
+    def testDelete() {
+        when:
+        service.delete(name)
+        then:
+        noExceptionThrown()
+        1 * connectorTableService.delete(_,_)
+        when:
+        service.delete(name)
+        then:
+        thrown(ConnectorException)
+        1 * connectorTableService.delete(_,_) >> { throw new ConnectorException("Exception") }
+    }
+
+    def testGet() {
+        when:
+        service.get(name, false)
+        then:
+        noExceptionThrown()
+        1 * connectorTableService.get(_,_)
+        when:
+        service.get(name, false)
+        then:
+        thrown(ConnectorException)
+        1 * connectorTableService.get(_,_) >> { throw new ConnectorException("Exception") }
+    }
+
+    def testRename() {
+        when:
+        service.rename(name, name, false)
+        then:
+        noExceptionThrown()
+        1 * connectorTableService.rename(_,_,_)
+        when:
+        service.rename(name, name, false)
+        then:
+        thrown(ConnectorException)
+        1 * connectorTableService.rename(_,_,_) >> { throw new ConnectorException("Exception") }
+    }
+
+    def testUpdate() {
+        when:
+        service.update(name, tableDto)
+        then:
+        noExceptionThrown()
+        1 * connectorTableService.update(_,_)
+        when:
+        service.update(name, tableDto)
+        then:
+        thrown(ConnectorException)
+        1 * connectorTableService.update(_,_) >> { throw new ConnectorException("Exception") }
+    }
+
+    def testExists() {
+        when:
+        service.exists(name)
+        then:
+        noExceptionThrown()
+        1 * connectorTableService.exists(_,_)
+        when:
+        service.exists(name)
+        then:
+        thrown(ConnectorException)
+        1 * connectorTableService.exists(_,_) >> { throw new ConnectorException("Exception") }
+    }
+}

--- a/metacat-main/src/test/groovy/com/netflix/metacat/main/services/impl/TableServiceImplSpec.groovy
+++ b/metacat-main/src/test/groovy/com/netflix/metacat/main/services/impl/TableServiceImplSpec.groovy
@@ -52,6 +52,7 @@ class TableServiceImplSpec extends Specification {
     def config = Mock(Config)
     def tableDto = DataDtoProvider.getTable('a', 'b', 'c', "amajumdar", "s3:/a/b")
     def name = tableDto.name
+    def connectorTableServiceProxy
     TableService service
     def setup() {
         connectorManager.getTableService(_) >> connectorTableService
@@ -60,8 +61,9 @@ class TableServiceImplSpec extends Specification {
         usermetadataService.getDefinitionMetadata(_) >> Optional.empty()
         usermetadataService.getDataMetadata(_) >> Optional.empty()
         usermetadataService.getDefinitionMetadataWithInterceptor(_,_) >> Optional.empty()
-        service = new TableServiceImpl(connectorManager, databaseService, tagService,
-            usermetadataService, eventBus, converterUtil, registry, config)
+        connectorTableServiceProxy = new ConnectorTableServiceProxy(connectorManager, converterUtil)
+        service = new TableServiceImpl(connectorTableServiceProxy, databaseService, tagService,
+            usermetadataService, eventBus, registry, config)
     }
 
     def testTableGet() {


### PR DESCRIPTION
Added cache support for TableInfo. By default, caching is disabled. Configuration property 'metacat.cache.enabled' setting to true will enable it. If no cache manager is set, the default map is used.