### PR TITLE
Fixed issue where getTable/updateTable/createTables that uses S3 client fails after the s3 client connection pool crashes

### DIFF
--- a/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/monitoring/HiveMetrics.java
+++ b/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/monitoring/HiveMetrics.java
@@ -37,6 +37,7 @@ public enum HiveMetrics {
     CounterHivePartitionPathIsNotDir(Type.counter,"partitionPathIsNotDir"),
     CounterHivePartitionFileSystemCall(Type.counter,"partitionFileSystemCall"),
     CounterHiveGetPartitionsExceedThresholdFailure(Type.counter,"getPartitionsExceedThresholdFailure"),
+    CounterHiveFileSystemFailure(Type.counter,"fileSystemFailure"),
 
     /**
      * Gauge.


### PR DESCRIPTION
The fix is to create a new instance of s3 client whenever the pool shuts down.