### PR TITLE
Fixed issue where getTable API for an iceberg table with invalid location throws a HTTP 500 instead of HTTP 400.

### DIFF
--- a/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/iceberg/IcebergTableHandler.java
+++ b/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/iceberg/IcebergTableHandler.java
@@ -27,11 +27,13 @@ import com.netflix.iceberg.ScanSummary;
 import com.netflix.iceberg.Schema;
 import com.netflix.iceberg.Table;
 import com.netflix.iceberg.TableMetadata;
+import com.netflix.iceberg.exceptions.NoSuchTableException;
 import com.netflix.iceberg.expressions.Expression;
 import com.netflix.metacat.common.QualifiedName;
 import com.netflix.metacat.common.exception.MetacatBadRequestException;
 import com.netflix.metacat.common.exception.MetacatNotSupportedException;
 import com.netflix.metacat.common.server.connectors.ConnectorContext;
+import com.netflix.metacat.common.server.connectors.exception.InvalidMetaException;
 import com.netflix.metacat.common.server.connectors.model.PartitionListRequest;
 import com.netflix.metacat.common.server.partition.parser.ParseException;
 import com.netflix.metacat.common.server.partition.parser.PartitionParser;
@@ -145,6 +147,8 @@ public class IcebergTableHandler {
             this.icebergTableCriteria.checkCriteria(tableName, tableMetadataLocation);
             log.debug("Loading icebergTable {} from {}", tableName, tableMetadataLocation);
             return new IcebergMetastoreTables(tableMetadataLocation).load(tableName.toString());
+        } catch (NoSuchTableException e) {
+            throw new InvalidMetaException(tableName, e);
         } finally {
             final long duration = registry.clock().wallTime() - start;
             log.info("Time taken to getIcebergTable {} is {} ms", tableName, duration);

--- a/metacat-functional-tests/src/functionalTest/groovy/com/netflix/metacat/MetacatSmokeSpec.groovy
+++ b/metacat-functional-tests/src/functionalTest/groovy/com/netflix/metacat/MetacatSmokeSpec.groovy
@@ -375,6 +375,12 @@ class MetacatSmokeSpec extends Specification {
         then:
         noExceptionThrown()
         when:
+        FileUtils.moveFile(metadataFile, new File(metadataFile.getAbsolutePath() + '1'))
+        api.getTable(catalogName, databaseName, tableName, true, false, false)
+        then:
+        thrown(MetacatBadRequestException)
+        FileUtils.moveFile(new File(metadataFile.getAbsolutePath() + '1'), metadataFile)
+        when:
         def metadataLocation2 = '/tmp/data/00089-5641e8bf-06b8-46b3-a0fc-5c867f5bca58.metadata.json'
         def metadata2 = [table_type: 'ICEBERG', metadata_location: metadataLocation2, previous_metadata_location: metadataLocation1]
         tableDto.getMetadata().putAll(metadata2)


### PR DESCRIPTION
Iceberg API to read a table throws a NoSuchTableException when the metadata location is invalid. Modified the code to catch the exception and propagate it as InvalidMetaException.