### PR TITLE
Reverted back a previous change of removing snapshots from the TableMetadata.

### DIFF
--- a/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/iceberg/IcebergTableOpsProxy.java
+++ b/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/iceberg/IcebergTableOpsProxy.java
@@ -17,6 +17,6 @@ public class IcebergTableOpsProxy {
      */
     @Cacheable(key = "'iceberg.' + #icebergTableOps.currentMetadataLocation()", condition = "#useCache")
     public TableMetadata getMetadata(final IcebergTableOps icebergTableOps, final boolean useCache) {
-        return icebergTableOps.refresh().removeSnapshotsIf(s -> true);
+        return icebergTableOps.refresh();
     }
 }


### PR DESCRIPTION
 This does not work when getting partitions for a table.