### PR TITLE
Update build status location

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ TODO
 
 ## Builds
 
-Metacat builds are run on Travis CI [here](https://travis-ci.org/Netflix/metacat).
-[![Build Status](https://travis-ci.org/Netflix/metacat.svg?branch=master)](https://travis-ci.org/Netflix/meatcat)
+Metacat builds are run on Travis CI [here](https://travis-ci.com/Netflix/metacat).
+[![Build Status](https://travis-ci.com/Netflix/metacat.svg?branch=master)](https://travis-ci.com/Netflix/metacat)
 
 ## Getting Started
 


### PR DESCRIPTION
This build has been migrated to travis-ci.com as per their [recommendation](https://mailchi.mp/3d439eeb1098/travis-ciorg-is-moving-to-travis-cicom).