### PR TITLE
Add support for caching of iceberg table info. 

### DIFF
--- a/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/configs/HiveConnectorFastServiceConfig.java
+++ b/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/configs/HiveConnectorFastServiceConfig.java
@@ -33,6 +33,7 @@ import com.netflix.metacat.connector.hive.sql.DirectSqlTable;
 import com.netflix.metacat.connector.hive.sql.HiveConnectorFastDatabaseService;
 import com.netflix.metacat.connector.hive.sql.HiveConnectorFastPartitionService;
 import com.netflix.metacat.connector.hive.sql.HiveConnectorFastTableService;
+import com.netflix.metacat.connector.hive.sql.HiveConnectorFastTableServiceProxy;
 import com.netflix.metacat.connector.hive.sql.SequenceGeneration;
 import com.netflix.metacat.connector.hive.util.HiveConnectorFastServiceMetric;
 import org.apache.hadoop.hive.metastore.Warehouse;
@@ -218,6 +219,7 @@ public class HiveConnectorFastServiceConfig {
      * @param directSqlTable               table jpa service
      * @param icebergTableHandler          iceberg table handler
      * @param commonViewHandler            common view handler
+     * @param hiveConnectorFastTableServiceProxy hive connector fast table service proxy
      * @return HiveConnectorFastTableService
      */
     @Bean
@@ -228,7 +230,8 @@ public class HiveConnectorFastServiceConfig {
         final ConnectorContext connectorContext,
         final DirectSqlTable directSqlTable,
         final IcebergTableHandler icebergTableHandler,
-        final CommonViewHandler commonViewHandler
+        final CommonViewHandler commonViewHandler,
+        final HiveConnectorFastTableServiceProxy hiveConnectorFastTableServiceProxy
     ) {
         return new HiveConnectorFastTableService(
             connectorContext.getCatalogName(),
@@ -237,6 +240,28 @@ public class HiveConnectorFastServiceConfig {
             hiveMetacatConverters,
             connectorContext,
             directSqlTable,
+            icebergTableHandler,
+            commonViewHandler,
+            hiveConnectorFastTableServiceProxy
+        );
+    }
+
+    /**
+     * create hive connector fast table service proxy.
+     *
+     * @param hiveMetacatConverters        hive metacat converters
+     * @param icebergTableHandler          iceberg table handler
+     * @param commonViewHandler            common view handler
+     * @return HiveConnectorFastTableServiceProxy
+     */
+    @Bean
+    public HiveConnectorFastTableServiceProxy hiveConnectorFastTableServiceProxy(
+        final HiveConnectorInfoConverter hiveMetacatConverters,
+        final IcebergTableHandler icebergTableHandler,
+        final CommonViewHandler commonViewHandler
+    ) {
+        return new HiveConnectorFastTableServiceProxy(
+            hiveMetacatConverters,
             icebergTableHandler,
             commonViewHandler
         );

--- a/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/sql/HiveConnectorFastTableServiceProxy.java
+++ b/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/sql/HiveConnectorFastTableServiceProxy.java
@@ -1,0 +1,94 @@
+/*
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
+
+package com.netflix.metacat.connector.hive.sql;
+
+import com.netflix.metacat.common.QualifiedName;
+import com.netflix.metacat.common.server.connectors.model.TableInfo;
+import com.netflix.metacat.connector.hive.commonview.CommonViewHandler;
+import com.netflix.metacat.connector.hive.converters.HiveConnectorInfoConverter;
+import com.netflix.metacat.connector.hive.converters.HiveTypeConverter;
+import com.netflix.metacat.connector.hive.iceberg.IcebergTableHandler;
+import com.netflix.metacat.connector.hive.iceberg.IcebergTableWrapper;
+import org.springframework.cache.annotation.CacheConfig;
+import org.springframework.cache.annotation.Cacheable;
+
+/**
+ * Proxy class to get the metadata info from cache if exists.
+ */
+@CacheConfig(cacheNames = "metacat")
+public class HiveConnectorFastTableServiceProxy {
+    private final IcebergTableHandler icebergTableHandler;
+    private final HiveConnectorInfoConverter hiveMetacatConverters;
+    private final CommonViewHandler commonViewHandler;
+
+    /**
+     * Constructor.
+     *
+     * @param hiveMetacatConverters        hive converter
+     * @param icebergTableHandler          iceberg table handler
+     * @param commonViewHandler            common view handler
+     */
+    public HiveConnectorFastTableServiceProxy(
+        final HiveConnectorInfoConverter hiveMetacatConverters,
+        final IcebergTableHandler icebergTableHandler,
+        final CommonViewHandler commonViewHandler
+    ) {
+        this.hiveMetacatConverters = hiveMetacatConverters;
+        this.icebergTableHandler = icebergTableHandler;
+        this.commonViewHandler = commonViewHandler;
+    }
+
+    /**
+     * Return the table metadata from cache if exists. If not exists, make the iceberg call to refresh it.
+     * @param tableName             table name
+     * @param tableMetadataLocation table metadata location
+     * @param info                  table info stored in hive metastore
+     * @param includeInfoDetails    if true, will include more details like the manifest file content
+     * @param useCache true, if table can be retrieved from cache
+     * @return TableInfo
+     */
+    @Cacheable(key = "'iceberg.table.' + #includeInfoDetails + '.' + #tableMetadataLocation", condition = "#useCache")
+    public TableInfo getIcebergTable(final QualifiedName tableName,
+                                     final String tableMetadataLocation,
+                                     final TableInfo info,
+                                     final boolean includeInfoDetails,
+                                     final boolean useCache) {
+        final IcebergTableWrapper icebergTable =
+            this.icebergTableHandler.getIcebergTable(tableName, tableMetadataLocation, includeInfoDetails);
+        return this.hiveMetacatConverters.fromIcebergTableToTableInfo(tableName,
+            icebergTable, tableMetadataLocation, info);
+    }
+
+    /**
+     * Return the common view metadata from cache if exists. If not exists, make the common view handler call
+     * to refresh it.
+     * @param name                  common view name
+     * @param tableMetadataLocation common view metadata location
+     * @param info                  common view info stored in hive metastore
+     * @param hiveTypeConverter     hive type converter
+     * @param useCache true, if table can be retrieved from cache
+     * @return TableInfo
+     */
+    @Cacheable(key = "'iceberg.view.' + #tableMetadataLocation", condition = "#useCache")
+    public TableInfo getCommonViewTableInfo(final QualifiedName name,
+                                     final String tableMetadataLocation,
+                                     final TableInfo info,
+                                     final HiveTypeConverter hiveTypeConverter,
+                                     final boolean useCache) {
+        return commonViewHandler.getCommonViewTableInfo(name, tableMetadataLocation, info, hiveTypeConverter);
+    }
+}

--- a/metacat-connector-hive/src/test/groovy/com/netflix/metacat/connector/hive/sql/HiveConnectorFastTableServiceSpec.groovy
+++ b/metacat-connector-hive/src/test/groovy/com/netflix/metacat/connector/hive/sql/HiveConnectorFastTableServiceSpec.groovy
@@ -21,9 +21,7 @@ import com.netflix.metacat.common.QualifiedName
 import com.netflix.metacat.common.server.connectors.ConnectorContext
 import com.netflix.metacat.common.server.connectors.ConnectorRequestContext
 import com.netflix.metacat.common.server.connectors.exception.TableNotFoundException
-import com.netflix.metacat.common.server.connectors.exception.TablePreconditionFailedException
 import com.netflix.metacat.common.server.connectors.model.TableInfo
-import com.netflix.metacat.common.server.properties.Config
 import com.netflix.metacat.connector.hive.HiveConnectorDatabaseService
 import com.netflix.metacat.connector.hive.HiveConnectorTableService
 import com.netflix.metacat.connector.hive.client.thrift.MetacatHiveClient
@@ -33,7 +31,6 @@ import com.netflix.metacat.connector.hive.converters.HiveTypeConverter
 import com.netflix.metacat.connector.hive.iceberg.IcebergTableHandler
 import com.netflix.metacat.connector.hive.util.HiveConfigConstants
 import com.netflix.metacat.testdata.provider.DataDtoProvider
-import com.netflix.spectator.api.Registry
 import org.apache.hadoop.hive.metastore.api.FieldSchema
 import org.apache.hadoop.hive.metastore.api.NoSuchObjectException
 import org.apache.hadoop.hive.metastore.api.SerDeInfo
@@ -48,15 +45,18 @@ class HiveConnectorFastTableServiceSpec extends Specification {
     ConnectorContext connectorContext = DataDtoProvider.newContext(null, ImmutableMap.of(HiveConfigConstants.ALLOW_RENAME_TABLE, "true"))
     IcebergTableHandler handler = Mock(IcebergTableHandler)
     DirectSqlTable directSqlTable = Mock(DirectSqlTable)
+    HiveConnectorInfoConverter infoConverter = new HiveConnectorInfoConverter(new HiveTypeConverter())
+    CommonViewHandler commonViewHandler = new CommonViewHandler(connectorContext)
     HiveConnectorTableService service = new HiveConnectorFastTableService(
         "testhive",
         metacatHiveClient,
         hiveConnectorDatabaseService,
-        new HiveConnectorInfoConverter(new HiveTypeConverter()),
+        infoConverter,
         connectorContext,
         directSqlTable,
         handler,
-        new CommonViewHandler(connectorContext)
+        new CommonViewHandler(connectorContext),
+        new HiveConnectorFastTableServiceProxy(infoConverter, handler, commonViewHandler)
     )
     def catalogName = 'c'
     def databaseName = 'd'

--- a/metacat-main/src/main/java/com/netflix/metacat/main/services/notifications/sns/SNSNotificationMetric.java
+++ b/metacat-main/src/main/java/com/netflix/metacat/main/services/notifications/sns/SNSNotificationMetric.java
@@ -57,6 +57,9 @@ public class SNSNotificationMetric {
         this.counterHashMap.put(Metrics.CounterSNSNotificationTablePartitionAdd.getMetricName(),
             registry.counter(registry.createId(Metrics.CounterSNSNotificationTablePartitionAdd.getMetricName())
                 .withTags(Metrics.tagStatusSuccessMap)));
+        this.counterHashMap.put(Metrics.CounterSNSNotificationTablePartitionDelete.getMetricName(),
+            registry.counter(registry.createId(Metrics.CounterSNSNotificationTablePartitionDelete.getMetricName())
+                .withTags(Metrics.tagStatusSuccessMap)));
         this.counterHashMap.put(Metrics.CounterSNSNotificationPartitionDelete.getMetricName(),
             registry.counter(registry.createId(Metrics.CounterSNSNotificationPartitionDelete.getMetricName())
                 .withTags(Metrics.tagStatusSuccessMap)));


### PR DESCRIPTION
Previously we added caching of iceberg TableMetadata. Size of the serialized TableMetadata, at times, tend to be huge. Size of table info should be small.