### PR TITLE
On getTable for an iceberg table, return the manifest content as part of the metadata properties

### DIFF
--- a/metacat-client/build.gradle
+++ b/metacat-client/build.gradle
@@ -15,12 +15,6 @@
  *     limitations under the License.
  *
  */
-
-compileJava {
-    sourceCompatibility = 1.7
-    targetCompatibility = 1.7
-}
-
 dependencies {
     /*******************************
      * API Dependencies

--- a/metacat-client/src/main/java/com/netflix/metacat/client/api/MetacatV1.java
+++ b/metacat-client/src/main/java/com/netflix/metacat/client/api/MetacatV1.java
@@ -254,6 +254,30 @@ public interface MetacatV1 {
      * @param includeDataMetadata       true if the data metadata to be included
      * @return table
      */
+    default TableDto getTable(
+            String catalogName,
+            String databaseName,
+            String tableName,
+            Boolean includeInfo,
+            Boolean includeDefinitionMetadata,
+            Boolean includeDataMetadata
+    ) {
+        return getTable(catalogName, databaseName, tableName, includeInfo,
+            includeDefinitionMetadata, includeDataMetadata, false);
+    }
+
+    /**
+     * Get the table.
+     *
+     * @param catalogName               catalog name
+     * @param databaseName              database name
+     * @param tableName                 table name.
+     * @param includeInfo               true if the details need to be included
+     * @param includeDefinitionMetadata true if the definition metadata to be included
+     * @param includeDataMetadata       true if the data metadata to be included
+     * @param includeInfoDetails        true if the more info details to be included
+     * @return table
+     */
     @GET
     @Path("catalog/{catalog-name}/database/{database-name}/table/{table-name}")
     @Consumes(MediaType.APPLICATION_JSON)
@@ -273,7 +297,10 @@ public interface MetacatV1 {
             Boolean includeDefinitionMetadata,
         @DefaultValue("true")
         @QueryParam("includeDataMetadata")
-            Boolean includeDataMetadata
+            Boolean includeDataMetadata,
+        @DefaultValue("false")
+        @QueryParam("includeInfoDetails")
+            Boolean includeInfoDetails
     );
 
     /**

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/api/v1/MetacatV1.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/api/v1/MetacatV1.java
@@ -45,13 +45,38 @@ public interface MetacatV1 {
      * @param includeDataMetadata       true if the data metadata to be included
      * @return table
      */
-    TableDto getTable(
+    default TableDto getTable(
         final String catalogName,
         final String databaseName,
         final String tableName,
         final boolean includeInfo,
         final boolean includeDefinitionMetadata,
         final boolean includeDataMetadata
+    ) {
+        return getTable(catalogName, databaseName, tableName, includeInfo, includeDefinitionMetadata,
+            includeDataMetadata, false);
+    }
+
+    /**
+     * Get the table.
+     *
+     * @param catalogName               catalog name
+     * @param databaseName              database name
+     * @param tableName                 table name.
+     * @param includeInfo               true if the details need to be included
+     * @param includeDefinitionMetadata true if the definition metadata to be included
+     * @param includeDataMetadata       true if the data metadata to be included
+     * @param includeInfoDetails        true if the more info details to be included
+     * @return table
+     */
+    TableDto getTable(
+        final String catalogName,
+        final String databaseName,
+        final String tableName,
+        final boolean includeInfo,
+        final boolean includeDefinitionMetadata,
+        final boolean includeDataMetadata,
+        final boolean includeInfoDetails
     );
 
     /**

--- a/metacat-common/build.gradle
+++ b/metacat-common/build.gradle
@@ -15,12 +15,6 @@
  *     limitations under the License.
  *
  */
-
-compileJava {
-    sourceCompatibility = 1.7
-    targetCompatibility = 1.7
-}
-
 dependencies {
     /*******************************
      * API Dependencies

--- a/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/iceberg/IcebergTableWrapper.java
+++ b/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/iceberg/IcebergTableWrapper.java
@@ -1,0 +1,31 @@
+/*
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
+
+package com.netflix.metacat.connector.hive.iceberg;
+
+import com.netflix.iceberg.Table;
+import lombok.Data;
+
+import java.util.Map;
+
+/**
+ * This class represents the iceberg table.
+ */
+@Data
+public class IcebergTableWrapper {
+    private final Table table;
+    private final Map<String, String> extraProperties;
+}

--- a/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/sql/HiveConnectorFastPartitionService.java
+++ b/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/sql/HiveConnectorFastPartitionService.java
@@ -358,7 +358,7 @@ public class HiveConnectorFastPartitionService extends HiveConnectorPartitionSer
         final PartitionListRequest partitionsRequest) {
         final QualifiedName tableName = tableInfo.getName();
         final com.netflix.iceberg.Table icebergTable = this.icebergTableHandler.getIcebergTable(tableName,
-            HiveTableUtil.getIcebergTableMetadataLocation(tableInfo));
+            HiveTableUtil.getIcebergTableMetadataLocation(tableInfo), false).getTable();
         final Pageable pageable = partitionsRequest.getPageable();
         final Map<String, ScanSummary.PartitionMetrics> partitionMap
             = icebergTableHandler.getIcebergTablePartitionMap(tableName, partitionsRequest, icebergTable);

--- a/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/sql/HiveConnectorFastTableService.java
+++ b/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/sql/HiveConnectorFastTableService.java
@@ -26,6 +26,7 @@ import com.netflix.metacat.connector.hive.HiveConnectorTableService;
 import com.netflix.metacat.connector.hive.IMetacatHiveClient;
 import com.netflix.metacat.connector.hive.converters.HiveConnectorInfoConverter;
 import com.netflix.metacat.connector.hive.iceberg.IcebergTableHandler;
+import com.netflix.metacat.connector.hive.iceberg.IcebergTableWrapper;
 import com.netflix.metacat.connector.hive.util.HiveTableUtil;
 import com.netflix.spectator.api.Registry;
 import lombok.extern.slf4j.Slf4j;
@@ -96,7 +97,8 @@ public class HiveConnectorFastTableService extends HiveConnectorTableService {
             return info;
         }
         final String tableLoc = HiveTableUtil.getIcebergTableMetadataLocation(info);
-        final com.netflix.iceberg.Table icebergTable = this.icebergTableHandler.getIcebergTable(name, tableLoc);
+        final IcebergTableWrapper icebergTable =
+            this.icebergTableHandler.getIcebergTable(name, tableLoc, requestContext.isIncludeMetadata());
         return this.hiveMetacatConverters.fromIcebergTableToTableInfo(name,
             icebergTable, tableLoc, info);
     }

--- a/metacat-connector-hive/src/test/groovy/com/netflix/metacat/connector/hive/HiveConnectorFastPartitionSpec.groovy
+++ b/metacat-connector-hive/src/test/groovy/com/netflix/metacat/connector/hive/HiveConnectorFastPartitionSpec.groovy
@@ -30,6 +30,7 @@ import com.netflix.metacat.connector.hive.client.thrift.MetacatHiveClient
 import com.netflix.metacat.connector.hive.converters.HiveConnectorInfoConverter
 import com.netflix.metacat.connector.hive.converters.HiveTypeConverter
 import com.netflix.metacat.connector.hive.iceberg.IcebergTableHandler
+import com.netflix.metacat.connector.hive.iceberg.IcebergTableWrapper
 import com.netflix.metacat.connector.hive.sql.DirectSqlGetPartition
 import com.netflix.metacat.connector.hive.sql.DirectSqlSavePartition
 import com.netflix.metacat.connector.hive.sql.HiveConnectorFastPartitionService
@@ -85,7 +86,7 @@ class HiveConnectorFastPartitionSpec extends Specification {
         metric3.dataTimestampMillis() >> null
         metric3.recordCount() >> 1
 
-        icebergTableHandler.getIcebergTable(_,_) >> Mock(Table)
+        icebergTableHandler.getIcebergTable(_,_,_) >> new IcebergTableWrapper(Mock(Table), [:])
         icebergTableHandler.getIcebergTablePartitionMap(_,_,_) >> ["dateint=20170101/hour=1": metric1,
                                                                    "dateint=20170102/hour=1": metric1,
                                                                    "dateint=20170103/hour=1": metric1,

--- a/metacat-connector-hive/src/test/groovy/com/netflix/metacat/connector/hive/HiveConnectorIcebergTableHandlerSpec.groovy
+++ b/metacat-connector-hive/src/test/groovy/com/netflix/metacat/connector/hive/HiveConnectorIcebergTableHandlerSpec.groovy
@@ -75,9 +75,8 @@ class HiveConnectorIcebergTableHandlerSpec extends Specification{
         def icebergHandler = new IcebergTableHandler(connectorContext, criteriaImpl, icebergTableOp)
 
         when:
-        ret = icebergHandler.getIcebergTable(QualifiedName.fromString("testing/db/table"), "abc")
+        icebergHandler.getIcebergTable(QualifiedName.fromString("testing/db/table"), "abc", false)
         then:
         thrown(MetacatException)
     }
-
 }

--- a/metacat-connector-hive/src/test/groovy/com/netflix/metacat/connector/hive/converters/HiveConnectorInfoConvertorSpec.groovy
+++ b/metacat-connector-hive/src/test/groovy/com/netflix/metacat/connector/hive/converters/HiveConnectorInfoConvertorSpec.groovy
@@ -30,6 +30,7 @@ import com.netflix.metacat.common.server.connectors.model.PartitionInfo
 import com.netflix.metacat.common.server.connectors.model.StorageInfo
 import com.netflix.metacat.common.server.connectors.model.TableInfo
 import com.netflix.metacat.common.type.VarcharType
+import com.netflix.metacat.connector.hive.iceberg.IcebergTableWrapper
 import com.netflix.metacat.connector.hive.sql.DirectSqlTable
 import org.apache.hadoop.hive.metastore.api.FieldSchema
 import org.apache.hadoop.hive.metastore.api.Partition
@@ -500,6 +501,7 @@ class HiveConnectorInfoConvertorSpec extends Specification{
 
     def "test fromIcebergTableToTableInfo"() {
         def icebergTable = Mock(com.netflix.iceberg.Table)
+        def icebergTableWrapper = new IcebergTableWrapper(icebergTable, [:])
         def partSpec = Mock(PartitionSpec)
         def field = Mock(PartitionField)
         def schema =  Mock(Schema)
@@ -508,7 +510,7 @@ class HiveConnectorInfoConvertorSpec extends Specification{
         def type = Mock(Type)
         when:
         def tableInfo = converter.fromIcebergTableToTableInfo(QualifiedName.ofTable('c', 'd', 't'),
-           icebergTable, "/tmp/test", TableInfo.builder().build() )
+            icebergTableWrapper, "/tmp/test", TableInfo.builder().build() )
         then:
         1 * icebergTable.properties() >> ["test":"abd"]
         2 * icebergTable.spec() >>  partSpec

--- a/metacat-functional-tests/src/functionalTest/groovy/com/netflix/metacat/MetacatSmokeSpec.groovy
+++ b/metacat-functional-tests/src/functionalTest/groovy/com/netflix/metacat/MetacatSmokeSpec.groovy
@@ -401,6 +401,12 @@ class MetacatSmokeSpec extends Specification {
         noExceptionThrown()
         updatedTable.getMetadata().get('metadata_location') == metadataLocation2
         updatedTable.getMetadata().get('partition_spec') != 'invalid'
+        !updatedTable.getMetadata().containsKey('metadata_content')
+        when:
+        api.updateTable(catalogName, databaseName, tableName, tableDto)
+        def tableWithDetails = api.getTable(catalogName, databaseName, tableName, true, false, false, true)
+        then:
+        tableWithDetails.getMetadata().get('metadata_content') != null
         when:
         api.deleteTable(catalogName, databaseName, renamedTableName)
         api.renameTable(catalogName, databaseName, tableName, renamedTableName)

--- a/metacat-main/src/main/java/com/netflix/metacat/main/api/v1/MetacatController.java
+++ b/metacat-main/src/main/java/com/netflix/metacat/main/api/v1/MetacatController.java
@@ -651,7 +651,10 @@ public class MetacatController implements MetacatV1 {
             defaultValue = "true"
         ) final boolean includeDefinitionMetadata,
         @ApiParam(value = "Whether to include user data metadata information to the response")
-        @RequestParam(name = "includeDataMetadata", defaultValue = "true") final boolean includeDataMetadata
+        @RequestParam(name = "includeDataMetadata", defaultValue = "true") final boolean includeDataMetadata,
+        @ApiParam(value = "Whether to include more info details to the response. This value is considered only if "
+            + "includeInfo is true.")
+        @RequestParam(name = "includeInfoDetails", defaultValue = "false") final boolean includeInfoDetails
     ) {
         final QualifiedName name = this.requestWrapper.qualifyName(
             () -> QualifiedName.ofTable(catalogName, databaseName, tableName)
@@ -667,6 +670,7 @@ public class MetacatController implements MetacatV1 {
                         .includeDefinitionMetadata(includeDefinitionMetadata)
                         .includeDataMetadata(includeDataMetadata)
                         .disableOnReadMetadataIntercetor(false)
+                        .includeMetadataFromConnector(includeInfoDetails)
                         .useCache(true)
                         .build()
                 );


### PR DESCRIPTION
At present, the json content is returned as a string. Also removed the java compatibility to 1.7 for client modules.