### PR TITLE
Make connectorManager plugins accessor public

### DIFF
--- a/metacat-main/src/main/java/com/netflix/metacat/main/manager/ConnectorManager.java
+++ b/metacat-main/src/main/java/com/netflix/metacat/main/manager/ConnectorManager.java
@@ -314,7 +314,7 @@ public class ConnectorManager {
      * @param connectorType connector type
      * @return Returns the plugin for the given <code>catalogName</code>
      */
-    private ConnectorPlugin getPlugin(final String connectorType) {
+    public ConnectorPlugin getPlugin(final String connectorType) {
         Preconditions.checkNotNull(connectorType, "connectorType is null");
         final ConnectorPlugin result = plugins.get(connectorType);
         Preconditions.checkNotNull(result, "No connector plugin exists for type %s", connectorType);


### PR DESCRIPTION
- Accessing the list of available connector plugins can be generally useful to other components as well.