### PR TITLE
Fixed hive integration issues.

### DIFF
--- a/metacat-common-server/src/test/groovy/com/netflix/metacat/common/server/partition/util/FilterPartitionSpec.groovy
+++ b/metacat-common-server/src/test/groovy/com/netflix/metacat/common/server/partition/util/FilterPartitionSpec.groovy
@@ -98,5 +98,9 @@ class FilterPartitionSpec extends Specification{
         "a=1"                   | "1a=1"
         "dateint=1"             | "('12' <- 2)"
         "dateint=1"             | "(12 < 2))"
+        "dateint=1"             | "((dateint)=1)"
+        "dateint=1"             | "(dateint=(1))"
+        "dateint=1"             | "dateint is null"
+        "dateint=1"             | "dateint is not null"
     }
 }

--- a/metacat-functional-tests/src/functionalTest/groovy/com/netflix/metacat/MetacatSmokeSpec.groovy
+++ b/metacat-functional-tests/src/functionalTest/groovy/com/netflix/metacat/MetacatSmokeSpec.groovy
@@ -523,6 +523,37 @@ class MetacatSmokeSpec extends Specification {
     }
 
     @Unroll
+    def "Test drop and rename table"() {
+        given:
+        def tableName = 'test_create_table_rename'
+        def tableName1 = 'test_create_table_rename1'
+        createTable(catalogName, databaseName, tableName, 'TRUE')
+        createTable(catalogName, databaseName, tableName1, 'TRUE')
+        api.deleteTable(catalogName, databaseName, tableName)
+        when:
+        api.renameTable(catalogName, databaseName, tableName1, tableName)
+        then:
+        noExceptionThrown()
+        when:
+        api.renameTable(catalogName, databaseName, tableName, tableName1)
+        then:
+        noExceptionThrown()
+        when:
+        api.renameTable(catalogName, databaseName, tableName1, tableName)
+        then:
+        noExceptionThrown()
+        def table = api.getTable(catalogName, databaseName, tableName, true, true, false)
+        table.getMetadata() != null && table.getMetadata().get('EXTERNAL').equalsIgnoreCase('TRUE')
+        table.getDefinitionMetadata() != null
+        cleanup:
+        api.deleteTable(catalogName, databaseName, tableName1)
+        where:
+        catalogName                    | databaseName
+        'embedded-fast-hive-metastore' | 'hsmoke_db3'
+        'embedded-fast-hive-metastore' | 'fsmoke_ddb1'
+    }
+
+    @Unroll
     def "Test create view for #catalogName/#databaseName/#tableName/#viewName"() {
         expect:
         try {

--- a/metacat-functional-tests/src/functionalTest/groovy/com/netflix/metacat/MetacatSmokeThriftSpec.groovy
+++ b/metacat-functional-tests/src/functionalTest/groovy/com/netflix/metacat/MetacatSmokeThriftSpec.groovy
@@ -41,6 +41,7 @@ import org.apache.hadoop.hive.ql.session.SessionState
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory
 import org.apache.log4j.Level
 import org.apache.log4j.Logger
+import org.apache.thrift.TApplicationException
 import org.slf4j.LoggerFactory
 import spock.lang.Ignore
 import spock.lang.Shared
@@ -381,12 +382,19 @@ class MetacatSmokeThriftSpec extends Specification {
         client.getPartitionsByExpr(hiveTable, totalExprInvalid, client.getConf(), result3)
         def result4 = []
         client.getPartitionsByExpr(hiveTable, oneExprAndTotalExpr, client.getConf(), result4)
+        def result5 = []
+        def oneIsNullExpr = new ExprNodeGenericFuncDesc(TypeInfoFactory.booleanTypeInfo,
+            FunctionRegistry.getFunctionInfo('isnull').getGenericUDF(), Lists.newArrayList(oneColExpr))
+        try {
+            client.getPartitionsByExpr(hiveTable, oneIsNullExpr, client.getConf(), result4)
+        } catch (TApplicationException ignored){}
         then:
         result.size() == 10
         result1.size() == 1
         result2.size() == 0
         result3.size() == 0
         result4.size() == 1
+        result5.size() == 0
         cleanup:
         def partitionNames = client.getPartitionNames(databaseName, tableName, (short) -1)
         partitionNames.each {

--- a/metacat-metadata-mysql/src/main/java/com/netflix/metacat/metadata/mysql/MySqlTagService.java
+++ b/metacat-metadata-mysql/src/main/java/com/netflix/metacat/metadata/mysql/MySqlTagService.java
@@ -217,6 +217,9 @@ public class MySqlTagService implements TagService {
         try {
             final QualifiedName newName = QualifiedName.ofTable(name.getCatalogName(), name.getDatabaseName(),
                 newTableName);
+            jdbcTemplate.update(SQL_UPDATE_TAG_ITEM,
+                new String[]{MysqlUserMetadataService.DELETE_MARKER + newName.toString(), newName.toString()},
+                new int[]{Types.VARCHAR, Types.VARCHAR});
             jdbcTemplate.update(SQL_UPDATE_TAG_ITEM, new String[]{newName.toString(), name.toString()},
                 new int[]{Types.VARCHAR, Types.VARCHAR});
         } catch (Exception e) {

--- a/metacat-metadata-mysql/src/main/java/com/netflix/metacat/metadata/mysql/MysqlUserMetadataService.java
+++ b/metacat-metadata-mysql/src/main/java/com/netflix/metacat/metadata/mysql/MysqlUserMetadataService.java
@@ -64,6 +64,11 @@ import java.util.stream.Collectors;
 @SuppressFBWarnings
 @Transactional("metadataTxManager")
 public class MysqlUserMetadataService extends BaseUserMetadataService {
+    /**
+     *  Marker for the items that are marked deleted.
+     *  TODO: Need to better handle soft delete.
+     */
+    public static final String DELETE_MARKER = "_";
     private final MetacatJson metacatJson;
     private final Config config;
     private JdbcTemplate jdbcTemplate;
@@ -589,6 +594,7 @@ public class MysqlUserMetadataService extends BaseUserMetadataService {
     public int renameDefinitionMetadataKey(
         @Nonnull final QualifiedName oldName,
         @Nonnull final QualifiedName newName) {
+        executeUpdateForKey(SQL.RENAME_DEFINITION_METADATA, DELETE_MARKER + newName.toString(), newName.toString());
         return executeUpdateForKey(SQL.RENAME_DEFINITION_METADATA, newName.toString(), oldName.toString());
     }
 


### PR DESCRIPTION
1. Throw TApplicationException when partition filtering fails. During partition pruning, hive ignores this error and continues to query the data without applying predicate pushdown to metastore.
2. Fixed issue where renaming a table to a name that already existed fails when updating the user metadata since in Metacat(based on app configuration) we do not drop the metadata.