### PR TITLE
Add a getConnection API to HiveConnector fast table service

### DIFF
--- a/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/sql/DirectSqlTable.java
+++ b/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/sql/DirectSqlTable.java
@@ -47,6 +47,8 @@ import org.springframework.jdbc.core.SqlParameterValue;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.sql.Connection;
+import java.sql.SQLException;
 import java.sql.Types;
 import java.util.List;
 import java.util.Map;
@@ -135,6 +137,16 @@ public class DirectSqlTable {
         this.directSqlSavePartition = directSqlSavePartition;
         this.warehouse = warehouse;
         this.config = connectorContext.getConfig();
+    }
+
+    /**
+     * Returns the Jdbc connection of the underlying database
+     *
+     * @return the Jdbc connection of the underlying database
+     * @throws SQLException is the connection could not be fetched
+     */
+    public Connection getConnection() throws SQLException {
+        return jdbcTemplate.getDataSource().getConnection();
     }
 
     /**

--- a/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/sql/DirectSqlTable.java
+++ b/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/sql/DirectSqlTable.java
@@ -35,6 +35,7 @@ import com.netflix.metacat.connector.hive.monitoring.HiveMetrics;
 import com.netflix.metacat.connector.hive.util.HiveConnectorFastServiceMetric;
 import com.netflix.metacat.connector.hive.util.HiveTableUtil;
 import com.netflix.spectator.api.Registry;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.fs.Path;
@@ -143,8 +144,10 @@ public class DirectSqlTable {
      * Returns the Jdbc connection of the underlying database.
      *
      * @return the Jdbc connection of the underlying database
-     * @throws SQLException is the connection could not be fetched
+     * @throws SQLException if the connection could not be fetched
+     * @throws NullPointerException if no data source has been configured
      */
+    @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
     public Connection getConnection() throws SQLException {
         return jdbcTemplate.getDataSource().getConnection();
     }

--- a/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/sql/DirectSqlTable.java
+++ b/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/sql/DirectSqlTable.java
@@ -140,7 +140,7 @@ public class DirectSqlTable {
     }
 
     /**
-     * Returns the Jdbc connection of the underlying database
+     * Returns the Jdbc connection of the underlying database.
      *
      * @return the Jdbc connection of the underlying database
      * @throws SQLException is the connection could not be fetched

--- a/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/sql/HiveConnectorFastTableService.java
+++ b/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/sql/HiveConnectorFastTableService.java
@@ -35,6 +35,8 @@ import com.netflix.spectator.api.Registry;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.hadoop.fs.FileSystem;
 
+import java.sql.Connection;
+import java.sql.SQLException;
 import java.util.List;
 import java.util.Map;
 
@@ -82,6 +84,16 @@ public class HiveConnectorFastTableService extends HiveConnectorTableService {
         this.icebergTableHandler = icebergTableHandler;
         this.commonViewHandler = commonViewHandler;
         this.hiveConnectorFastTableServiceProxy = hiveConnectorFastTableServiceProxy;
+    }
+
+    /**
+     * Returns the Jdbc connection of the underlying database
+     *
+     * @return the Jdbc connection of the underlying database
+     * @throws SQLException is the connection could not be fetched
+     */
+    public Connection getConnection() throws SQLException {
+        return directSqlTable.getConnection();
     }
 
     @Override

