### PR TITLE
Fix exception handling on Get after UpdateTable

### DIFF
--- a/metacat-functional-tests/src/functionalTest/groovy/com/netflix/metacat/MetacatSmokeSpec.groovy
+++ b/metacat-functional-tests/src/functionalTest/groovy/com/netflix/metacat/MetacatSmokeSpec.groovy
@@ -40,6 +40,7 @@ import com.netflix.metacat.common.json.MetacatJsonLocator
 import com.netflix.metacat.common.server.connectors.exception.InvalidMetaException
 import com.netflix.metacat.connector.hive.util.PartitionUtil
 import com.netflix.metacat.testdata.provider.PigDataDtoProvider
+import org.apache.commons.io.FileUtils
 import feign.*
 import feign.jaxrs.JAXRSContract
 import feign.slf4j.Slf4jLogger
@@ -411,9 +412,15 @@ class MetacatSmokeSpec extends Specification {
         def databaseName = 'iceberg_db'
         def tableName = 'iceberg_table'
         def renamedTableName = 'iceberg_table_rename'
+        def icebergManifestFileName = '/metacat-test-cluster/etc-metacat/data/icebergManifest.json'
+        def metadataFileName = '/metacat-test-cluster/etc-metacat/data/00088-5641e8bf-06b8-46b3-a0fc-5c867f5bca58.metadata.json'
+        def curWorkingDir = new File("").getAbsolutePath()
+        def icebergManifestFile = new File(curWorkingDir + icebergManifestFileName)
+        def metadataFile = new File(curWorkingDir + metadataFileName)
         def uri = isLocalEnv ? String.format('file:/tmp/%s/%s', databaseName, tableName) : null
         def tableDto = PigDataDtoProvider.getTable(catalogName, databaseName, tableName, 'test', uri)
-        def metadataLocation = String.format('/tmp/data/00088-5641e8bf-06b8-46b3-a0fc-5c867f5bca58.metadata.json')
+        def metadataLocation = '/tmp/data/00088-5641e8bf-06b8-46b3-a0fc-5c867f5bca58.metadata.json'
+        def icebergMetadataLocation = '/tmp/data/icebergManifest.json'
         def metadata = [table_type: 'ICEBERG', metadata_location: metadataLocation]
         tableDto.setMetadata(metadata)
         when:
@@ -425,7 +432,7 @@ class MetacatSmokeSpec extends Specification {
         when:
         api.deleteTable(catalogName, databaseName, tableName)
         api.createTable(catalogName, databaseName, tableName, tableDto)
-        def metadataLocation1 = String.format('/tmp/data/00088-5641e8bf-06b8-46b3-a0fc-5c867f5bca58.metadata.json')
+        def metadataLocation1 = '/tmp/data/00088-5641e8bf-06b8-46b3-a0fc-5c867f5bca58.metadata.json'
         def metadata1 = [table_type: 'ICEBERG', metadata_location: metadataLocation1, previous_metadata_location: metadataLocation]
         tableDto.getMetadata().putAll(metadata1)
         api.updateTable(catalogName, databaseName, tableName, tableDto)
@@ -456,8 +463,18 @@ class MetacatSmokeSpec extends Specification {
         api.updateTable(catalogName, databaseName, tableName, tableDto)
         then:
         thrown(MetacatPreconditionFailedException)
+        when:
+        // Failure to get table after a successful update shouldn't fail
+        def updatedInvalidMetadata = [table_type: 'ICEBERG', metadata_location: icebergMetadataLocation, previous_metadata_location: metadataLocation2]
+        tableDto.getMetadata().putAll(updatedInvalidMetadata)
+        api.updateTable(catalogName, databaseName, tableName, tableDto)
+        then:
+        noExceptionThrown()
+        // Actually create the iceberg manifest file so deleteTable succeeds
+        FileUtils.copyFile(metadataFile, icebergManifestFile)
         cleanup:
         api.deleteTable(catalogName, databaseName, tableName)
+        FileUtils.deleteQuietly(icebergManifestFile)
     }
 
     @Unroll

--- a/metacat-main/src/main/java/com/netflix/metacat/main/services/impl/TableServiceImpl.java
+++ b/metacat-main/src/main/java/com/netflix/metacat/main/services/impl/TableServiceImpl.java
@@ -378,13 +378,18 @@ public class TableServiceImpl implements TableService {
                 .record(duration, TimeUnit.MILLISECONDS);
         }
 
-        final TableDto updatedDto = get(name,
-            GetTableServiceParameters.builder()
-                .disableOnReadMetadataIntercetor(false)
-                .includeInfo(true)
-                .includeDataMetadata(true)
-                .includeDefinitionMetadata(true)
-                .build()).orElse(tableDto);
+        TableDto updatedDto = tableDto;
+        try {
+            updatedDto = get(name,
+                GetTableServiceParameters.builder()
+                    .disableOnReadMetadataIntercetor(false)
+                    .includeInfo(true)
+                    .includeDataMetadata(true)
+                    .includeDefinitionMetadata(true)
+                    .build()).orElse(tableDto);
+        } catch (Exception e) {
+            log.warn("Failed to read updated TableDto", e);
+        }
         eventBus.post(new MetacatUpdateTablePostEvent(name, metacatRequestContext, this, oldTable,
             updatedDto, updatedDto != tableDto));
         return updatedDto;

--- a/metacat-main/src/test/groovy/com/netflix/metacat/main/services/impl/TableServiceImplSpec.groovy
+++ b/metacat-main/src/test/groovy/com/netflix/metacat/main/services/impl/TableServiceImplSpec.groovy
@@ -223,5 +223,19 @@ class TableServiceImplSpec extends Specification {
         })
         result == updatedTableDto
         noExceptionThrown()
+
+        when:
+        result = service.updateAndReturn(name, updatedTableDto)
+
+        then:
+        1 * converterUtil.toTableDto(_) >> this.tableDto
+        1 * converterUtil.toTableDto(_) >> { throw new FileNotFoundException("test") }
+        1 * eventBus.post(_ as MetacatUpdateTablePreEvent)
+        1 * eventBus.post({
+            MetacatUpdateTablePostEvent e ->
+                !e.latestCurrentTable && e.currentTable == updatedTableDto
+        })
+        result == updatedTableDto
+        noExceptionThrown()
     }
 }


### PR DESCRIPTION
- Previously, we were only handling TableNotFoundExceptions. But looks like we need to handle various other types as well (eg. Iceberg could throw FileNotFoundException). We fix this by catching all exceptions on a Get() after a successful Update(). This is inline with the semantics defined for the UpdateTable API as well.
- Added a functional test specifically to test this scenario end-to-end.