### PR TITLE
Add a service to provide Aliases for Table Names

### DIFF
--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/AliasServiceProperties.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/AliasServiceProperties.java
@@ -1,0 +1,32 @@
+/*
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+
+package com.netflix.metacat.common.server.properties;
+
+import lombok.Data;
+
+/**
+ * Alias Service Properties.
+ *
+ * @author rveeramacheneni
+ * @since 1.3.0
+ */
+@Data
+public class AliasServiceProperties {
+    private boolean enabled;
+}

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/Config.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/Config.java
@@ -437,5 +437,11 @@ public interface Config {
      * @return Iceberg table partition uri scheme.
      */
     String getIcebergPartitionUriScheme();
+
+    /**
+     * Whether the table alias is enabled.
+     * @return True if it is.
+     */
+    boolean isTableAliasEnabled();
 }
 

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/DefaultConfigImpl.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/DefaultConfigImpl.java
@@ -515,4 +515,12 @@ public class DefaultConfigImpl implements Config {
     public String getIcebergPartitionUriScheme() {
         return this.metacatProperties.getHive().getIceberg().getPartitionUriScheme();
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isTableAliasEnabled() {
+        return this.metacatProperties.getAliasServiceProperties().isEnabled();
+    }
 }

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/MetacatProperties.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/MetacatProperties.java
@@ -63,4 +63,6 @@ public class MetacatProperties {
     private CacheProperties cache = new CacheProperties();
     @NonNull
     private AuthorizationServiceProperties authorization = new AuthorizationServiceProperties();
+    @NonNull
+    private AliasServiceProperties aliasServiceProperties = new AliasServiceProperties();
 }

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/usermetadata/AliasService.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/usermetadata/AliasService.java
@@ -1,0 +1,39 @@
+/*
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package com.netflix.metacat.common.server.usermetadata;
+
+import com.netflix.metacat.common.QualifiedName;
+import lombok.NonNull;
+
+/**
+ * Alias Service API.
+ *
+ * @author rveeramacheneni
+ * @since 1.3.0
+ */
+public interface AliasService {
+    /**
+     * Returns the original table name if present.
+     *
+     * @param tableAlias the table alias.
+     * @return the original name if present or the alias otherwise.
+     */
+    default QualifiedName getTableName(@NonNull final QualifiedName tableAlias) {
+        return tableAlias;
+    }
+}

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/usermetadata/DefaultAliasService.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/usermetadata/DefaultAliasService.java
@@ -1,0 +1,27 @@
+/*
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package com.netflix.metacat.common.server.usermetadata;
+
+/**
+ * Alias Service API.
+ *
+ * @author rveeramacheneni
+ * @since 1.3.0
+ */
+public class DefaultAliasService implements AliasService {
+}

--- a/metacat-main/src/main/java/com/netflix/metacat/main/configs/ServicesConfig.java
+++ b/metacat-main/src/main/java/com/netflix/metacat/main/configs/ServicesConfig.java
@@ -20,7 +20,9 @@ package com.netflix.metacat.main.configs;
 import com.netflix.metacat.common.server.converter.ConverterUtil;
 import com.netflix.metacat.common.server.events.MetacatEventBus;
 import com.netflix.metacat.common.server.properties.Config;
+import com.netflix.metacat.common.server.usermetadata.AliasService;
 import com.netflix.metacat.common.server.usermetadata.AuthorizationService;
+import com.netflix.metacat.common.server.usermetadata.DefaultAliasService;
 import com.netflix.metacat.common.server.usermetadata.DefaultAuthorizationService;
 import com.netflix.metacat.common.server.usermetadata.DefaultLookupService;
 import com.netflix.metacat.common.server.usermetadata.DefaultTagService;
@@ -97,6 +99,16 @@ public class ServicesConfig {
         final Config config
     ) {
         return new DefaultAuthorizationService(config);
+    }
+
+    /**
+     * Alias service.
+     * @return an instance of the Alias service.
+     */
+    @Bean
+    @ConditionalOnMissingBean(AliasService.class)
+    public AliasService aliasService() {
+        return new DefaultAliasService();
     }
 
     /**


### PR DESCRIPTION
- No functionality changes in this PR, just an interface addition. Existing tests should suffice.