### PR TITLE
refactor throttling to allow for splitting request validation and rate limiting separately

### DIFF
--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/api/traffic_control/DefaultRequestGateway.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/api/traffic_control/DefaultRequestGateway.java
@@ -1,0 +1,14 @@
+package com.netflix.metacat.common.server.api.traffic_control;
+
+import com.netflix.metacat.common.QualifiedName;
+import lombok.NonNull;
+
+/**
+ * A default no-op gateway.
+ */
+public class DefaultRequestGateway implements RequestGateway {
+    @Override
+    public void validateRequest(@NonNull final String requestName, @NonNull final QualifiedName resource) {
+        // no-op
+    }
+}

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/api/traffic_control/RequestGateway.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/api/traffic_control/RequestGateway.java
@@ -1,0 +1,19 @@
+package com.netflix.metacat.common.server.api.traffic_control;
+
+import com.netflix.metacat.common.QualifiedName;
+import lombok.NonNull;
+
+/**
+ * An interface to gate incoming requests against unauthorized operations,
+ * blocked resources/apis etc.
+ */
+public interface RequestGateway {
+    /**
+     * Validate whether the request is alloed or not for the given resource. Implementations
+     * are expected to throw the relevant exception with the right context and detail.
+     *
+     * @param requestName the name of the request (ex: getTable).
+     * @param resource the primary resource of the request; like a table.
+     */
+    void validateRequest(@NonNull String requestName, @NonNull QualifiedName resource);
+}

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/api/traffic_control/package-info.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/api/traffic_control/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Package for traffic control related classes like rate limiting
+ * and request validation against blocked lists.
+ */
+package com.netflix.metacat.common.server.api.traffic_control;

--- a/metacat-common/src/main/java/com/netflix/metacat/common/MetacatRequestContext.java
+++ b/metacat-common/src/main/java/com/netflix/metacat/common/MetacatRequestContext.java
@@ -81,6 +81,9 @@ public class MetacatRequestContext implements Serializable {
     @Getter(AccessLevel.NONE)
     private Map<QualifiedName, String> tableTypeMap;
 
+    @Setter
+    private String requestName = UNKNOWN;
+
     /**
      * Constructor.
      */
@@ -137,6 +140,7 @@ public class MetacatRequestContext implements Serializable {
         sb.append(", dataTypeContext='").append(dataTypeContext).append('\'');
         sb.append(", apiUri='").append(apiUri).append('\'');
         sb.append(", scheme='").append(scheme).append('\'');
+        sb.append(", requestName='").append(requestName).append('\'');
         sb.append('}');
         return sb.toString();
     }

--- a/metacat-main/src/main/java/com/netflix/metacat/main/configs/ServicesConfig.java
+++ b/metacat-main/src/main/java/com/netflix/metacat/main/configs/ServicesConfig.java
@@ -20,6 +20,8 @@ package com.netflix.metacat.main.configs;
 import com.netflix.metacat.common.json.MetacatJson;
 import com.netflix.metacat.common.server.api.ratelimiter.DefaultRateLimiter;
 import com.netflix.metacat.common.server.api.ratelimiter.RateLimiter;
+import com.netflix.metacat.common.server.api.traffic_control.DefaultRequestGateway;
+import com.netflix.metacat.common.server.api.traffic_control.RequestGateway;
 import com.netflix.metacat.common.server.converter.ConverterUtil;
 import com.netflix.metacat.common.server.events.MetacatEventBus;
 import com.netflix.metacat.common.server.properties.Config;
@@ -136,6 +138,17 @@ public class ServicesConfig {
     @ConditionalOnMissingBean(RateLimiter.class)
     public RateLimiter rateLimiter() {
         return new DefaultRateLimiter();
+    }
+
+    /**
+     * The default {@link RequestGateway} bean.
+     *
+     * @return the default {@link RequestGateway} bean.
+     */
+    @Bean
+    @ConditionalOnMissingBean(RequestGateway.class)
+    public RequestGateway requestGateway() {
+        return new DefaultRequestGateway();
     }
 
     /**


### PR DESCRIPTION
Having separate interfaces for rate limiting and request blocklisting will allow us to move the functionality to other places. For now the rate limiting is still kept at the controller layer in case we want to enforce it later.