### PR TITLE
BugFix: On RenameTags, don't delete defintionMetadata for existing table with the newName.

### DIFF
--- a/metacat-metadata-mysql/src/main/java/com/netflix/metacat/metadata/mysql/MySqlTagService.java
+++ b/metacat-metadata-mysql/src/main/java/com/netflix/metacat/metadata/mysql/MySqlTagService.java
@@ -230,7 +230,7 @@ public class MySqlTagService implements TagService {
             final QualifiedName newName = QualifiedName.ofTable(name.getCatalogName(), name.getDatabaseName(),
                 newTableName);
             if (get(newName) != null) {
-                delete(newName, true);
+                delete(newName, false /*don't delete existing definition metadata with the new name*/);
             }
             jdbcTemplate.update(SQL_UPDATE_TAG_ITEM, new String[]{newName.toString(), name.toString()},
                 new int[]{Types.VARCHAR, Types.VARCHAR});


### PR DESCRIPTION
The renameTable API handles the definitionMetadata update and does the right thing. Clearing the tags here again would be a double-delete. 