### PR TITLE
Add a TABLE_RENAME SNS Message Type

### DIFF
--- a/metacat-common/src/main/java/com/netflix/metacat/common/dto/notifications/sns/SNSMessageFactory.java
+++ b/metacat-common/src/main/java/com/netflix/metacat/common/dto/notifications/sns/SNSMessageFactory.java
@@ -23,6 +23,7 @@ import com.netflix.metacat.common.dto.notifications.sns.messages.AddPartitionMes
 import com.netflix.metacat.common.dto.notifications.sns.messages.CreateTableMessage;
 import com.netflix.metacat.common.dto.notifications.sns.messages.DeletePartitionMessage;
 import com.netflix.metacat.common.dto.notifications.sns.messages.DeleteTableMessage;
+import com.netflix.metacat.common.dto.notifications.sns.messages.RenameTableMessage;
 import com.netflix.metacat.common.dto.notifications.sns.messages.UpdateTableMessage;
 import com.netflix.metacat.common.dto.notifications.sns.messages.UpdateTablePartitionsMessage;
 import lombok.NonNull;
@@ -67,6 +68,8 @@ public class SNSMessageFactory {
                     return this.mapper.readValue(json, DeleteTableMessage.class);
                 case TABLE_UPDATE:
                     return this.mapper.readValue(json, UpdateTableMessage.class);
+                case TABLE_RENAME:
+                    return this.mapper.readValue(json, RenameTableMessage.class);
                 case TABLE_PARTITIONS_UPDATE:
                     return this.mapper.readValue(json, UpdateTablePartitionsMessage.class);
                 case PARTITION_ADD:

--- a/metacat-common/src/main/java/com/netflix/metacat/common/dto/notifications/sns/SNSMessageType.java
+++ b/metacat-common/src/main/java/com/netflix/metacat/common/dto/notifications/sns/SNSMessageType.java
@@ -40,6 +40,11 @@ public enum SNSMessageType {
     TABLE_UPDATE,
 
     /**
+     * When a table is renamed.
+     */
+    TABLE_RENAME,
+
+    /**
      * When the partitions for a table are either created or deleted.
      */
     TABLE_PARTITIONS_UPDATE,

--- a/metacat-common/src/main/java/com/netflix/metacat/common/dto/notifications/sns/messages/RenameTableMessage.java
+++ b/metacat-common/src/main/java/com/netflix/metacat/common/dto/notifications/sns/messages/RenameTableMessage.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright 2016 Netflix, Inc.
+ *  Copyright 2020 Netflix, Inc.
  *
  *     Licensed under the Apache License, Version 2.0 (the "License");
  *     you may not use this file except in compliance with the License.
@@ -27,18 +27,17 @@ import lombok.Getter;
 import lombok.ToString;
 
 /**
- * A message sent when a table is updated.
+ * A message sent when a table is renamed.
  *
- * @author tgianos
- * @since 0.1.47
+ * @author rveeramacheneni
  */
 @Getter
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-public class UpdateTableMessage extends UpdateOrRenameTableMessageBase {
+public class RenameTableMessage extends UpdateOrRenameTableMessageBase {
 
     /**
-     * Create a new UpdateTableMessage.
+     * Create a new RenameTableMessage.
      *
      * @param id        The unique id of the message
      * @param timestamp The number of milliseconds since epoch that this message occurred
@@ -47,13 +46,13 @@ public class UpdateTableMessage extends UpdateOrRenameTableMessageBase {
      * @param payload   The payload of the notification
      */
     @JsonCreator
-    public UpdateTableMessage(
+    public RenameTableMessage(
         @JsonProperty("id") final String id,
         @JsonProperty("timestamp") final long timestamp,
         @JsonProperty("requestId") final String requestId,
         @JsonProperty("name") final String name,
         @JsonProperty("payload") final UpdatePayload<TableDto> payload
     ) {
-        super(id, timestamp, requestId, name, payload, SNSMessageType.TABLE_UPDATE);
+        super(id, timestamp, requestId, name, payload, SNSMessageType.TABLE_RENAME);
     }
 }

--- a/metacat-common/src/main/java/com/netflix/metacat/common/dto/notifications/sns/messages/UpdateOrRenameTableMessageBase.java
+++ b/metacat-common/src/main/java/com/netflix/metacat/common/dto/notifications/sns/messages/UpdateOrRenameTableMessageBase.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright 2016 Netflix, Inc.
+ *  Copyright 2020 Netflix, Inc.
  *
  *     Licensed under the Apache License, Version 2.0 (the "License");
  *     you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ package com.netflix.metacat.common.dto.notifications.sns.messages;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.netflix.metacat.common.dto.TableDto;
+import com.netflix.metacat.common.dto.notifications.sns.SNSMessage;
 import com.netflix.metacat.common.dto.notifications.sns.SNSMessageType;
 import com.netflix.metacat.common.dto.notifications.sns.payloads.UpdatePayload;
 import lombok.EqualsAndHashCode;
@@ -27,33 +28,34 @@ import lombok.Getter;
 import lombok.ToString;
 
 /**
- * A message sent when a table is updated.
+ * Base message type for Update and Rename messages.
  *
- * @author tgianos
- * @since 0.1.47
+ * @author rveeramacheneni
  */
 @Getter
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-public class UpdateTableMessage extends UpdateOrRenameTableMessageBase {
+public abstract class UpdateOrRenameTableMessageBase extends SNSMessage<UpdatePayload<TableDto>> {
 
     /**
-     * Create a new UpdateTableMessage.
+     * Ctor for this base class.
      *
-     * @param id        The unique id of the message
-     * @param timestamp The number of milliseconds since epoch that this message occurred
-     * @param requestId The id of the API request that generated this and possibly other messages. Used for grouping
-     * @param name      The qualified name of the resource that this notification is being generated for
-     * @param payload   The payload of the notification
+     * @param id          The unique id of the message
+     * @param timestamp   The number of milliseconds since epoch that this message occurred
+     * @param requestId   The id of the API request that generated this and possibly other messages. Used for grouping
+     * @param name        The qualified name of the resource that this notification is being generated for
+     * @param payload     The payload of the notification
+     * @param messageType Whether this is an Update or Rename message
      */
     @JsonCreator
-    public UpdateTableMessage(
+    public UpdateOrRenameTableMessageBase(
         @JsonProperty("id") final String id,
         @JsonProperty("timestamp") final long timestamp,
         @JsonProperty("requestId") final String requestId,
         @JsonProperty("name") final String name,
-        @JsonProperty("payload") final UpdatePayload<TableDto> payload
+        @JsonProperty("payload") final UpdatePayload<TableDto> payload,
+        final SNSMessageType messageType
     ) {
-        super(id, timestamp, requestId, name, payload, SNSMessageType.TABLE_UPDATE);
+        super(id, timestamp, requestId, messageType, name, payload);
     }
 }

--- a/metacat-common/src/test/groovy/com/netflix/metacat/common/dto/notifications/sns/SNSMessageFactorySpec.groovy
+++ b/metacat-common/src/test/groovy/com/netflix/metacat/common/dto/notifications/sns/SNSMessageFactorySpec.groovy
@@ -87,6 +87,21 @@ class SNSMessageFactorySpec extends Specification {
             )
         )       | UpdateTableMessage.class
         this.mapper.writeValueAsString(
+            new RenameTableMessage(
+                UUID.randomUUID().toString(),
+                Instant.now().toEpochMilli(),
+                UUID.randomUUID().toString(),
+                UUID.randomUUID().toString(),
+                new UpdatePayload<TableDto>(
+                    new TableDto(),
+                    JsonDiff.asJsonPatch(
+                        this.mapper.readTree("{\"a\":\"b\"}"),
+                        this.mapper.readTree("{\"a\":\"c\"}")
+                    )
+                )
+            )
+        )       | RenameTableMessage.class
+        this.mapper.writeValueAsString(
             new UpdateTablePartitionsMessage(
                 UUID.randomUUID().toString(),
                 Instant.now().toEpochMilli(),

--- a/metacat-main/src/test/groovy/com/netflix/metacat/main/services/notifications/sns/SNSNotificationServiceImplSpec.groovy
+++ b/metacat-main/src/test/groovy/com/netflix/metacat/main/services/notifications/sns/SNSNotificationServiceImplSpec.groovy
@@ -196,7 +196,7 @@ class SNSNotificationServiceImplSpec extends Specification {
 
         then:
         2 * this.mapper.valueToTree(_ as TableDto) >> new TextNode(UUID.randomUUID().toString())
-        1 * this.mapper.writeValueAsString(_ as UpdateTableMessage) >> UUID.randomUUID().toString()
+        1 * this.mapper.writeValueAsString(_ as RenameTableMessage) >> UUID.randomUUID().toString()
         1 * this.client.publish(this.tableArn, _ as String) >> result
         2 * this.timer.record(_ as Long, _ as TimeUnit)
     }


### PR DESCRIPTION
- Today, Rename events are clubbed into the TABLE_UPDATE message type. This will help downstream event consumers (like Microbots) avoid processing irrelevant Update messages.