### PR TITLE
Making Metacat resilient on getPartitions call for tables with high number of partitions.

### DIFF
--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/Config.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/Config.java
@@ -234,6 +234,13 @@ public interface Config {
     List<QualifiedName> getNamesToThrowErrorOnListPartitionsWithNoFilter();
 
     /**
+     * Threshold for list of partitions returned.
+     *
+     * @return Threshold for list of partitions returned
+     */
+    int getMaxPartitionsThreshold();
+
+    /**
      * Elastic search index.
      *
      * @return elastic search index name

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/DefaultConfigImpl.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/DefaultConfigImpl.java
@@ -307,6 +307,20 @@ public class DefaultConfigImpl implements Config {
      * {@inheritDoc}
      */
     @Override
+    public int getMaxPartitionsThreshold() {
+        return this.metacatProperties
+            .getService()
+            .getTables()
+            .getError()
+            .getList()
+            .getPartitions()
+            .getThreshold();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public String getEsIndex() {
         return this.metacatProperties.getElasticsearch().getIndex().getName();
     }

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/ServiceProperties.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/ServiceProperties.java
@@ -104,7 +104,7 @@ public class ServiceProperties {
                  */
                 @Data
                 public static class Partitions {
-
+                    private int threshold = Integer.MAX_VALUE;
                     @NonNull
                     private No no = new No();
 

--- a/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/iceberg/IcebergTableHandler.java
+++ b/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/iceberg/IcebergTableHandler.java
@@ -106,6 +106,7 @@ public class IcebergTableHandler {
                 result = this.icebergTableOpWrapper.getPartitionMetricsMap(icebergTable, null);
             }
         } catch (ParseException ex) {
+            log.error("Iceberg filter parse error", ex);
             throw new MetacatBadRequestException("Iceberg filter parse error");
         } finally {
             final long duration = registry.clock().wallTime() - start;

--- a/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/iceberg/IcebergTableOpWrapper.java
+++ b/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/iceberg/IcebergTableOpWrapper.java
@@ -45,7 +45,9 @@ public class IcebergTableOpWrapper {
     public Map<String, ScanSummary.PartitionMetrics> getPartitionMetricsMap(final Table icebergTable,
                                                                      @Nullable final Expression filter) {
         return (filter != null)
-            ? ScanSummary.of(icebergTable.newScan().filter(filter)).build()
+            ? ScanSummary.of(icebergTable.newScan().filter(filter))
+                .limit(connectorContext.getConfig().getIcebergTableSummaryFetchSize())
+                .build()
             :
             ScanSummary.of(icebergTable.newScan())  //the top x records
                 .limit(connectorContext.getConfig().getIcebergTableSummaryFetchSize())

--- a/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/monitoring/HiveMetrics.java
+++ b/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/monitoring/HiveMetrics.java
@@ -35,6 +35,7 @@ public enum HiveMetrics {
     CounterHiveExperimentGetTablePartitionsFailure(Type.counter,"experimentGetPartitionsFailure"),
     CounterHivePartitionPathIsNotDir(Type.counter,"partitionPathIsNotDir"),
     CounterHivePartitionFileSystemCall(Type.counter,"partitionFileSystemCall"),
+    CounterHiveGetPartitionsExceedThresholdFailure(Type.counter,"getPartitionsExceedThresholdFailure"),
 
     /**
      * Gauge.
@@ -42,6 +43,7 @@ public enum HiveMetrics {
     GaugeAddPartitions(Type.gauge, "partitionAdd"),
     GaugeDeletePartitions(Type.gauge, "partitionDelete"),
     GaugeGetPartitionsCount(Type.gauge, "partitionGet"),
+    GaugePreExpressionFilterGetPartitionsCount(Type.gauge, "preExpressionFilterGetPartitionsCount"),
 
     /**
      * Timer.

--- a/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/util/HiveConnectorFastServiceMetric.java
+++ b/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/util/HiveConnectorFastServiceMetric.java
@@ -68,7 +68,6 @@ public class HiveConnectorFastServiceMetric {
 
         getHiveTablePartsFailureCounter = registry.counter(
             HiveMetrics.CounterHiveExperimentGetTablePartitionsFailure.getMetricName());
-
     }
 
     private Timer createTimer(final Registry registry, final String requestTag) {

--- a/metacat-functional-tests/metacat-test-cluster/docker-compose.yml
+++ b/metacat-functional-tests/metacat-test-cluster/docker-compose.yml
@@ -60,7 +60,8 @@ services:
                 -Dmetacat.cache.enabled=true
                 -Dmetacat.authorization.enabled=true
                 -Dmetacat.authorization.createAcl.createAclStr=embedded-fast-hive-metastore/fsmoke_acl:metacat-prod
-                -Dmetacat.authorization.deleteAcl.deleteAclStr=embedded-fast-hive-metastore/fsmoke_acl:metacat-prod'
+                -Dmetacat.authorization.deleteAcl.deleteAclStr=embedded-fast-hive-metastore/fsmoke_acl:metacat-prod
+                -Dmetacat.service.tables.error.list.partitions.threshold=100'
         labels:
           - "com.netflix.metacat.oss.test"
           - "com.netflix.metacat.oss.test.war"


### PR DESCRIPTION
GetPartitions will fail if the number of partitions exceeds the configured threshold. This is handled only in hive connector with configurations hive.use.embedded.metastore=true and hive.use.embedded.fastservice=true.