### PR TITLE
Fixed issue with the previous commit on supporting caching of tables.

### DIFF
--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/connectors/model/AuditInfo.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/connectors/model/AuditInfo.java
@@ -23,6 +23,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
+import java.io.Serializable;
 import java.util.Date;
 
 /**
@@ -37,7 +38,8 @@ import java.util.Date;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class AuditInfo {
+public class AuditInfo implements Serializable {
+    private static final long serialVersionUID = -4683417661637244309L;
     /* Created By */
     private String createdBy;
     /* Created date */

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/connectors/model/BaseInfo.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/connectors/model/BaseInfo.java
@@ -22,6 +22,7 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.io.Serializable;
 import java.util.Map;
 
 /**
@@ -33,7 +34,8 @@ import java.util.Map;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-public abstract class BaseInfo {
+public abstract class BaseInfo implements Serializable {
+    private static final long serialVersionUID = 284049639636194327L;
     /* Name of the resource */
     private QualifiedName name;
     /* Audit information of the resource */

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/connectors/model/StorageInfo.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/connectors/model/StorageInfo.java
@@ -23,6 +23,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
+import java.io.Serializable;
 import java.util.Map;
 
 /**
@@ -36,7 +37,8 @@ import java.util.Map;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class StorageInfo {
+public class StorageInfo implements Serializable {
+    private static final long serialVersionUID = -1261997541007723844L;
     private String inputFormat;
     private String outputFormat;
     private String owner;

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/connectors/model/ViewInfo.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/connectors/model/ViewInfo.java
@@ -24,6 +24,8 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
+import java.io.Serializable;
+
 /**
  * Hive Virtual View Info.
  *
@@ -36,7 +38,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @EqualsAndHashCode
-public class ViewInfo {
+public class ViewInfo implements Serializable {
+    private static final long serialVersionUID = -7841464527538892424L;
     /* view original text*/
     private String viewOriginalText;
     /* view expanded text*/

--- a/metacat-common-server/src/test/groovy/com/netflix/metacat/common/server/connectors/model/FieldInfoSpec.groovy
+++ b/metacat-common-server/src/test/groovy/com/netflix/metacat/common/server/connectors/model/FieldInfoSpec.groovy
@@ -1,0 +1,94 @@
+/*
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
+
+package com.netflix.metacat.common.server.connectors.model
+
+import com.netflix.metacat.common.type.TypeRegistry
+import com.netflix.metacat.common.type.TypeSignature
+import spock.lang.Shared;
+import spock.lang.Specification;
+
+/**
+ * Specifications for FieldInfoSpec serialization/deserialization.
+ *
+ * @author amajumdar
+ * @since 1.2.0
+ */
+class FieldInfoSpec extends Specification {
+    @Shared
+    def file
+
+    def setupSpec() {
+        file = new File('fieldInfo.txt')
+    }
+
+    def cleanupSpec() {
+        file.delete()
+    }
+    def test() {
+        given:
+        def type = signature == null ? null : TypeRegistry.getTypeRegistry().getType(TypeSignature.parseTypeSignature(signature))
+        def field = new FieldInfo(comment:'hi', name:'name',partitionKey: true, isNullable: true, size: 10, defaultValue: '10', type: type)
+        file.withObjectOutputStream { oos -> oos.writeObject(field) }
+        def savedField = (FieldInfo) file.withObjectInputStream { ois -> ois.readObject()}
+        expect:
+        savedField.type == type
+        where:
+        signature << [
+        null,
+        'tinyint',
+        'smallint',
+        'int',
+        'bigint',
+        'float',
+        'double',
+        'decimal(4,2)',
+        'array<decimal(4,2)>',
+        'timestamp',
+        'date',
+        'string',
+        'varchar(10)',
+        'char(10)',
+        'boolean',
+        'binary',
+        'array<bigint>',
+        'array<boolean>',
+        'array<double>',
+        'array<bigint>',
+        'array<string>',
+        'array<map<bigint,bigint>>',
+        'array<map<bigint,string>>',
+        'array<map<string,bigint>>',
+        'array<map<string,string>>',
+        'array<struct<field1:bigint,field2:bigint>>',
+        'array<struct<field1:bigint,field2:string>>',
+        'array<struct<field1:string,field2:bigint>>',
+        'array<struct<field1:string,field2:string>>',
+        'map<boolean,boolean>',
+        'map<boolean,string>',
+        'map<bigint,bigint>',
+        'map<string,double>',
+        'map<string,bigint>',
+        'map<string,string>',
+        'map<string,struct<field1:array<bigint>>>',
+        'struct<field1:bigint,field2:bigint,field3:bigint>',
+        'struct<field1:bigint,field2:string,field3:double>',
+        'struct<field1:bigint,field2:string,field3:string>',
+        'struct<field1:string,field2:bigint,field3:bigint>',
+        'struct<field1:string,field2:string,field3:bigint>',
+        'struct<field1:string,field2:string,field3:string>']
+    }
+}

