### PR TITLE
Added extra conditional check during update of an Iceberg table schema modification.

### DIFF
--- a/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/iceberg/IcebergTableHandler.java
+++ b/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/iceberg/IcebergTableHandler.java
@@ -184,7 +184,9 @@ public class IcebergTableHandler {
     public boolean update(final TableInfo tableInfo) {
         boolean result = false;
         final List<FieldInfo> fields = tableInfo.getFields();
-        if (fields != null && !fields.isEmpty()) {
+        if (fields != null && !fields.isEmpty()
+            // This parameter is only sent during data change and not during schema change.
+            && Strings.isNullOrEmpty(tableInfo.getMetadata().get(DirectSqlTable.PARAM_PREVIOUS_METADATA_LOCATION))) {
             final QualifiedName tableName = tableInfo.getName();
             final String tableMetadataLocation = HiveTableUtil.getIcebergTableMetadataLocation(tableInfo);
             if (Strings.isNullOrEmpty(tableMetadataLocation)) {


### PR DESCRIPTION
Only update an iceberg schema if the request contains fields and the previous_metadata_location is not sent as part of the table parameters.