### PR TITLE
Fixed issue where getPartition calls for audit tables were falling back to default logic after failing query because of invalid SQL

### DIFF
--- a/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/monitoring/HiveMetrics.java
+++ b/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/monitoring/HiveMetrics.java
@@ -32,6 +32,7 @@ public enum HiveMetrics {
      * hive sql lock error.
      */
     CounterHiveSqlLockError(Type.counter, "hiveSqlLockError"),
+    CounterHiveGetTablePartitionsTimeoutFailure(Type.counter,"getPartitionsTimeoutFailure"),
     CounterHiveExperimentGetTablePartitionsFailure(Type.counter,"experimentGetPartitionsFailure"),
     CounterHivePartitionPathIsNotDir(Type.counter,"partitionPathIsNotDir"),
     CounterHivePartitionFileSystemCall(Type.counter,"partitionFileSystemCall"),

--- a/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/util/HiveConnectorFastServiceMetric.java
+++ b/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/util/HiveConnectorFastServiceMetric.java
@@ -17,7 +17,6 @@
 package com.netflix.metacat.connector.hive.util;
 
 import com.netflix.metacat.connector.hive.monitoring.HiveMetrics;
-import com.netflix.spectator.api.Counter;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spectator.api.Timer;
 import lombok.Getter;
@@ -37,7 +36,6 @@ import java.util.concurrent.TimeUnit;
 @Slf4j
 public class HiveConnectorFastServiceMetric {
     private final HashMap<String, Timer> timerMap = new HashMap<>();
-    private final Counter getHiveTablePartsFailureCounter;
 
     /**
      * Constructor.
@@ -65,9 +63,6 @@ public class HiveConnectorFastServiceMetric {
             HiveMetrics.TagDropHivePartitions.getMetricName()));
         timerMap.put(HiveMetrics.TagAddDropPartitions.getMetricName(), createTimer(registry,
             HiveMetrics.TagAddDropPartitions.getMetricName()));
-
-        getHiveTablePartsFailureCounter = registry.counter(
-            HiveMetrics.CounterHiveExperimentGetTablePartitionsFailure.getMetricName());
     }
 
     private Timer createTimer(final Registry registry, final String requestTag) {


### PR DESCRIPTION
Also, on sql timeouts, made the code change to propagate the error instead of falling back to the default logic.