### PR TITLE
Fixed issue where the thrift API to rename an iceberg table was failing.

### DIFF
--- a/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/sql/HiveConnectorFastTableService.java
+++ b/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/sql/HiveConnectorFastTableService.java
@@ -129,20 +129,25 @@ public class HiveConnectorFastTableService extends HiveConnectorTableService {
             ? existingMetadata.get(DirectSqlTable.PARAM_METADATA_LOCATION) : null;
         final String previousMetadataLocation = newMetadata != null
             ? newMetadata.get(DirectSqlTable.PARAM_PREVIOUS_METADATA_LOCATION) : null;
+        final String newMetadataLocation = newMetadata != null
+            ? newMetadata.get(DirectSqlTable.PARAM_METADATA_LOCATION) : null;
         if (StringUtils.isBlank(existingMetadataLocation)) {
             final String message = "Invalid iceberg table metadata location. Existing metadata location is empty.";
             log.error(message);
             throw new IllegalStateException(message);
-        } else if (StringUtils.isBlank(previousMetadataLocation)) {
-            final String message =
-                "Invalid iceberg table metadata location. Provided previous metadata location is empty.";
-            log.error(message);
-            throw new IllegalStateException(message);
-        } else if (!Objects.equals(existingMetadataLocation, previousMetadataLocation)) {
-            final String message = String.format("Invalid iceberg table metadata location (expected:%s, provided:%s)",
-                existingMetadataLocation, previousMetadataLocation);
-            log.error(message);
-            throw new IllegalStateException(message);
+        } else if (!Objects.equals(existingMetadataLocation, newMetadataLocation)) {
+            if (StringUtils.isBlank(previousMetadataLocation)) {
+                final String message =
+                    "Invalid iceberg table metadata location. Provided previous metadata location is empty.";
+                log.error(message);
+                throw new IllegalStateException(message);
+            } else if (!Objects.equals(existingMetadataLocation, previousMetadataLocation)) {
+                final String message =
+                    String.format("Invalid iceberg table metadata location (expected:%s, provided:%s)",
+                        existingMetadataLocation, previousMetadataLocation);
+                log.error(message);
+                throw new IllegalStateException(message);
+            }
         }
     }
 

--- a/metacat-functional-tests/src/functionalTest/groovy/com/netflix/metacat/MetacatSmokeSpec.groovy
+++ b/metacat-functional-tests/src/functionalTest/groovy/com/netflix/metacat/MetacatSmokeSpec.groovy
@@ -386,6 +386,7 @@ class MetacatSmokeSpec extends Specification {
         def catalogName = 'embedded-fast-hive-metastore'
         def databaseName = 'iceberg_db'
         def tableName = 'iceberg_table'
+        def renamedTableName = 'iceberg_table_rename'
         def uri = isLocalEnv ? String.format('file:/tmp/%s/%s', databaseName, tableName) : null
         def tableDto = PigDataDtoProvider.getTable(catalogName, databaseName, tableName, 'test', uri)
         def metadataLocation = String.format('file:/tmp/%s/%s/%s', databaseName, tableName, 'iceberg.0')
@@ -413,6 +414,17 @@ class MetacatSmokeSpec extends Specification {
         api.updateTable(catalogName, databaseName, tableName, tableDto)
         then:
         noExceptionThrown()
+        when:
+        api.renameTable(catalogName, databaseName, tableName, renamedTableName)
+        api.updateTable(catalogName, databaseName, renamedTableName, api.getTable(catalogName, databaseName, renamedTableName, true, false, false))
+        then:
+        noExceptionThrown()
+        api.getTable(catalogName, databaseName, renamedTableName, true, false, false) != null
+        when:
+        api.renameTable(catalogName, databaseName, renamedTableName, tableName)
+        then:
+        noExceptionThrown()
+        api.getTable(catalogName, databaseName, tableName, true, false, false) != null
         when:
         tableDto.getMetadata().putAll(metadata1)
         api.updateTable(catalogName, databaseName, tableName, tableDto)


### PR DESCRIPTION
The issue was that the iceberg table update was failing the validation since the thrift rename API did a rename and update call. The second call to update failed since it was missing the previous_metadata_location. Modified to pass the validation if there is no change in the metadata_location.