### PR TITLE
Set the owner in table dto on create call for Thrift API

### DIFF
--- a/metacat-main/src/main/java/com/netflix/metacat/main/services/impl/TableServiceImpl.java
+++ b/metacat-main/src/main/java/com/netflix/metacat/main/services/impl/TableServiceImpl.java
@@ -285,7 +285,10 @@ public class TableServiceImpl implements TableService {
     }
 
     private boolean isOwnerValid(@Nullable final String userId) {
-        return StringUtils.isNotBlank(userId) && !"metacat".equals(userId) && !"root".equals(userId);
+        return StringUtils.isNotBlank(userId)
+                   && !"metacat".equals(userId)
+                   && !"root".equals(userId)
+                   && !"metacat-thrift-interface".equals(userId);
     }
 
     @SuppressFBWarnings

--- a/metacat-main/src/test/groovy/com/netflix/metacat/main/services/impl/TableServiceImplSpec.groovy
+++ b/metacat-main/src/test/groovy/com/netflix/metacat/main/services/impl/TableServiceImplSpec.groovy
@@ -342,18 +342,19 @@ class TableServiceImplSpec extends Specification {
         then:
         tableDto.getDefinitionMetadata() == toObjectNode(expectedDefMetadata)
         tableDto.getSerde() == expectedSerde
+        tableDto.getTableOwner() == Optional.ofNullable(expetedFinalOwner)
 
         where:
-        initialDefinitionMetadata                               | sessionUser | initialSerde                      || expectedDefMetadata                     | expectedSerde
-        null                                                    | null        | null                              || "{}"                                    | new StorageDto()
-        null                                                    | "ssarma"    | null                              || "{\"owner\":{\"userId\":\"ssarma\"}}"   | new StorageDto()
-        null                                                    | "root"      | new StorageDto(owner: "swaranga") || "{\"owner\":{\"userId\":\"swaranga\"}}" | new StorageDto(owner: "swaranga")
-        "{\"owner\":{\"userId\":\"ssarma\"}}"                   | "asdf"      | new StorageDto(owner: "swaranga") || "{\"owner\":{\"userId\":\"ssarma\"}}"   | new StorageDto(owner: "swaranga")
-        "{\"owner\":{\"userId\":\"metacat\"}}"                  | "ssarma"    | new StorageDto(owner: "swaranga") || "{\"owner\":{\"userId\":\"ssarma\"}}"   | new StorageDto(owner: "swaranga")
-        "{\"owner\":{\"userId\":\"root\"}}"                     | "ssarma"    | new StorageDto(owner: "swaranga") || "{\"owner\":{\"userId\":\"ssarma\"}}"   | new StorageDto(owner: "swaranga")
-        "{\"owner\":{\"userId\":\"root\"}}"                     | "metacat"   | new StorageDto(owner: "swaranga") || "{\"owner\":{\"userId\":\"swaranga\"}}" | new StorageDto(owner: "swaranga")
-        "{\"owner\":{\"userId\":\"root\"}}"                     | "metacat"   | new StorageDto(owner: "metacat")  || "{\"owner\":{\"userId\":\"root\"}}"     | new StorageDto(owner: "metacat")
-        "{\"owner\":{\"userId\":\"metacat-thrift-interface\"}}" | "ssarma"    | new StorageDto(owner: "swaranga") || "{\"owner\":{\"userId\":\"ssarma\"}}"   | new StorageDto(owner: "swaranga")
+        initialDefinitionMetadata                               | sessionUser | initialSerde                      || expectedDefMetadata                     | expectedSerde                     | expetedFinalOwner
+        null                                                    | null        | null                              || "{}"                                    | new StorageDto()                  | null
+        null                                                    | "ssarma"    | null                              || "{\"owner\":{\"userId\":\"ssarma\"}}"   | new StorageDto()                  | "ssarma"
+        null                                                    | "root"      | new StorageDto(owner: "swaranga") || "{\"owner\":{\"userId\":\"swaranga\"}}" | new StorageDto(owner: "swaranga") | "swaranga"
+        "{\"owner\":{\"userId\":\"ssarma\"}}"                   | "asdf"      | new StorageDto(owner: "swaranga") || "{\"owner\":{\"userId\":\"ssarma\"}}"   | new StorageDto(owner: "swaranga") | "ssarma"
+        "{\"owner\":{\"userId\":\"metacat\"}}"                  | "ssarma"    | new StorageDto(owner: "swaranga") || "{\"owner\":{\"userId\":\"ssarma\"}}"   | new StorageDto(owner: "swaranga") | "ssarma"
+        "{\"owner\":{\"userId\":\"root\"}}"                     | "ssarma"    | new StorageDto(owner: "swaranga") || "{\"owner\":{\"userId\":\"ssarma\"}}"   | new StorageDto(owner: "swaranga") | "ssarma"
+        "{\"owner\":{\"userId\":\"root\"}}"                     | "metacat"   | new StorageDto(owner: "swaranga") || "{\"owner\":{\"userId\":\"swaranga\"}}" | new StorageDto(owner: "swaranga") | "swaranga"
+        "{\"owner\":{\"userId\":\"root\"}}"                     | "metacat"   | new StorageDto(owner: "metacat")  || "{\"owner\":{\"userId\":\"root\"}}"     | new StorageDto(owner: "metacat")  | "root"
+        "{\"owner\":{\"userId\":\"metacat-thrift-interface\"}}" | "ssarma"    | new StorageDto(owner: "swaranga") || "{\"owner\":{\"userId\":\"ssarma\"}}"   | new StorageDto(owner: "swaranga") | "ssarma"
     }
 
     ObjectNode toObjectNode(jsonString) {

--- a/metacat-main/src/test/groovy/com/netflix/metacat/main/services/impl/TableServiceImplSpec.groovy
+++ b/metacat-main/src/test/groovy/com/netflix/metacat/main/services/impl/TableServiceImplSpec.groovy
@@ -344,15 +344,16 @@ class TableServiceImplSpec extends Specification {
         tableDto.getSerde() == expectedSerde
 
         where:
-        initialDefinitionMetadata              | sessionUser | initialSerde                      || expectedDefMetadata                     | expectedSerde
-        null                                   | null        | null                              || "{}"                                    | new StorageDto()
-        null                                   | "ssarma"    | null                              || "{\"owner\":{\"userId\":\"ssarma\"}}"   | new StorageDto()
-        null                                   | "root"      | new StorageDto(owner: "swaranga") || "{\"owner\":{\"userId\":\"swaranga\"}}" | new StorageDto(owner: "swaranga")
-        "{\"owner\":{\"userId\":\"ssarma\"}}"  | "asdf"      | new StorageDto(owner: "swaranga") || "{\"owner\":{\"userId\":\"ssarma\"}}"   | new StorageDto(owner: "swaranga")
-        "{\"owner\":{\"userId\":\"metacat\"}}" | "ssarma"    | new StorageDto(owner: "swaranga") || "{\"owner\":{\"userId\":\"ssarma\"}}"   | new StorageDto(owner: "swaranga")
-        "{\"owner\":{\"userId\":\"root\"}}"    | "ssarma"    | new StorageDto(owner: "swaranga") || "{\"owner\":{\"userId\":\"ssarma\"}}"   | new StorageDto(owner: "swaranga")
-        "{\"owner\":{\"userId\":\"root\"}}"    | "metacat"   | new StorageDto(owner: "swaranga") || "{\"owner\":{\"userId\":\"swaranga\"}}" | new StorageDto(owner: "swaranga")
-        "{\"owner\":{\"userId\":\"root\"}}"    | "metacat"   | new StorageDto(owner: "metacat")  || "{\"owner\":{\"userId\":\"root\"}}"     | new StorageDto(owner: "metacat")
+        initialDefinitionMetadata                               | sessionUser | initialSerde                      || expectedDefMetadata                     | expectedSerde
+        null                                                    | null        | null                              || "{}"                                    | new StorageDto()
+        null                                                    | "ssarma"    | null                              || "{\"owner\":{\"userId\":\"ssarma\"}}"   | new StorageDto()
+        null                                                    | "root"      | new StorageDto(owner: "swaranga") || "{\"owner\":{\"userId\":\"swaranga\"}}" | new StorageDto(owner: "swaranga")
+        "{\"owner\":{\"userId\":\"ssarma\"}}"                   | "asdf"      | new StorageDto(owner: "swaranga") || "{\"owner\":{\"userId\":\"ssarma\"}}"   | new StorageDto(owner: "swaranga")
+        "{\"owner\":{\"userId\":\"metacat\"}}"                  | "ssarma"    | new StorageDto(owner: "swaranga") || "{\"owner\":{\"userId\":\"ssarma\"}}"   | new StorageDto(owner: "swaranga")
+        "{\"owner\":{\"userId\":\"root\"}}"                     | "ssarma"    | new StorageDto(owner: "swaranga") || "{\"owner\":{\"userId\":\"ssarma\"}}"   | new StorageDto(owner: "swaranga")
+        "{\"owner\":{\"userId\":\"root\"}}"                     | "metacat"   | new StorageDto(owner: "swaranga") || "{\"owner\":{\"userId\":\"swaranga\"}}" | new StorageDto(owner: "swaranga")
+        "{\"owner\":{\"userId\":\"root\"}}"                     | "metacat"   | new StorageDto(owner: "metacat")  || "{\"owner\":{\"userId\":\"root\"}}"     | new StorageDto(owner: "metacat")
+        "{\"owner\":{\"userId\":\"metacat-thrift-interface\"}}" | "ssarma"    | new StorageDto(owner: "swaranga") || "{\"owner\":{\"userId\":\"ssarma\"}}"   | new StorageDto(owner: "swaranga")
     }
 
     ObjectNode toObjectNode(jsonString) {

--- a/metacat-thrift/src/main/java/com/netflix/metacat/thrift/HiveConvertersImpl.java
+++ b/metacat-thrift/src/main/java/com/netflix/metacat/thrift/HiveConvertersImpl.java
@@ -16,6 +16,8 @@
  */
 package com.netflix.metacat.thrift;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
@@ -28,6 +30,7 @@ import com.netflix.metacat.common.dto.PartitionDto;
 import com.netflix.metacat.common.dto.StorageDto;
 import com.netflix.metacat.common.dto.TableDto;
 import com.netflix.metacat.common.dto.ViewDto;
+import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.hive.common.FileUtils;
 import org.apache.hadoop.hive.metastore.TableType;
 import org.apache.hadoop.hive.metastore.Warehouse;
@@ -54,6 +57,7 @@ import java.util.stream.Collectors;
  * Hive converter.
  */
 public class HiveConvertersImpl implements HiveConverters {
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     @VisibleForTesting
     Integer dateToEpochSeconds(@Nullable final Date date) {
@@ -121,6 +125,15 @@ public class HiveConvertersImpl implements HiveConverters {
         dto.setFields(allFields);
         dto.setView(new ViewDto(table.getViewOriginalText(),
             table.getViewExpandedText()));
+
+        if (StringUtils.isNotBlank(table.getOwner())) {
+            final ObjectNode definitionMetadata = OBJECT_MAPPER.createObjectNode();
+            final ObjectNode ownerNode = definitionMetadata.with("owner");
+            ownerNode.put("userId", table.getOwner());
+
+            dto.setDefinitionMetadata(definitionMetadata);
+        }
+
         return dto;
     }
 

--- a/metacat-thrift/src/main/java/com/netflix/metacat/thrift/HiveConvertersImpl.java
+++ b/metacat-thrift/src/main/java/com/netflix/metacat/thrift/HiveConvertersImpl.java
@@ -221,6 +221,9 @@ public class HiveConvertersImpl implements HiveConverters {
             table.setPartitionKeys(partitionFields);
             table.getSd().setCols(nonPartitionFields);
         }
+
+        dto.getTableOwner().ifPresent(table::setOwner);
+
         return table;
     }
 

--- a/metacat-thrift/src/test/groovy/com/netflix/metacat/thrift/HiveConvertersSpec.groovy
+++ b/metacat-thrift/src/test/groovy/com/netflix/metacat/thrift/HiveConvertersSpec.groovy
@@ -18,10 +18,7 @@ import com.netflix.metacat.common.dto.*
 import com.netflix.metacat.common.server.connectors.ConnectorTypeConverter
 import com.netflix.metacat.common.server.properties.Config
 import com.netflix.metacat.common.type.VarcharType
-import org.apache.hadoop.hive.conf.HiveConf
 import org.apache.hadoop.hive.metastore.api.*
-import org.apache.hadoop.hive.ql.metadata.Hive
-import org.apache.hadoop.hive.ql.session.SessionState
 import org.joda.time.Instant
 import spock.lang.Specification
 
@@ -224,6 +221,7 @@ class HiveConvertersSpec extends Specification {
         }
         dto.fields.findAll { it.partition_key }.size() == 2
         dto.metadata == tableParams
+        dto.definitionMetadata.get("owner").get("userId").asText() == owner
 
         where:
         databaseName = 'database'

--- a/metacat-thrift/src/test/groovy/com/netflix/metacat/thrift/HiveConvertersSpec.groovy
+++ b/metacat-thrift/src/test/groovy/com/netflix/metacat/thrift/HiveConvertersSpec.groovy
@@ -234,6 +234,7 @@ class HiveConvertersSpec extends Specification {
         dto.fields.findAll { it.partition_key }.size() == 2
         dto.metadata == tableParams
         dto.definitionMetadata.get("owner").get("userId").asText() == owner
+        dto.getTableOwner().get() == owner
 
         where:
         databaseName = 'database'

--- a/metacat-thrift/src/test/groovy/com/netflix/metacat/thrift/HiveConvertersSpec.groovy
+++ b/metacat-thrift/src/test/groovy/com/netflix/metacat/thrift/HiveConvertersSpec.groovy
@@ -13,6 +13,7 @@
 
 package com.netflix.metacat.thrift
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.metacat.common.QualifiedName
 import com.netflix.metacat.common.dto.*
 import com.netflix.metacat.common.server.connectors.ConnectorTypeConverter
@@ -29,6 +30,8 @@ import java.util.Date
 
 class HiveConvertersSpec extends Specification {
     private static final ZoneOffset PACIFIC = LocalDateTime.now().atZone(ZoneId.of('America/Los_Angeles')).offset
+    private static final ObjectMapper MAPPER = new ObjectMapper()
+
     Config config = Mock(Config)
 //    TypeManager typeManager = Mock(TypeManager)
     HiveConvertersImpl converter
@@ -131,6 +134,15 @@ class HiveConvertersSpec extends Specification {
         table.partitionKeys != null
         table.parameters != null
         table.tableType != null
+
+        when:
+        def definitionMetadata = MAPPER.createObjectNode()
+        def ownerNode = definitionMetadata.with("owner")
+        ownerNode.put("userId", "asdf")
+        dto.setDefinitionMetadata(definitionMetadata)
+
+        then:
+        converter.metacatToHiveTable(dto).owner == "asdf"
     }
 
     def 'test metacatToHiveTable'() {


### PR DESCRIPTION
Since we have already established that the owner in the DTO takes highest priority, we set the owner in the DTO in the create call. Also made metacat-thrift-interface one of the invalid owners.