### PR TITLE
Fixed issue where unsupported operations for iceberg tables were responding back with HTTP 500..

### DIFF
--- a/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/sql/HiveConnectorFastPartitionService.java
+++ b/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/sql/HiveConnectorFastPartitionService.java
@@ -20,7 +20,6 @@ import com.netflix.iceberg.ScanSummary;
 import com.netflix.metacat.common.QualifiedName;
 import com.netflix.metacat.common.dto.Pageable;
 import com.netflix.metacat.common.dto.Sort;
-import com.netflix.metacat.common.exception.MetacatNotSupportedException;
 import com.netflix.metacat.common.server.connectors.ConnectorContext;
 import com.netflix.metacat.common.server.connectors.ConnectorRequestContext;
 import com.netflix.metacat.common.server.connectors.ConnectorUtils;
@@ -112,7 +111,7 @@ public class HiveConnectorFastPartitionService extends HiveConnectorPartitionSer
         final TableInfo tableInfo
     ) {
         if (context.getConfig().isIcebergEnabled() && HiveTableUtil.isIcebergTable(tableInfo)) {
-            throw new MetacatNotSupportedException("IcebergTable Unsupported Operation!");
+            throw new UnsupportedOperationException("IcebergTable Unsupported Operation!");
         }
         return directSqlGetPartition.getPartitionCount(requestContext, tableName);
     }
@@ -160,7 +159,7 @@ public class HiveConnectorFastPartitionService extends HiveConnectorPartitionSer
         final TableInfo tableInfo
     ) {
         if (context.getConfig().isIcebergEnabled() && HiveTableUtil.isIcebergTable(tableInfo)) {
-            throw new MetacatNotSupportedException("IcebergTable Unsupported Operation!");
+            throw new UnsupportedOperationException("IcebergTable Unsupported Operation!");
         }
         return directSqlGetPartition.getPartitionUris(requestContext, tableName, partitionsRequest);
     }
@@ -333,7 +332,7 @@ public class HiveConnectorFastPartitionService extends HiveConnectorPartitionSer
     ) {
         //TODO: implemented as next step
         if (context.getConfig().isIcebergEnabled() && HiveTableUtil.isIcebergTable(tableInfo)) {
-            throw new MetacatNotSupportedException("IcebergTable Unsupported Operation!");
+            throw new UnsupportedOperationException("IcebergTable Unsupported Operation!");
         }
         //The direct sql based deletion doesn't check if the partition is valid
         if (Boolean.parseBoolean(getContext().getConfiguration()

--- a/metacat-connector-hive/src/test/groovy/com/netflix/metacat/connector/hive/HiveConnectorFastPartitionSpec.groovy
+++ b/metacat-connector-hive/src/test/groovy/com/netflix/metacat/connector/hive/HiveConnectorFastPartitionSpec.groovy
@@ -104,19 +104,36 @@ class HiveConnectorFastPartitionSpec extends Specification {
     }
 
 
-    def "Test for get iceberg table partitionKeys" (){
+    def "Test for get iceberg table partitions" (){
+        given:
+        def tableName = QualifiedName.ofTable("testhive", "test1", "icebergtable")
+        def tableInfo = MetacatDataInfoProvider.getIcebergTableInfo("icebergtable")
+        def partitionListRequest = new PartitionListRequest();
         when:
-        PartitionListRequest partitionListRequest = new PartitionListRequest();
         partitionListRequest.partitionNames = [
             "dateint=20170101/hour=1"
         ]
-        def partKeys = hiveConnectorFastPartitionService.getPartitionKeys(
-            connectorContext, QualifiedName.ofTable("testhive", "test1", "icebergtable"),
-            partitionListRequest, MetacatDataInfoProvider.getIcebergTableInfo("icebergtable"))
-
+        def partKeys = hiveConnectorFastPartitionService.getPartitionKeys(connectorContext, tableName, partitionListRequest, tableInfo)
         then:
         partKeys== [
             "dateint=20170101/hour=1"
         ]
+
+        when:
+        hiveConnectorFastPartitionService.getPartitionCount(connectorContext, tableName, tableInfo)
+        then:
+        thrown(UnsupportedOperationException)
+
+        when:
+        hiveConnectorFastPartitionService.getPartitionUris(connectorContext, tableName, partitionListRequest, tableInfo)
+        then:
+        thrown(UnsupportedOperationException)
+
+        when:
+        hiveConnectorFastPartitionService.deletePartitions(connectorContext, tableName, ['field1=true'], tableInfo)
+        then:
+        thrown(UnsupportedOperationException)
     }
+
+
 }

--- a/metacat-functional-tests/src/functionalTest/groovy/com/netflix/metacat/MetacatSmokeSpec.groovy
+++ b/metacat-functional-tests/src/functionalTest/groovy/com/netflix/metacat/MetacatSmokeSpec.groovy
@@ -514,6 +514,21 @@ class MetacatSmokeSpec extends Specification {
         parts.get(0).dataMetadata != null
         partkeys.size() == 2
 
+        when:
+        partitionApi.getPartitionCount(catalogName, databaseName, tableName)
+        then:
+        thrown(MetacatNotSupportedException)
+
+        when:
+        partitionApi.getPartitionUris(catalogName, databaseName, tableName, null, null, null, null, null)
+        then:
+        noExceptionThrown()
+
+        when:
+        partitionApi.deletePartitions(catalogName, databaseName, tableName, ['field1=true'])
+        then:
+        thrown(MetacatNotSupportedException)
+
         cleanup:
         api.deleteTable(catalogName, databaseName, tableName)
     }


### PR DESCRIPTION
Unsupported operations for iceberg tables should respond back with http 415 (MetacatNotSupportedException).