### PR TITLE
Modified getCatalog API to take in request params includeDatabaseNames and includeUserMetadata

### DIFF
--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/api/v1/MetacatV1.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/api/v1/MetacatV1.java
@@ -241,6 +241,6 @@ public interface MetacatV1 {
      * @param includeUserMetadata if true, the response includes the user metadata
      * @return catalog
      */
-    CatalogDto getCatalog(final String catalogName, final boolean includeDatabaseNames,
+    CatalogDto getCatalog(final String catalogName, final Boolean includeDatabaseNames,
                           final boolean includeUserMetadata);
 }

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/Config.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/Config.java
@@ -530,6 +530,13 @@ public interface Config {
     boolean listTableNamesByDefaultOnGetDatabase();
 
     /**
+     * Whether to list database names by default on getCatalog request call.
+     *
+     * @return True if it is.
+     */
+    boolean listDatabaseNameByDefaultOnGetCatalog();
+
+    /**
      * Metadata query timeout in seconds.
      *
      * @return Metadata query timeout in seconds

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/DefaultConfigImpl.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/DefaultConfigImpl.java
@@ -622,6 +622,11 @@ public class DefaultConfigImpl implements Config {
     }
 
     @Override
+    public boolean listDatabaseNameByDefaultOnGetCatalog() {
+        return this.metacatProperties.getService().isListDatabaseNameByDefaultOnGetCatalog();
+    }
+
+    @Override
     public int getMetadataQueryTimeout() {
         return this.metacatProperties.getUsermetadata().getQueryTimeoutInSeconds();
     }

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/ServiceProperties.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/ServiceProperties.java
@@ -36,6 +36,7 @@ public class ServiceProperties {
     @NonNull
     private Tables tables = new Tables();
     private boolean listTableNamesByDefaultOnGetDatabase = true;
+    private boolean listDatabaseNameByDefaultOnGetCatalog = true;
 
     /**
      * Max related properties.

--- a/metacat-main/src/main/java/com/netflix/metacat/main/api/v1/MetacatController.java
+++ b/metacat-main/src/main/java/com/netflix/metacat/main/api/v1/MetacatController.java
@@ -476,6 +476,11 @@ public class MetacatController implements MetacatV1 {
         );
     }
 
+    @Override
+    public CatalogDto getCatalog(final String catalogName) {
+        return getCatalog(catalogName, true, true);
+    }
+
     /**
      * Get the catalog by name.
      *
@@ -504,23 +509,19 @@ public class MetacatController implements MetacatV1 {
     @Override
     public CatalogDto getCatalog(
         @ApiParam(value = "The name of the catalog", required = true)
-        @PathVariable("catalog-name") final String catalogName
-    ) {
-        return getCatalog(catalogName, true, true);
-    }
-
-    @Override
-    public CatalogDto getCatalog(
-        final String catalogName,
-        final boolean includeUserMetadata,
-        final boolean includeDatabaseNames
-    ) {
+        @PathVariable("catalog-name") final String catalogName,
+        @ApiParam(value = "Whether to include list of database names")
+        @Nullable @RequestParam(name = "includeDatabaseNames", required = false) final Boolean includeDatabaseNames,
+        @ApiParam(value = "Whether to include user metadata information to the response")
+        @RequestParam(name = "includeUserMetadata", defaultValue = "true") final boolean includeUserMetadata) {
         final QualifiedName name = this.requestWrapper.qualifyName(() -> QualifiedName.ofCatalog(catalogName));
         return this.requestWrapper.processRequest(
             name,
             "getCatalog",
             () -> this.catalogService.get(name, GetCatalogServiceParameters.builder()
-                .includeDatabaseNames(includeDatabaseNames).includeUserMetadata(includeUserMetadata).build())
+                .includeDatabaseNames(includeDatabaseNames == null
+                    ? config.listDatabaseNameByDefaultOnGetCatalog() : includeDatabaseNames)
+                .includeUserMetadata(includeUserMetadata).build())
         );
     }
 

--- a/metacat-main/src/main/java/com/netflix/metacat/main/configs/ServicesConfig.java
+++ b/metacat-main/src/main/java/com/netflix/metacat/main/configs/ServicesConfig.java
@@ -163,7 +163,6 @@ public class ServicesConfig {
      * @param userMetadataService  User metadata service to use
      * @param metacatEventBus      Event bus to use
      * @param converterUtil        Converter utilities
-     * @param catalogService       The catalog service to use
      * @param authorizationService authorization Service
      * @return Catalog service implementation
      */
@@ -173,11 +172,9 @@ public class ServicesConfig {
         final UserMetadataService userMetadataService,
         final MetacatEventBus metacatEventBus,
         final ConverterUtil converterUtil,
-        final CatalogService catalogService,
         final AuthorizationService authorizationService
     ) {
         return new DatabaseServiceImpl(
-            catalogService,
             connectorManager,
             userMetadataService,
             metacatEventBus,

--- a/metacat-main/src/main/java/com/netflix/metacat/main/services/search/ElasticSearchCatalogTraversalAction.java
+++ b/metacat-main/src/main/java/com/netflix/metacat/main/services/search/ElasticSearchCatalogTraversalAction.java
@@ -22,7 +22,6 @@ import com.netflix.metacat.common.MetacatRequestContext;
 import com.netflix.metacat.common.QualifiedName;
 import com.netflix.metacat.common.dto.DatabaseDto;
 import com.netflix.metacat.common.dto.TableDto;
-import com.netflix.metacat.common.server.connectors.exception.DatabaseNotFoundException;
 import com.netflix.metacat.common.server.events.MetacatDeleteTablePostEvent;
 import com.netflix.metacat.common.server.events.MetacatEventBus;
 import com.netflix.metacat.common.server.monitoring.Metrics;
@@ -32,8 +31,6 @@ import com.netflix.metacat.common.server.usermetadata.UserMetadataService;
 import com.netflix.metacat.main.services.CatalogTraversal;
 import com.netflix.metacat.main.services.CatalogTraversalAction;
 import com.netflix.metacat.main.services.DatabaseService;
-import com.netflix.metacat.main.services.GetDatabaseServiceParameters;
-import com.netflix.metacat.main.services.GetTableServiceParameters;
 import com.netflix.metacat.main.services.TableService;
 import com.netflix.spectator.api.Registry;
 import lombok.NonNull;
@@ -124,17 +121,7 @@ public class ElasticSearchCatalogTraversalAction implements CatalogTraversalActi
                     boolean result = false;
                     try {
                         unmarkedDatabaseNames.add(databaseDto.getName().toString());
-                        final DatabaseDto dto = databaseService.get(databaseDto.getName(),
-                            GetDatabaseServiceParameters.builder()
-                                .includeUserMetadata(false)
-                                .includeTableNames(false)
-                                .disableOnReadMetadataIntercetor(false)
-                                .build());
-                        if (dto == null) {
-                            result = true;
-                        }
-                    } catch (DatabaseNotFoundException de) {
-                        result = true;
+                        result = !databaseService.exists(databaseDto.getName());
                     } catch (Exception e) {
                         log.warn("Ignoring exception during deleteUnmarkedEntities for {}. Message: {}",
                             databaseDto.getName(), e.getMessage());
@@ -174,16 +161,7 @@ public class ElasticSearchCatalogTraversalAction implements CatalogTraversalActi
                     boolean result = false;
                     try {
                         unmarkedTableNames.add(tableDto.getName().toString());
-                        final Optional<TableDto> dto = tableService.get(tableDto.getName(),
-                            GetTableServiceParameters.builder()
-                                .includeDataMetadata(false)
-                                .disableOnReadMetadataIntercetor(false)
-                                .includeInfo(true)
-                                .includeDefinitionMetadata(false)
-                                .build());
-                        if (!dto.isPresent()) {
-                            result = true;
-                        }
+                        result = !tableService.exists(tableDto.getName());
                     } catch (Exception e) {
                         log.warn("Ignoring exception during deleteUnmarkedEntities for {}. Message: {}",
                             tableDto.getName(), e.getMessage());

--- a/metacat-thrift/src/main/java/com/netflix/metacat/thrift/CatalogThriftHiveMetastore.java
+++ b/metacat-thrift/src/main/java/com/netflix/metacat/thrift/CatalogThriftHiveMetastore.java
@@ -903,7 +903,8 @@ public class CatalogThriftHiveMetastore extends FacebookBase
      */
     @Override
     public List<String> get_all_databases() throws TException {
-        return requestWrapper("get_all_databases", new Object[]{}, () -> v1.getCatalog(catalogName).getDatabases());
+        return requestWrapper("get_all_databases", new Object[]{},
+            () -> v1.getCatalog(catalogName, true, false).getDatabases());
     }
 
     /**
@@ -950,7 +951,7 @@ public class CatalogThriftHiveMetastore extends FacebookBase
     @Override
     public List<String> get_databases(final String hivePattern) throws TException {
         return requestWrapper("get_databases", new Object[]{hivePattern}, () -> {
-            List<String> result = v1.getCatalog(catalogName).getDatabases();
+            List<String> result = v1.getCatalog(catalogName, true, false).getDatabases();
             if (hivePattern != null) {
                 // Unsure about the pattern format.  I couldn't find any tests.  Assuming it is regex.
                 final Pattern pattern = PATTERNS.getUnchecked("(?i)" + hivePattern.replaceAll("\\*", ".*"));

--- a/metacat-thrift/src/test/groovy/com/netflix/metacat/thrift/CatalogThriftHiveMetastoreSpec.groovy
+++ b/metacat-thrift/src/test/groovy/com/netflix/metacat/thrift/CatalogThriftHiveMetastoreSpec.groovy
@@ -1392,7 +1392,7 @@ class CatalogThriftHiveMetastoreSpec extends Specification {
 
         given:
         def databases = ['db1', 'db2', 'db3']
-        metacatV1.getCatalog(_) >> new CatalogDto(databases: databases)
+        metacatV1.getCatalog(_,_,_) >> new CatalogDto(databases: databases)
 
         when:
         def result = ms.get_all_databases()
@@ -1485,7 +1485,7 @@ class CatalogThriftHiveMetastoreSpec extends Specification {
         def ms = new CatalogThriftHiveMetastore(config, hiveConverters, metacatV1, partitionV1, catalogName, registry)
 
         given:
-        metacatV1.getCatalog(_) >> new CatalogDto(
+        metacatV1.getCatalog(_,_,_) >> new CatalogDto(
                 databases: ['adb', 'bdb', 'cdb', 'ddb', 'ddb1', 'ddb2', 'ddb3', 'edb', 'fdb']
         )
 


### PR DESCRIPTION
Modified the catalog traversal action to use `exists` method instead of doing a `get`.