### PR TITLE
Capturing the username when a thrift call is made. 

### DIFF
--- a/metacat-common/src/main/java/com/netflix/metacat/common/MetacatRequestContext.java
+++ b/metacat-common/src/main/java/com/netflix/metacat/common/MetacatRequestContext.java
@@ -58,7 +58,7 @@ public class MetacatRequestContext {
     // TODO: Move to Java 8 and use java.time.Instant
     private final long timestamp = new Date().getTime();
 
-    private final String userName;
+    private String userName;
     private final String clientAppName;
     private final String clientId;
     private final String jobId;
@@ -122,6 +122,14 @@ public class MetacatRequestContext {
         sb.append(", scheme='").append(scheme).append('\'');
         sb.append('}');
         return sb.toString();
+    }
+
+    /**
+     * Returns the username.
+     * @param userName user name
+     */
+    public void setUserName(final String userName) {
+        this.userName = userName;
     }
 
     /**

--- a/metacat-functional-tests/src/functionalTest/groovy/com/netflix/metacat/MetacatSmokeThriftSpec.groovy
+++ b/metacat-functional-tests/src/functionalTest/groovy/com/netflix/metacat/MetacatSmokeThriftSpec.groovy
@@ -228,14 +228,15 @@ class MetacatSmokeThriftSpec extends Specification {
         } catch (Exception ignored) {
         }
         def uri = getUri(databaseName, tableName)
-        def dto = DataDtoProvider.getTable(catalogName, databaseName, tableName, 'test', uri)
+        def dto = DataDtoProvider.getTable(catalogName, databaseName, tableName, null, uri)
         def hiveTable = new Table(hiveConverter.fromTableInfo(converter.fromTableDto(dto)))
         when:
         client.createTable(hiveTable)
         then:
         def table = client.getTable(databaseName, tableName)
-        assert table != null && table.getTableName() == tableName
-        assert table.getSd().getLocation() == uri
+        table != null && table.getTableName() == tableName
+        table.getSd().getLocation() == uri
+        table.getOwner() == client.getConf().getUser()
         when:
         client.createTable(hiveTable)
         then:

--- a/metacat-thrift/src/main/java/com/netflix/metacat/thrift/CatalogThriftHiveMetastore.java
+++ b/metacat-thrift/src/main/java/com/netflix/metacat/thrift/CatalogThriftHiveMetastore.java
@@ -1202,6 +1202,7 @@ public class CatalogThriftHiveMetastore extends FacebookBase
         final List<String> groupNames
     ) throws TException {
         //TODO: Handle setting the privileges
+        MetacatContextManager.getContext().setUserName(userName);
         return get_partition(dbName, tblName, partVals);
     }
 
@@ -1346,6 +1347,7 @@ public class CatalogThriftHiveMetastore extends FacebookBase
         final List<String> groupNames
     ) throws TException {
         //TODO: Handle setting the privileges
+        MetacatContextManager.getContext().setUserName(userName);
         return get_partitions_ps(dbName, tblName, partVals, maxParts);
     }
 
@@ -1378,6 +1380,7 @@ public class CatalogThriftHiveMetastore extends FacebookBase
         final List<String> groupNames
     ) throws TException {
         //TODO: Handle setting the privileges
+        MetacatContextManager.getContext().setUserName(userName);
         return get_partitions(dbName, tblName, maxParts);
     }
 
@@ -1397,6 +1400,7 @@ public class CatalogThriftHiveMetastore extends FacebookBase
     public PrincipalPrivilegeSet get_privilege_set(final HiveObjectRef hiveObject, final String userName,
                                                    final List<String> groupNames)
         throws TException {
+        MetacatContextManager.getContext().setUserName(userName);
         return requestWrapper("get_privilege_set", new Object[]{hiveObject, userName, groupNames},
             () -> {
                 Map<String, List<PrivilegeGrantInfo>> groupPrivilegeSet = null;
@@ -1912,6 +1916,7 @@ public class CatalogThriftHiveMetastore extends FacebookBase
      */
     @Override
     public List<String> set_ugi(final String userName, final List<String> groupNames) throws TException {
+        MetacatContextManager.getContext().setUserName(userName);
         return requestWrapper("set_ugi", new Object[]{userName, groupNames}, () -> {
             Collections.addAll(groupNames, userName);
             return groupNames;


### PR DESCRIPTION
Once a thrift connection is established, the hive client calls the set_ugi method by passing in the username. During this call, Metacat captures the username and sets in the request context. The same request context is used for subsequent thrift calls.