### PR TITLE
Reverted part of the changes from commit 3fc06ecc4c5ecb818087e20a29a82744a1c32fbd

### DIFF
--- a/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/sql/DirectSqlGetPartition.java
+++ b/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/sql/DirectSqlGetPartition.java
@@ -49,7 +49,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.dao.QueryTimeoutException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.ResultSetExtractor;
 import org.springframework.jdbc.core.SqlParameterValue;
@@ -586,14 +585,6 @@ public class DirectSqlGetPartition {
                     null, null,
                     null, sort, pageable, forceDisableAudit);
             }
-        } catch (QueryTimeoutException e) {
-            //
-            // On query timeouts, propagate the error.
-            // API calling into this method will throw a HTTP 500 error with the timeout message.
-            //
-            registry.counter(registry.createId(HiveMetrics.CounterHiveGetTablePartitionsTimeoutFailure.getMetricName())
-                .withTags(tableQName.parts())).increment();
-            throw e;
         } catch (Exception e) {
             log.warn("Experiment: Get partitions for for table {} filter {}"
                     + " failed with error {}", tableQName.toString(), filterExpression,


### PR DESCRIPTION
Reverted the query time out change since few getPartitions requests for huge tables timed out instead of falling back.