--- a/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/sql/HiveConnectorFastTableService.java
+++ b/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/sql/HiveConnectorFastTableService.java
@@ -87,7 +87,7 @@ public class HiveConnectorFastTableService extends HiveConnectorTableService {
     }
 
     /**
-     * Returns the Jdbc connection of the underlying database
+     * Returns the Jdbc connection of the underlying database.
      *
      * @return the Jdbc connection of the underlying database
      * @throws SQLException is the connection could not be fetched

--- a/metacat-connector-hive/src/test/groovy/com/netflix/metacat/connector/hive/sql/DirectSqlTableSpec.groovy
+++ b/metacat-connector-hive/src/test/groovy/com/netflix/metacat/connector/hive/sql/DirectSqlTableSpec.groovy
@@ -4,7 +4,6 @@ import com.netflix.metacat.common.QualifiedName
 import com.netflix.metacat.common.server.connectors.exception.ConnectorException
 import com.netflix.metacat.common.server.connectors.exception.InvalidMetaException
 import com.netflix.metacat.common.server.connectors.exception.TableNotFoundException
-import com.netflix.metacat.common.server.connectors.exception.TablePreconditionFailedException
 import com.netflix.metacat.common.server.connectors.model.TableInfo
 import com.netflix.metacat.common.server.properties.DefaultConfigImpl
 import com.netflix.metacat.common.server.properties.MetacatProperties
@@ -18,6 +17,8 @@ import org.springframework.dao.EmptyResultDataAccessException
 import org.springframework.jdbc.core.JdbcTemplate
 import spock.lang.Specification
 
+import javax.sql.DataSource
+import java.sql.Connection
 import java.util.function.Supplier
 
 /**
@@ -40,6 +41,8 @@ class DirectSqlTableSpec extends Specification {
     def tableName = 't'
     def qualifiedName = QualifiedName.ofTable(catalogName, databaseName, tableName)
     def tableUpdateService = Mock(Supplier)
+    def dataSource = Mock(DataSource)
+    def connection = Mock(Connection)
 
     def "Test table exists check"() {
         when:
@@ -143,5 +146,19 @@ class DirectSqlTableSpec extends Specification {
         then:
         1 * jdbcTemplate.queryForObject(DirectSqlTable.SQL.TABLE_SEQUENCE_IDS,_,_,_) >> new TableSequenceIds(1,1,1,1)
         noExceptionThrown()
+    }
+
+    def "Test get-connection"() {
+        given:
+        jdbcTemplate.getDataSource() >> dataSource
+
+        and:
+        dataSource.getConnection() >> connection
+
+        when:
+        def actualConnection = service.getConnection()
+
+        then:
+        actualConnection == connection
     }
 }

--- a/metacat-connector-hive/src/test/groovy/com/netflix/metacat/connector/hive/sql/DirectSqlTableSpec.groovy
+++ b/metacat-connector-hive/src/test/groovy/com/netflix/metacat/connector/hive/sql/DirectSqlTableSpec.groovy
@@ -161,4 +161,12 @@ class DirectSqlTableSpec extends Specification {
         then:
         actualConnection == connection
     }
+
+    def "Test get-connection when no data source configured"() {
+        when:
+        service.getConnection()
+
+        then:
+        thrown(NullPointerException)
+    }
 }

--- a/metacat-connector-hive/src/test/groovy/com/netflix/metacat/connector/hive/sql/HiveConnectorFastTableServiceSpec.groovy
+++ b/metacat-connector-hive/src/test/groovy/com/netflix/metacat/connector/hive/sql/HiveConnectorFastTableServiceSpec.groovy
@@ -38,6 +38,8 @@ import org.apache.hadoop.hive.metastore.api.StorageDescriptor
 import org.apache.hadoop.hive.metastore.api.Table
 import spock.lang.Specification
 
+import java.sql.Connection
+
 class HiveConnectorFastTableServiceSpec extends Specification {
     MetacatHiveClient metacatHiveClient = Mock(MetacatHiveClient)
     HiveConnectorDatabaseService hiveConnectorDatabaseService = Mock(HiveConnectorDatabaseService)
@@ -47,6 +49,7 @@ class HiveConnectorFastTableServiceSpec extends Specification {
     DirectSqlTable directSqlTable = Mock(DirectSqlTable)
     HiveConnectorInfoConverter infoConverter = new HiveConnectorInfoConverter(new HiveTypeConverter())
     CommonViewHandler commonViewHandler = new CommonViewHandler(connectorContext)
+    Connection connection = Mock(Connection)
     HiveConnectorTableService service = new HiveConnectorFastTableService(
         "testhive",
         metacatHiveClient,
@@ -79,5 +82,16 @@ class HiveConnectorFastTableServiceSpec extends Specification {
         then:
         thrown(TableNotFoundException)
         metacatHiveClient.getTableByName(_,_) >> { throw new NoSuchObjectException()}
+    }
+
+    def "Test get-connection"() {
+        given:
+        directSqlTable.getConnection() >> connection
+
+        when:
+        def actualConnection = service.getConnection()
+
+        then:
+        actualConnection == connection
     }
 }


### PR DESCRIPTION
Adding an APi to get the underlying JDBC connection from the Hive fast table service.