### PR TITLE
Fixed issue, with AsyncListeners, introduced in the previous checkin. 

### DIFF
--- a/metacat-main/src/main/java/com/netflix/metacat/main/configs/CommonServerConfig.java
+++ b/metacat-main/src/main/java/com/netflix/metacat/main/configs/CommonServerConfig.java
@@ -113,7 +113,6 @@ public class CommonServerConfig {
      * Default event listener factory.
      * @return The application event multicaster to use.
      */
-    @ConditionalOnMissingBean
     @Bean(AnnotationConfigUtils.EVENT_LISTENER_FACTORY_BEAN_NAME)
     public EventListenerFactory eventListenerFactory() {
         return new MetacatEventListenerFactory();

--- a/metacat-main/src/main/resources/application.yml
+++ b/metacat-main/src/main/resources/application.yml
@@ -52,3 +52,5 @@ spring:
     default-property-inclusion: always
     deserialization:
       FAIL_ON_UNKNOWN_PROPERTIES: false
+  main:
+    allow-bean-definition-overriding: true


### PR DESCRIPTION
AsyncListeners were not getting registered with the Async event listener pool.