### PR TITLE
Add a UserMetadataService API to Delete Stale Definition Metadata

### DIFF
--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/usermetadata/UserMetadataService.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/usermetadata/UserMetadataService.java
@@ -81,6 +81,16 @@ public interface UserMetadataService {
     }
 
     /**
+     * Delete definition metadata older than the given timestamp for names
+     * that match the given pattern.
+     *
+     * @param qualifiedNamePattern The pattern to match against qualified names.
+     * @param lastUpdated The lastUpdated timestamp to use as a cut-off.
+     */
+    default void deleteStaleDefinitionMetadata(String qualifiedNamePattern, Date lastUpdated) {
+    }
+
+    /**
      * Delete definition metadata and soft delete data metadata.
      *
      * @param userId  username

--- a/metacat-metadata-mysql/src/test/groovy/com/netflix/metacat/metadata/mysql/MysqlUserMetadataServiceSpec.groovy
+++ b/metacat-metadata-mysql/src/test/groovy/com/netflix/metacat/metadata/mysql/MysqlUserMetadataServiceSpec.groovy
@@ -17,6 +17,8 @@ import com.google.common.collect.Lists
 import com.netflix.metacat.common.QualifiedName
 import com.netflix.metacat.testdata.provider.DataDtoProvider
 
+import java.time.Instant
+
 /**
  * Tests for MysqlUserMetadataService.
  * TODO: Need to move this to integration-test
@@ -98,5 +100,10 @@ class MysqlUserMetadataServiceSpec extends BaseSpec {
         mysqlUserMetadataService.deleteDataMetadata(uris)
         then:
         mysqlUserMetadataService.getDeletedDataMetadataUris(new Date(), 0, 10).size() == 0
+        when:
+        mysqlUserMetadataService.saveMetadata(userName, table, true)
+        mysqlUserMetadataService.deleteStaleDefinitionMetadata("prod%", Date.from(Instant.now().plusSeconds(500)))
+        then:
+        !mysqlUserMetadataService.getDefinitionMetadata(qualifiedName).isPresent()
     }
 }


### PR DESCRIPTION
- Will allow for deleting metadata that is older than a given timestamp.