--- a/metacat-common/src/main/java/com/netflix/metacat/common/QualifiedName.java
+++ b/metacat-common/src/main/java/com/netflix/metacat/common/QualifiedName.java
@@ -37,6 +37,7 @@ import java.util.Objects;
  */
 @Getter
 public final class QualifiedName implements Serializable {
+    private static final long serialVersionUID = -7916364073519921672L;
     private final String catalogName;
     private final String databaseName;
     private final String partitionName;

--- a/metacat-main/src/main/java/com/netflix/metacat/main/configs/ServicesConfig.java
+++ b/metacat-main/src/main/java/com/netflix/metacat/main/configs/ServicesConfig.java
@@ -167,6 +167,7 @@ public class ServicesConfig {
      * @param eventBus                   Internal event bus
      * @param registry                   registry handle
      * @param config                     configurations
+     * @param converterUtil              converter utilities
      * @param authorizationService       authorization Service
      * @return The table service bean
      */
@@ -179,6 +180,7 @@ public class ServicesConfig {
         final MetacatEventBus eventBus,
         final Registry registry,
         final Config config,
+        final ConverterUtil converterUtil,
         final AuthorizationService authorizationService
     ) {
         return new TableServiceImpl(
@@ -189,6 +191,7 @@ public class ServicesConfig {
             eventBus,
             registry,
             config,
+            converterUtil,
             authorizationService
         );
     }

--- a/metacat-main/src/main/java/com/netflix/metacat/main/services/impl/ConnectorTableServiceProxy.java
+++ b/metacat-main/src/main/java/com/netflix/metacat/main/services/impl/ConnectorTableServiceProxy.java
@@ -20,9 +20,9 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.netflix.metacat.common.MetacatRequestContext;
 import com.netflix.metacat.common.QualifiedName;
-import com.netflix.metacat.common.dto.TableDto;
 import com.netflix.metacat.common.server.connectors.ConnectorRequestContext;
 import com.netflix.metacat.common.server.connectors.ConnectorTableService;
+import com.netflix.metacat.common.server.connectors.model.TableInfo;
 import com.netflix.metacat.common.server.converter.ConverterUtil;
 import com.netflix.metacat.common.server.util.MetacatContextManager;
 import com.netflix.metacat.main.manager.ConnectorManager;
@@ -62,13 +62,13 @@ public class ConnectorTableServiceProxy {
     /**
      * Calls the connector table service create method.
      * @param name table name
-     * @param tableDto table object
+     * @param tableInfo table object
      */
-    public void create(final QualifiedName name, final TableDto tableDto) {
+    public void create(final QualifiedName name, final TableInfo tableInfo) {
         final MetacatRequestContext metacatRequestContext = MetacatContextManager.getContext();
         final ConnectorTableService service = connectorManager.getTableService(name);
         final ConnectorRequestContext connectorRequestContext = converterUtil.toConnectorContext(metacatRequestContext);
-        service.create(connectorRequestContext, converterUtil.fromTableDto(tableDto));
+        service.create(connectorRequestContext, tableInfo);
     }
 
     /**
@@ -95,11 +95,11 @@ public class ConnectorTableServiceProxy {
      * @return table dto
      */
     @Cacheable(key = "'table.' + #name", condition = "#useCache")
-    public TableDto get(final QualifiedName name, final boolean useCache) {
+    public TableInfo get(final QualifiedName name, final boolean useCache) {
         final MetacatRequestContext metacatRequestContext = MetacatContextManager.getContext();
         final ConnectorRequestContext connectorRequestContext = converterUtil.toConnectorContext(metacatRequestContext);
         final ConnectorTableService service = connectorManager.getTableService(name);
-        return converterUtil.toTableDto(service.get(connectorRequestContext, name));
+        return service.get(connectorRequestContext, name);
     }
 
     /**
@@ -129,17 +129,17 @@ public class ConnectorTableServiceProxy {
     /**
      * Calls the connector table service update method.
      * @param name table name
-     * @param tableDto table object
+     * @param tableInfo table object
      */
     @CacheEvict(key = "'table.' + #name")
-    public void update(final QualifiedName name, final TableDto tableDto) {
+    public void update(final QualifiedName name, final TableInfo tableInfo) {
         final MetacatRequestContext metacatRequestContext = MetacatContextManager.getContext();
         final ConnectorTableService service = connectorManager.getTableService(name);
         try {
             log.info("Updating table {}", name);
             final ConnectorRequestContext connectorRequestContext
                 = converterUtil.toConnectorContext(metacatRequestContext);
-            service.update(connectorRequestContext, converterUtil.fromTableDto(tableDto));
+            service.update(connectorRequestContext, tableInfo);
         } catch (UnsupportedOperationException ignored) {
             //Ignore if the operation is not supported, so that we can at least go ahead and save the user metadata.
             log.debug("Catalog {} does not support the table update operation.", name.getCatalogName());

--- a/metacat-main/src/test/groovy/com/netflix/metacat/main/services/impl/TableServiceImplSpec.groovy
+++ b/metacat-main/src/test/groovy/com/netflix/metacat/main/services/impl/TableServiceImplSpec.groovy
@@ -73,7 +73,7 @@ class TableServiceImplSpec extends Specification {
         connectorTableServiceProxy = new ConnectorTableServiceProxy(connectorManager, converterUtil)
         authorizationService = new DefaultAuthorizationService(config)
         service = new TableServiceImpl(connectorTableServiceProxy, databaseService, tagService,
-            usermetadataService, eventBus, registry, config, authorizationService)
+            usermetadataService, eventBus, registry, config, converterUtil, authorizationService)
     }
 
     def testTableGet() {


### PR DESCRIPTION
The issue was we were caching TableDto object for a table instead of TableInfo. Caching TableDto would cause an issue where a hive client calling a getTable will get a cached TableDto created for a previous pig client call. The column types will be represented in pig instead of in hive.