### PR TITLE
Add tags to block table updates if needed

### DIFF
--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/connectors/exception/TableMigrationInProgressException.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/connectors/exception/TableMigrationInProgressException.java
@@ -1,0 +1,22 @@
+package com.netflix.metacat.common.server.connectors.exception;
+
+import com.netflix.metacat.common.exception.MetacatTooManyRequestsException;
+
+/**
+ * Exception indicating that the table is currently under migration
+ * and cannot be modified.
+ *
+ * Extends MetacatTooManyRequestsException so users can handle a HTTP 429 error code
+ * to retry with a backoff until migration completes.
+ */
+public class TableMigrationInProgressException extends MetacatTooManyRequestsException {
+
+    /**
+     * Ctor.
+     *
+     * @param reason The exception message.
+     */
+    public TableMigrationInProgressException(final String reason) {
+        super(reason);
+    }
+}

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/Config.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/Config.java
@@ -501,6 +501,13 @@ public interface Config {
     Set<String> getNoTableRenameOnTags();
 
     /**
+     * Set of tags that disable table update.
+     *
+     * @return set of tags
+     */
+    Set<String> getNoTableUpdateOnTags();
+
+    /**
      * Whether the rate limiter is enabled.
      *
      * @return True if it is.

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/DefaultConfigImpl.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/DefaultConfigImpl.java
@@ -591,6 +591,11 @@ public class DefaultConfigImpl implements Config {
         return this.metacatProperties.getTable().getRename().getNoRenameOnTagsSet();
     }
 
+    @Override
+    public Set<String> getNoTableUpdateOnTags() {
+        return this.metacatProperties.getTable().getUpdate().getNoUpdateOnTagsSet();
+    }
+
     /**
      * Whether the rate limiter is enabled.
      *

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/Table.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/Table.java
@@ -38,6 +38,8 @@ public class Table {
     private Delete delete = new Delete();
     @NonNull
     private Rename rename = new Rename();
+    @NonNull
+    private Update update = new Update();
 
     /**
      * Delete related properties.
@@ -126,6 +128,36 @@ public class Table {
                 }
             }
             return noRenameOnTagsSet;
+        }
+    }
+
+    /**
+     * Update related properties.
+     */
+    @lombok.Data
+    public static class Update {
+
+        private String noUpdateOnTags;
+        private Set<String> noUpdateOnTagsSet;
+
+        /**
+         * Get the tags that disable table updates.
+         *
+         * @return Set of tags
+         */
+        @JsonIgnore
+        public Set<String> getNoUpdateOnTagsSet() {
+            if (noUpdateOnTagsSet == null) {
+                if (StringUtils.isNotBlank(noUpdateOnTags)) {
+                    noUpdateOnTagsSet = new HashSet<>(Splitter.on(',')
+                            .omitEmptyStrings()
+                            .trimResults()
+                            .splitToList(noUpdateOnTags));
+                } else {
+                    noUpdateOnTagsSet = new HashSet<>();
+                }
+            }
+            return noUpdateOnTagsSet;
         }
     }
 }

--- a/metacat-functional-tests/metacat-test-cluster/docker-compose.yml
+++ b/metacat-functional-tests/metacat-test-cluster/docker-compose.yml
@@ -68,8 +68,9 @@ services:
                 -Dmetacat.authorization.createAcl.createAclStr=embedded-fast-hive-metastore/fsmoke_acl:metacat-prod
                 -Dmetacat.authorization.deleteAcl.deleteAclStr=embedded-fast-hive-metastore/fsmoke_acl:metacat-prod
                 -Dmetacat.service.tables.error.list.partitions.threshold=100
-                -Dmetacat.table.delete.noDeleteOnTags=do_not_drop
-                -Dmetacat.table.rename.noRenameOnTags=do_not_rename
+                -Dmetacat.table.delete.noDeleteOnTags=do_not_drop,iceberg_migration_do_not_modify
+                -Dmetacat.table.rename.noRenameOnTags=do_not_rename,iceberg_migration_do_not_modify
+                -Dmetacat.table.update.noUpdateOnTags=iceberg_migration_do_not_modify
                 -Dmetacat.event.updateIcebergTablePostEventEnabled=true'
         labels:
           - "com.netflix.metacat.oss.test"

--- a/metacat-main/src/main/java/com/netflix/metacat/main/services/TableService.java
+++ b/metacat-main/src/main/java/com/netflix/metacat/main/services/TableService.java
@@ -99,4 +99,6 @@ public interface TableService extends MetacatService<TableDto> {
      * @return list of table names
      */
     List<QualifiedName> getQualifiedNames(QualifiedName name, GetTableNamesServiceParameters parameters);
+
+
 }

--- a/metacat-testdata-provider/src/main/groovy/com/netflix/metacat/testdata/provider/DataDtoProvider.groovy
+++ b/metacat-testdata-provider/src/main/groovy/com/netflix/metacat/testdata/provider/DataDtoProvider.groovy
@@ -24,6 +24,7 @@ import com.netflix.metacat.common.server.connectors.ConnectorContext
 import com.netflix.metacat.common.server.properties.Config
 import com.netflix.metacat.common.server.properties.DefaultConfigImpl
 import com.netflix.metacat.common.server.properties.MetacatProperties
+import com.netflix.metacat.common.server.util.MetacatUtils
 import com.netflix.spectator.api.NoopRegistry
 
 /**
@@ -88,6 +89,16 @@ class DataDtoProvider {
                 ],
                 definitionMetadata: getDefinitionMetadata(owner)
         )
+    }
+
+    def static TableDto getTable(String sourceName, String databaseName, String tableName, String owner, String uri, Set<String> tags) {
+        def tableDto = getTable(sourceName, databaseName, tableName, owner, uri)
+        def tagArrayNode = metacatJson.getObjectMapper().createArrayNode()
+        for (String tag : tags) {
+            tagArrayNode.add(tag)
+        }
+        tableDto.getDefinitionMetadata().set(MetacatUtils.NAME_TAGS, tagArrayNode)
+        return tableDto
     }
 
     /**


### PR DESCRIPTION
- Will enable operations like migrating tables from hive to iceberg. 
- Added a tag specifically to block updates, renames and deletes when hive to iceberg migration is in progress. 
- When set, we throw a Retryable exception so the migration is transparent to users.