### PR TITLE
Fix UpdateTable API to not Throw on Failed Read After Update

### DIFF
--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/events/MetacatUpdateTablePostEvent.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/events/MetacatUpdateTablePostEvent.java
@@ -36,6 +36,7 @@ import javax.annotation.Nonnull;
 public class MetacatUpdateTablePostEvent extends MetacatEvent {
     private TableDto oldTable;
     private TableDto currentTable;
+    private boolean isLatestCurrentTable;
 
     /**
      * Constructor.
@@ -52,9 +53,33 @@ public class MetacatUpdateTablePostEvent extends MetacatEvent {
         @Nonnull @NonNull final Object source,
         @Nonnull @NonNull final TableDto oldTable,
         @Nonnull @NonNull final TableDto currentTable
+
+    ) {
+        this(name, requestContext, source, oldTable, currentTable, true);
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param name                  The name of the table that was updated
+     * @param requestContext        The metacat request context
+     * @param source                The source object which threw this event
+     * @param oldTable              The old DTO representation of the table
+     * @param currentTable          The current DTO representation of the table
+     * @param isLatestCurrentTable  Whether the current table was successfully refreshed post-update
+     */
+    public MetacatUpdateTablePostEvent(
+        @Nonnull @NonNull final QualifiedName name,
+        @Nonnull @NonNull final MetacatRequestContext requestContext,
+        @Nonnull @NonNull final Object source,
+        @Nonnull @NonNull final TableDto oldTable,
+        @Nonnull @NonNull final TableDto currentTable,
+        final boolean isLatestCurrentTable
+
     ) {
         super(name, requestContext, source);
         this.oldTable = oldTable;
         this.currentTable = currentTable;
+        this.isLatestCurrentTable = isLatestCurrentTable;
     }
 }

--- a/metacat-main/src/main/java/com/netflix/metacat/main/services/impl/TableServiceImpl.java
+++ b/metacat-main/src/main/java/com/netflix/metacat/main/services/impl/TableServiceImpl.java
@@ -377,14 +377,16 @@ public class TableServiceImpl implements TableService {
             registry.timer(registry.createId(Metrics.TimerSaveTableMetadata.getMetricName()).withTags(name.parts()))
                 .record(duration, TimeUnit.MILLISECONDS);
         }
+
         final TableDto updatedDto = get(name,
             GetTableServiceParameters.builder()
                 .disableOnReadMetadataIntercetor(false)
                 .includeInfo(true)
                 .includeDataMetadata(true)
                 .includeDefinitionMetadata(true)
-                .build()).orElseThrow(() -> new IllegalStateException("should exist"));
-        eventBus.post(new MetacatUpdateTablePostEvent(name, metacatRequestContext, this, oldTable, updatedDto));
+                .build()).orElse(tableDto);
+        eventBus.post(new MetacatUpdateTablePostEvent(name, metacatRequestContext, this, oldTable,
+            updatedDto, updatedDto != tableDto));
         return updatedDto;
     }
 


### PR DESCRIPTION
- We now do a best-effort Get() for the updated table. 
- If we fail on the Get(), notify clients via an SNS message to callback.