### PR TITLE
Changes to reduce memory issues when caching iceberg tables.

### DIFF
--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/Config.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/Config.java
@@ -422,6 +422,12 @@ public interface Config {
      * @return true if iceberg table cache is enabled
      */
     boolean isIcebergCacheEnabled();
+    /**
+     * Enable iceberg table TableMetadata cache.
+     *
+     * @return true if iceberg table cache is enabled
+     */
+    boolean isIcebergTableMetadataCacheEnabled();
 
     /**
      * Enable common view processing.

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/DefaultConfigImpl.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/DefaultConfigImpl.java
@@ -500,6 +500,11 @@ public class DefaultConfigImpl implements Config {
         return this.metacatProperties.getHive().getIceberg().getCache().isEnabled();
     }
 
+    @Override
+    public boolean isIcebergTableMetadataCacheEnabled() {
+        return this.metacatProperties.getHive().getIceberg().getCache().getMetadata().isEnabled();
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/HiveProperties.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/HiveProperties.java
@@ -118,6 +118,18 @@ public class HiveProperties {
     @Data
     public static class IcebergCacheProperties {
         private boolean enabled;
+        @NonNull
+        private TableMetadata metadata = new TableMetadata();
+    }
+
+    /**
+     * TableMetadata properties.
+     *
+     * @author amajumdar
+     */
+    @Data
+    public static class TableMetadata {
+        private boolean enabled;
     }
 
     /**

--- a/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/iceberg/IcebergTableOps.java
+++ b/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/iceberg/IcebergTableOps.java
@@ -40,7 +40,8 @@ public class IcebergTableOps extends BaseMetastoreTableOperations {
     @Override
     public TableMetadata current() {
         if (tableMetadata == null) {
-            tableMetadata = icebergTableOpsProxy.getMetadata(this, config.isIcebergCacheEnabled());
+            tableMetadata =
+                icebergTableOpsProxy.getMetadata(this, config.isIcebergTableMetadataCacheEnabled());
         }
         return tableMetadata;
     }

--- a/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/iceberg/IcebergTableOpsProxy.java
+++ b/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/iceberg/IcebergTableOpsProxy.java
@@ -17,6 +17,6 @@ public class IcebergTableOpsProxy {
      */
     @Cacheable(key = "'iceberg.' + #icebergTableOps.currentMetadataLocation()", condition = "#useCache")
     public TableMetadata getMetadata(final IcebergTableOps icebergTableOps, final boolean useCache) {
-        return icebergTableOps.refresh();
+        return icebergTableOps.refresh().removeSnapshotsIf(s -> true);
     }
 }


### PR DESCRIPTION
Added a configuration to enable/disable just the caching of TableMetadata for iceberg tables. When retrieving the TableMetadata, all snapshots other than the current one are removed from the list and history logs contained in TableMetadata. These changes are to reduce the heap pressure when caching TableMetadata.