### PR TITLE
Shallow cloning on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ addons:
     packages:
       - pass
 git:
-  depth: 250
+  depth: 3
 install: "./installViaTravis.sh"
 script: "./buildViaTravis.sh"
 before_install: "./beforeInstall.sh"


### PR DESCRIPTION
According to [https://docs.travis-ci.com/user/customizing-the-build#git-clone-depth](url), Travis CI provide a way to shallow clone a repository. This has the obvious benefit of speed, since you only need to download a small number of commits.