### PR TITLE
Added serde related attribute information for iceberg tables. 

### DIFF
--- a/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/converters/HiveConnectorInfoConverter.java
+++ b/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/converters/HiveConnectorInfoConverter.java
@@ -195,10 +195,17 @@ public class HiveConnectorInfoConverter implements ConnectorInfoConverter<Databa
         //adding iceberg table properties
         tableParameters.putAll(table.properties());
         tableParameters.putAll(tableWrapper.getExtraProperties());
-        final String location = tableInfo.getSerde() != null ? tableInfo.getSerde().getUri() : null;
+        final StorageInfo.StorageInfoBuilder storageInfoBuilder = StorageInfo.builder();
+        if (tableInfo.getSerde() != null) {
+            // Adding the serde properties to support old engines.
+            storageInfoBuilder.inputFormat(tableInfo.getSerde().getInputFormat())
+                .outputFormat(tableInfo.getSerde().getOutputFormat())
+                .uri(tableInfo.getSerde().getUri())
+                .serializationLib(tableInfo.getSerde().getSerializationLib());
+        }
         return TableInfo.builder().fields(allFields)
             .metadata(tableParameters)
-            .serde(StorageInfo.builder().uri(location).build())
+            .serde(storageInfoBuilder.build())
             .name(name).auditInfo(tableInfo.getAudit())
             .build();
     }

--- a/metacat-functional-tests/src/functionalTest/groovy/com/netflix/metacat/MetacatSmokeSpec.groovy
+++ b/metacat-functional-tests/src/functionalTest/groovy/com/netflix/metacat/MetacatSmokeSpec.groovy
@@ -486,6 +486,7 @@ class MetacatSmokeSpec extends Specification {
         updatedTable.getMetadata().get('metadata_location') == metadataLocation1
         updatedTable != null
         updatedTable.getDataUri() == updatedUri
+        updatedTable.getSerde().getInputFormat() == 'org.apache.hadoop.mapred.TextInputFormat'
         when:
         def metadataLocation2 = '/tmp/data/00089-5641e8bf-06b8-46b3-a0fc-5c867f5bca58.metadata.json'
         def metadata2 = [table_type: 'ICEBERG', metadata_location: metadataLocation2, previous_metadata_location: metadataLocation1, 'partition_spec': 'invalid']


### PR DESCRIPTION
Currently for iceberg tables, only uri and table properties retrieved from hive metastore are incorporated into the TableInfo. With this change, serde attributes like inputFormat, outputFormat and serializationLib will also be incorporated.