### PR TITLE
Overloaded getCatalog API with another optimized API.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -150,6 +150,9 @@ configure(javaProjects) {
             dependency("org.elasticsearch.client:transport:5.4.1")
             dependency("net.snowflake:snowflake-jdbc:3.4.2")
             dependency("com.esotericsoftware.kryo:kryo:2.22")
+            dependency("com.github.Netflix.iceberg:iceberg-common:0.3.2")
+            dependency("com.github.Netflix.iceberg:iceberg-core:0.3.2")
+            dependency("com.github.Netflix.iceberg:iceberg-api:0.3.2")
         }
     }
 

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/api/v1/MetacatV1.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/api/v1/MetacatV1.java
@@ -164,4 +164,15 @@ public interface MetacatV1 {
      * @return catalog
      */
     CatalogDto getCatalog(final String catalogName);
+
+    /**
+     * Get the catalog by name.
+     *
+     * @param catalogName catalog name
+     * @param includeDatabaseNames if true, the response includes the database names
+     * @param includeUserMetadata if true, the response includes the user metadata
+     * @return catalog
+     */
+    CatalogDto getCatalog(final String catalogName, final boolean includeDatabaseNames,
+                          final boolean includeUserMetadata);
 }

--- a/metacat-connector-hive/build.gradle
+++ b/metacat-connector-hive/build.gradle
@@ -31,9 +31,9 @@ dependencies {
     }
 
     compile("commons-dbutils:commons-dbutils")
-    compile('com.github.Netflix.iceberg:iceberg-common:0.3.0')
-    compile('com.github.Netflix.iceberg:iceberg-core:0.3.0')
-    compile('com.github.Netflix.iceberg:iceberg-api:0.3.0')
+    compile('com.github.Netflix.iceberg:iceberg-common')
+    compile('com.github.Netflix.iceberg:iceberg-core')
+    compile('com.github.Netflix.iceberg:iceberg-api')
     /*******************************
      * Provided Dependencies
      *******************************/

--- a/metacat-main/src/main/java/com/netflix/metacat/main/api/v1/MetacatController.java
+++ b/metacat-main/src/main/java/com/netflix/metacat/main/api/v1/MetacatController.java
@@ -29,6 +29,7 @@ import com.netflix.metacat.common.server.connectors.exception.TableNotFoundExcep
 import com.netflix.metacat.main.api.RequestWrapper;
 import com.netflix.metacat.main.services.CatalogService;
 import com.netflix.metacat.main.services.DatabaseService;
+import com.netflix.metacat.main.services.GetCatalogServiceParameters;
 import com.netflix.metacat.main.services.GetTableServiceParameters;
 import com.netflix.metacat.main.services.MViewService;
 import com.netflix.metacat.main.services.TableService;
@@ -496,11 +497,21 @@ public class MetacatController implements MetacatV1 {
         @ApiParam(value = "The name of the catalog", required = true)
         @PathVariable("catalog-name") final String catalogName
     ) {
+        return getCatalog(catalogName, true, true);
+    }
+
+    @Override
+    public CatalogDto getCatalog(
+        final String catalogName,
+        final boolean includeUserMetadata,
+        final boolean includeDatabaseNames
+    ) {
         final QualifiedName name = this.requestWrapper.qualifyName(() -> QualifiedName.ofCatalog(catalogName));
         return this.requestWrapper.processRequest(
             name,
             "getCatalog",
-            () -> this.catalogService.get(name)
+            () -> this.catalogService.get(name, GetCatalogServiceParameters.builder()
+                .includeDatabaseNames(includeDatabaseNames).includeUserMetadata(includeUserMetadata).build())
         );
     }
 

--- a/metacat-main/src/main/java/com/netflix/metacat/main/api/v1/TagController.java
+++ b/metacat-main/src/main/java/com/netflix/metacat/main/api/v1/TagController.java
@@ -32,6 +32,7 @@ import com.netflix.metacat.common.server.util.MetacatContextManager;
 import com.netflix.metacat.main.api.RequestWrapper;
 import com.netflix.metacat.main.services.CatalogService;
 import com.netflix.metacat.main.services.DatabaseService;
+import com.netflix.metacat.main.services.GetCatalogServiceParameters;
 import com.netflix.metacat.main.services.GetTableServiceParameters;
 import com.netflix.metacat.main.services.MViewService;
 import com.netflix.metacat.main.services.TableService;
@@ -252,7 +253,8 @@ public class TagController {
         switch (name.getType()) {
             case CATALOG:
                 //catalog service will throw exception if not found
-                final CatalogDto catalogDto = this.catalogService.get(name);
+                final CatalogDto catalogDto = this.catalogService.get(name, GetCatalogServiceParameters.builder()
+                        .includeDatabaseNames(false).includeUserMetadata(false).build());
                 if (catalogDto != null) {
                     return this.tagService.setTags(name, tags, true);
                 }
@@ -544,7 +546,8 @@ public class TagController {
         switch (name.getType()) {
             case CATALOG:
                 //catalog service will throw exception if not found
-                final CatalogDto catalogDto = this.catalogService.get(name);
+                final CatalogDto catalogDto = this.catalogService.get(name, GetCatalogServiceParameters.builder()
+                        .includeDatabaseNames(false).includeUserMetadata(false).build());
                 if (catalogDto != null) {
                     this.tagService.removeTags(name, tagRemoveRequestDto.getDeleteAll(),
                         new HashSet<>(tagRemoveRequestDto.getTags()), true);

--- a/metacat-main/src/main/java/com/netflix/metacat/main/services/CatalogService.java
+++ b/metacat-main/src/main/java/com/netflix/metacat/main/services/CatalogService.java
@@ -34,6 +34,15 @@ public interface CatalogService {
     CatalogDto get(QualifiedName name);
 
     /**
+     * Gets the catalog. Returned dto will have details if asked.
+     * @param name Qualified name of the catalog
+     * @param getCatalogServiceParameters parameters
+     * @return the information about the given catalog
+     */
+    @Nonnull
+    CatalogDto get(QualifiedName name, GetCatalogServiceParameters getCatalogServiceParameters);
+
+    /**
      * List of registered catalogs.
      * @return all of the registered catalogs
      */

--- a/metacat-main/src/main/java/com/netflix/metacat/main/services/GetCatalogServiceParameters.java
+++ b/metacat-main/src/main/java/com/netflix/metacat/main/services/GetCatalogServiceParameters.java
@@ -1,0 +1,33 @@
+/*
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
+
+package com.netflix.metacat.main.services;
+
+import lombok.Builder;
+import lombok.Value;
+
+/**
+ * Get Catalog Parameters.
+ *
+ * @author amajumdar
+ * @since 1.2.0
+ */
+@Value
+@Builder
+public class GetCatalogServiceParameters {
+    private final boolean includeDatabaseNames;
+    private final boolean includeUserMetadata;
+}


### PR DESCRIPTION
1. Overloaded getCatalog API with another optimized API that addeds the list of database names and user metadata only if explicitly requested.
2. Upgraded iceberg versions to 0.3.2.
