### PR TITLE
Add support for a proxy Catalog type

### DIFF
--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/connectors/ConnectorCatalogService.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/connectors/ConnectorCatalogService.java
@@ -1,0 +1,29 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.metacat.common.server.connectors;
+
+import com.netflix.metacat.common.server.connectors.model.CatalogInfo;
+
+/**
+ * Interfaces for manipulating catalog information for this connector.
+ *
+ * @author rveeramacheneni
+ * @since 1.3.0
+ */
+public interface ConnectorCatalogService extends ConnectorBaseService<CatalogInfo> {
+}

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/connectors/ConnectorFactory.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/connectors/ConnectorFactory.java
@@ -30,6 +30,16 @@ public interface ConnectorFactory {
     String UNSUPPORTED_MESSAGE = "Not supported by this connector";
 
     /**
+     * Returns the catalog service implementation of the connector.
+     *
+     * @return Returns the catalog service implementation of the connector.
+     */
+    default ConnectorCatalogService getCatalogService() {
+        throw new UnsupportedOperationException(UNSUPPORTED_MESSAGE);
+    }
+
+
+    /**
      * Returns the database service implementation of the connector.
      *
      * @return Returns the database service implementation of the connector.

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/connectors/model/CatalogInfo.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/connectors/model/CatalogInfo.java
@@ -1,0 +1,40 @@
+package com.netflix.metacat.common.server.connectors.model;
+
+import com.netflix.metacat.common.QualifiedName;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+import java.util.Map;
+
+/**
+ * Connector catalog information.
+ *
+ * @author rveeramacheneni
+ * @since 1.3.0
+ */
+@Data
+@NoArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+public final class CatalogInfo extends BaseInfo {
+    private ClusterInfo clusterInfo;
+
+    /**
+     * Constructor.
+     * @param name qualified name of the catalog
+     * @param auditInfo audit info
+     * @param metadata metadata properties
+     * @param clusterInfo cluster information
+     */
+    @Builder
+    private CatalogInfo(
+        final QualifiedName name,
+        final AuditInfo auditInfo,
+        final Map<String, String> metadata,
+        final ClusterInfo clusterInfo
+    ) {
+        super(name, auditInfo, metadata);
+        this.clusterInfo = clusterInfo;
+    }
+}

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/connectors/model/ClusterInfo.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/connectors/model/ClusterInfo.java
@@ -1,0 +1,52 @@
+/*
+ *
+ *  Copyright 2017 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.metacat.common.server.connectors.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+/**
+ * Cluster information.
+ *
+ * @author amajumdar
+ * @since 1.3.0
+ */
+@SuppressWarnings("unused")
+@Data
+@EqualsAndHashCode(callSuper = false)
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ClusterInfo implements Serializable {
+    private static final long serialVersionUID = -3119788564952124498L;
+    /** Name of the cluster. */
+    private String name;
+    /** Type of the cluster. */
+    private String type;
+    /** Account under which the cluster exists. Ex: "abc_test" */
+    private String account;
+    /** Environment under which the cluster exists. Ex: "prod", "test" */
+    private String env;
+    /** Region in which the cluster exists. Ex: "us-east-1" */
+    private String region;
+}

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/converter/ConverterUtil.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/converter/ConverterUtil.java
@@ -20,6 +20,8 @@ package com.netflix.metacat.common.server.converter;
 import com.google.common.collect.Maps;
 import com.netflix.metacat.common.MetacatRequestContext;
 import com.netflix.metacat.common.dto.AuditDto;
+import com.netflix.metacat.common.dto.CatalogDto;
+import com.netflix.metacat.common.dto.ClusterDto;
 import com.netflix.metacat.common.dto.DatabaseDto;
 import com.netflix.metacat.common.dto.FieldDto;
 import com.netflix.metacat.common.dto.GetPartitionsRequestDto;
@@ -33,6 +35,8 @@ import com.netflix.metacat.common.dto.StorageDto;
 import com.netflix.metacat.common.dto.TableDto;
 import com.netflix.metacat.common.server.connectors.ConnectorRequestContext;
 import com.netflix.metacat.common.server.connectors.model.AuditInfo;
+import com.netflix.metacat.common.server.connectors.model.CatalogInfo;
+import com.netflix.metacat.common.server.connectors.model.ClusterInfo;
 import com.netflix.metacat.common.server.connectors.model.DatabaseInfo;
 import com.netflix.metacat.common.server.connectors.model.FieldInfo;
 import com.netflix.metacat.common.server.connectors.model.ViewInfo;
@@ -82,6 +86,8 @@ public class ConverterUtil {
                     .fields("name", "name", FieldsMappingOptions.copyByReference());
                 mapping(PartitionDto.class, PartitionInfo.class)
                     .fields("name", "name", FieldsMappingOptions.copyByReference());
+                mapping(CatalogDto.class, CatalogInfo.class);
+                mapping(ClusterDto.class, ClusterInfo.class);
                 mapping(AuditDto.class, AuditInfo.class);
                 mapping(ViewDto.class, ViewInfo.class);
                 mapping(StorageDto.class, StorageInfo.class);
@@ -92,6 +98,46 @@ public class ConverterUtil {
         customConverterMap.put("typeConverter", dozerTypeConverter);
         dozerBeanMapper.setCustomConvertersWithId(customConverterMap);
         this.mapper = dozerBeanMapper;
+    }
+
+    /**
+     * Converts from CatalogInfo to CatalogDto.
+     *
+     * @param catalogInfo connector catalog info
+     * @return catalog dto
+     */
+    public CatalogDto toCatalogDto(final CatalogInfo catalogInfo) {
+        return this.mapper.map(catalogInfo, CatalogDto.class);
+    }
+
+    /**
+     * Converts from CatalogDto to CatalogInfo.
+     *
+     * @param catalogDto catalog dto
+     * @return connector catalog info
+     */
+    public CatalogInfo fromCatalogDto(final CatalogDto catalogDto) {
+        return this.mapper.map(catalogDto, CatalogInfo.class);
+    }
+
+    /**
+     * Converts from ClusterInfo to ClusterDto.
+     *
+     * @param clusterInfo catalog cluster info
+     * @return cluster dto
+     */
+    public ClusterDto toClusterDto(final ClusterInfo clusterInfo) {
+        return this.mapper.map(clusterInfo, ClusterDto.class);
+    }
+
+    /**
+     * Converts from ClusterDto to ClusterInfo.
+     *
+     * @param clusterDto catalog cluster dto
+     * @return cluster info
+     */
+    public ClusterInfo fromClusterDto(final ClusterDto clusterDto) {
+        return this.mapper.map(clusterDto, ClusterInfo.class);
     }
 
     /**

--- a/metacat-common/src/main/java/com/netflix/metacat/common/dto/CatalogDto.java
+++ b/metacat-common/src/main/java/com/netflix/metacat/common/dto/CatalogDto.java
@@ -52,7 +52,9 @@ public class CatalogDto extends BaseDto implements HasDefinitionMetadata {
     private QualifiedName name;
     @ApiModelProperty(value = "the type of the connector of this catalog", required = true)
     private String type;
-
+    @ApiModelProperty(value = "Cluster information referred to by this catalog", required = true)
+    @JsonProperty
+    private ClusterDto clusterDto;
     @JsonIgnore
     public QualifiedName getDefinitionName() {
         return name;

--- a/metacat-common/src/main/java/com/netflix/metacat/common/dto/CatalogMappingDto.java
+++ b/metacat-common/src/main/java/com/netflix/metacat/common/dto/CatalogMappingDto.java
@@ -17,10 +17,13 @@
  */
 package com.netflix.metacat.common.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
 
 /**
  * The name and type of a catalog.
@@ -28,6 +31,8 @@ import lombok.EqualsAndHashCode;
 @ApiModel(description = "The name and type of a catalog")
 @SuppressWarnings("unused")
 @Data
+@AllArgsConstructor
+@NoArgsConstructor
 @EqualsAndHashCode(callSuper = false)
 public class CatalogMappingDto extends BaseDto {
     private static final long serialVersionUID = -1223516438943164936L;
@@ -36,21 +41,7 @@ public class CatalogMappingDto extends BaseDto {
     private String catalogName;
     @ApiModelProperty(value = "The connector type of the catalog", required = true)
     private String connectorName;
-
-    /**
-     * Default constructor.
-     */
-    public CatalogMappingDto() {
-    }
-
-    /**
-     * Constructor.
-     *
-     * @param catalogName   catalog name
-     * @param connectorName connector name
-     */
-    public CatalogMappingDto(final String catalogName, final String connectorName) {
-        this.catalogName = catalogName;
-        this.connectorName = connectorName;
-    }
+    @ApiModelProperty(value = "Cluster information referred by this catalog", required = true)
+    @JsonProperty
+    private ClusterDto clusterDto;
 }

--- a/metacat-common/src/main/java/com/netflix/metacat/common/dto/ClusterDto.java
+++ b/metacat-common/src/main/java/com/netflix/metacat/common/dto/ClusterDto.java
@@ -1,0 +1,43 @@
+package com.netflix.metacat.common.dto;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+/**
+ * Catalog cluster information.
+ *
+ * @author rveeramacheneni
+ * @since 1.3.0
+ */
+@ApiModel(description = "Information about the catalog cluster")
+@SuppressWarnings("unused")
+@Data
+@EqualsAndHashCode(callSuper = false)
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ClusterDto implements Serializable {
+    private static final long serialVersionUID = 3575620733293405903L;
+    /** Name of the cluster. */
+    @ApiModelProperty(value = "the cluster hosting this catalog", required = false)
+    private String name;
+    /** Type of the cluster. */
+    @ApiModelProperty(value = "the type of the cluster", required = true)
+    private String type;
+    /** Account under which the cluster exists. Ex: "abc_test" */
+    @ApiModelProperty(value = "the account type for this catalog", required = false)
+    private String account;
+    /** Environment under which the cluster exists. Ex: "prod", "test" */
+    @ApiModelProperty(value = "the environment of this catalog", required = false)
+    private String env;
+    /** Region in which the cluster exists. Ex: "us-east-1" */
+    @ApiModelProperty(value = "the region of this catalog", required = false)
+    private String region;
+}

--- a/metacat-main/src/main/java/com/netflix/metacat/main/manager/CatalogManager.java
+++ b/metacat-main/src/main/java/com/netflix/metacat/main/manager/CatalogManager.java
@@ -92,7 +92,7 @@ public class CatalogManager implements HealthIndicator {
         // If catalogs are loaded we'll just report up
         final Health.Builder builder = this.catalogsLoaded.get() ? Health.up() : Health.outOfService();
 
-        this.connectorManager.getCatalogs().forEach(catalog -> {
+        this.connectorManager.getCatalogConfigs().forEach(catalog -> {
             final String key = catalog.getSchemaWhitelist().isEmpty() ? catalog.getCatalogName()
                 : String.format("%s:%s", catalog.getCatalogName(), catalog.getSchemaWhitelist());
             builder.withDetail(key, catalog.getType());

--- a/metacat-main/src/main/java/com/netflix/metacat/main/services/MetacatThriftService.java
+++ b/metacat-main/src/main/java/com/netflix/metacat/main/services/MetacatThriftService.java
@@ -45,7 +45,7 @@ public class MetacatThriftService {
     }
 
     protected List<CatalogThriftService> getCatalogThriftServices() {
-        return connectorManager.getCatalogs()
+        return connectorManager.getCatalogConfigs()
             .stream()
             .filter(MetacatCatalogConfig::isThriftInterfaceRequested)
             .map(catalog -> thriftServiceFactory.create(catalog.getCatalogName(), catalog.getThriftPort()))

--- a/metacat-main/src/test/groovy/com/netflix/metacat/main/manager/CatalogManagerSpec.groovy
+++ b/metacat-main/src/test/groovy/com/netflix/metacat/main/manager/CatalogManagerSpec.groovy
@@ -35,7 +35,7 @@ import spock.lang.Specification
 class CatalogManagerSpec extends Specification {
     def "can report health accurately based on whether catalogs are loaded or not"() {
         def connectorManager = Mock(ConnectorManager) {
-            2 * getCatalogs() >>> [
+            2 * getCatalogConfigs() >>> [
                 [],
                 [
                     MetacatCatalogConfig.createFromMapAndRemoveProperties("hive", "testhive", Maps.newHashMap()),

--- a/metacat-main/src/test/groovy/com/netflix/metacat/main/manager/ConnectorManagerSpec.groovy
+++ b/metacat-main/src/test/groovy/com/netflix/metacat/main/manager/ConnectorManagerSpec.groovy
@@ -160,7 +160,7 @@ class ConnectorManagerSpec extends Specification {
         1 * context.getConfiguration() >> [:]
         noExceptionThrown()
         expect:
-        connectorManager.getCatalogs().size() == 7
+        connectorManager.getCatalogConfigs().size() == 7
         connectorManager.getTypeConverter('hive') == connectorTypeConverter
         connectorManager.getInfoConverter('hive') == connectorInfoConverter
         connectorManager.getDatabaseService(QualifiedName.fromString('h/d1')) == databaseService1


### PR DESCRIPTION
- CatalogDto has been updated to include ClusterDto (region, account, env) info.
- Connectors now expose a getCatalogService() API
- getCatalogs() returns a list of all catalogs including those known by the proxy Catalog. getCatalogConfigs() returns a list of the static catalogs (i.e existing functionality)