### PR TITLE
Evict common view table cache entries on params update

### DIFF
--- a/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/sql/DirectSqlTable.java
+++ b/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/sql/DirectSqlTable.java
@@ -227,11 +227,8 @@ public class DirectSqlTable {
         //
         // Table info should have the table parameters with the metadata location.
         //
-        if (newTableMetadata == null || newTableMetadata.isEmpty()) {
-            final String message = String.format("No parameters defined for iceberg table %s", tableName);
-            log.warn(message);
-            throw new InvalidMetaException(tableName, message, null);
-        }
+        HiveTableUtil.throwIfTableMetadataNullOrEmpty(tableName, newTableMetadata);
+
         //
         // If the previous metadata location is not empty, check if it is valid.
         //

--- a/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/sql/HiveConnectorFastTableService.java
+++ b/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/sql/HiveConnectorFastTableService.java
@@ -188,8 +188,12 @@ public class HiveConnectorFastTableService extends HiveConnectorTableService {
             if (HiveTableUtil.isIcebergTable(tableInfo)) {
                 icebergTableHandler.handleUpdate(requestContext, this.directSqlTable, tableInfo);
             } else if (connectorContext.getConfig().isCommonViewEnabled()
-                && HiveTableUtil.isCommonView(tableInfo)) {
-                commonViewHandler.handleUpdate(requestContext, this.directSqlTable, tableInfo);
+                    && HiveTableUtil.isCommonView(tableInfo)) {
+                final QualifiedName tableName = tableInfo.getName();
+                HiveTableUtil.throwIfTableMetadataNullOrEmpty(tableName, tableInfo.getMetadata());
+                final String tableMetadataLocation = HiveTableUtil.getCommonViewMetadataLocation(tableInfo);
+                commonViewHandler.handleUpdate(requestContext, this.directSqlTable,
+                        tableInfo, tableMetadataLocation);
             } else {
                 super.update(requestContext, tableInfo);
             }
@@ -197,6 +201,7 @@ public class HiveConnectorFastTableService extends HiveConnectorTableService {
             throw handleException(e);
         }
     }
+
     /**
      * {@inheritDoc}.
      */

--- a/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/util/HiveTableUtil.java
+++ b/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/util/HiveTableUtil.java
@@ -19,9 +19,11 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 import com.netflix.metacat.common.MetacatRequestContext;
 import com.netflix.metacat.common.QualifiedName;
+import com.netflix.metacat.common.server.connectors.exception.InvalidMetaException;
 import com.netflix.metacat.common.server.connectors.model.TableInfo;
 import com.netflix.metacat.common.server.util.MetacatContextManager;
 import com.netflix.metacat.connector.hive.sql.DirectSqlTable;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.common.JavaUtils;
@@ -48,6 +50,7 @@ import java.util.Properties;
  * @since 1.0.0
  */
 @SuppressWarnings("deprecation")
+@Slf4j
 public final class HiveTableUtil {
     private static final String PARQUET_HIVE_SERDE = "parquet.hive.serde.ParquetHiveSerDe";
 
@@ -184,5 +187,21 @@ public final class HiveTableUtil {
      */
     public static String getCommonViewMetadataLocation(final TableInfo tableInfo) {
         return tableInfo.getMetadata().get(DirectSqlTable.PARAM_METADATA_LOCATION);
+    }
+
+    /**
+     * Throws an invalid meta exception
+     * if the metadata for a table is null or empty.
+     *
+     * @param tableName the table name.
+     * @param metadata the table metadata.
+     */
+    public static void throwIfTableMetadataNullOrEmpty(final QualifiedName tableName,
+                                                       final Map<String, String> metadata) {
+        if (metadata == null || metadata.isEmpty()) {
+            final String message = String.format("No parameters defined for iceberg table %s", tableName);
+            log.warn(message);
+            throw new InvalidMetaException(tableName, message, null);
+        }
     }
 }


### PR DESCRIPTION
- Err on the safe side and evict the entry before the updates since they're not expected to be updated often. 