### PR TITLE
Fixed 2 issues.

### DIFF
--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/partition/util/FilterPartition.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/partition/util/FilterPartition.java
@@ -78,7 +78,7 @@ public class FilterPartition {
                 }
             } catch (ParseException | TokenMgrError e) {
                 throw new IllegalArgumentException(String.format("Invalid expression: %s", partitionExpression), e);
-            } catch (StackOverflowError e) {
+            } catch (StackOverflowError | ArrayIndexOutOfBoundsException | NullPointerException e) {
                 throw new IllegalArgumentException(String.format("Expression too long: %s", partitionExpression), e);
             } catch (IllegalArgumentException e) {
                 throw e;

--- a/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/client/embedded/HivePersistenceManagerFactory.java
+++ b/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/client/embedded/HivePersistenceManagerFactory.java
@@ -34,14 +34,6 @@ import java.util.Map;
  */
 @Slf4j
 public final class HivePersistenceManagerFactory {
-    /**
-     * metacat.jdo.timeout.
-     */
-    private static final String JDO_TIMEOUT = "300000";
-
-    //TODO: Figure out how to do this statically in the new Spring based system
-//    public static final DynamicStringProperty JDO_TIMEOUT = DynamicPropertyFactory
-//            .getInstance().getStringProperty(HiveConfigConstants.METACAT_JDO_TIMEOUT, "300000");
     private static Map<String, PersistenceManagerFactory> factories = Maps.newConcurrentMap();
 
     private HivePersistenceManagerFactory() {
@@ -67,7 +59,6 @@ public final class HivePersistenceManagerFactory {
         PersistenceManagerFactory result = factories.get(name);
         if (result == null) {
             final DataSource dataSource = DataSourceManager.get().get(name);
-//            final String jdoTimeout = JDO_TIMEOUT.get();
             final Map<String, Object> properties = Maps.newHashMap();
             properties.put(HiveConfigConstants.DATANUCLEUS_FIXEDDATASTORE,
                 props.get(HiveConfigConstants.DATANUCLEUS_FIXEDDATASTORE));
@@ -88,12 +79,12 @@ public final class HivePersistenceManagerFactory {
             properties.put(HiveConfigConstants.DATANUCLEUS_AUTOSTARTMECHANISMMODE, "Checked");
             properties.put(HiveConfigConstants.DATANUCLEUS_DETACHALLONCOMMIT, true);
             properties.put(HiveConfigConstants.DATANUCLEUS_DETACHALLONROLLBACK, true);
-//            properties.put(HiveConfigConstants.JAVAX_JDO_DATASTORETIMEOUT, jdoTimeout);
-//            properties.put(HiveConfigConstants.JAVAX_JDO_DATASTOREREADTIMEOUT, jdoTimeout);
-//            properties.put(HiveConfigConstants.JAVAX_JDO_DATASTOREWRITETIMEOUT, jdoTimeout);
-            properties.put(HiveConfigConstants.JAVAX_JDO_DATASTORETIMEOUT, JDO_TIMEOUT);
-            properties.put(HiveConfigConstants.JAVAX_JDO_DATASTOREREADTIMEOUT, JDO_TIMEOUT);
-            properties.put(HiveConfigConstants.JAVAX_JDO_DATASTOREWRITETIMEOUT, JDO_TIMEOUT);
+            properties.put(HiveConfigConstants.JAVAX_JDO_DATASTORETIMEOUT,
+                props.get(HiveConfigConstants.JAVAX_JDO_DATASTORETIMEOUT));
+            properties.put(HiveConfigConstants.JAVAX_JDO_DATASTOREREADTIMEOUT,
+                props.get(HiveConfigConstants.JAVAX_JDO_DATASTOREREADTIMEOUT));
+            properties.put(HiveConfigConstants.JAVAX_JDO_DATASTOREWRITETIMEOUT,
+                props.get(HiveConfigConstants.JAVAX_JDO_DATASTOREWRITETIMEOUT));
             result = JDOPersistenceManagerFactory.getPersistenceManagerFactory(properties);
             factories.put(name, result);
         }


### PR DESCRIPTION
1. Fixed issue where getPartitions call with a long filter expression was returning an empty list instead of an error. 2. Fixed issue where the hive metastore persistence factory was not picking up the timeout settings defined in the catalog properties.