### PR TITLE
Implement partition APIs for polaris connector

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -202,6 +202,10 @@ configure(javaProjects) {
         configFile = new File(project.parent.projectDir, "codequality/checkstyle/checkstyle.xml")
     }
 
+    checkstyleTest {
+        configFile = new File(project.parent.projectDir, "codequality/checkstyle/checkstyle-test.xml")
+    }
+
     spotbugs {
         toolVersion = '4.0.6'
         excludeFilter = new File(project.parent.projectDir, "codequality/findbugs/excludeFilter.xml")

--- a/codequality/checkstyle/checkstyle-test.xml
+++ b/codequality/checkstyle/checkstyle-test.xml
@@ -50,11 +50,6 @@
         <!-- Check that finds import statements that use the * notation. -->
         <module name="AvoidStarImport"/>
 
-        <!-- Check that finds static imports. -->
-        <module name="AvoidStaticImport">
-            <property name="excludes" value="org.mockito.Mockito.*,org.assertj.core.api.Assertions.*"/>
-        </module>
-
         <!-- Checks that constant names conform to a format specified by the format property. -->
         <module name="ConstantName"/>
 
@@ -94,12 +89,6 @@
         <!-- Checks that class which has only private ctors is declared as final. -->
         <module name="FinalClass"/>
 
-        <!-- Ensures that local variables that never get their values changed, must be declared final. -->
-        <module name="FinalLocalVariable"/>
-
-        <!-- Check that method/constructor/catch/foreach parameters are final. -->
-        <module name="FinalParameters"/>
-
         <!-- Checks that the whitespace around the Generic tokens < and > are correct to the typical convention. -->
         <module name="GenericWhitespace"/>
 
@@ -131,30 +120,6 @@
         <!-- Implements Bloch, Effective Java, Item 17 - Use Interfaces only to define types. -->
         <module name="InterfaceIsType"/>
 
-        <!-- Checks the Javadoc of a method or constructor. -->
-        <module name="JavadocMethod">
-            <property name="scope" value="public"/>
-            <property name="allowThrowsTagsForSubclasses" value="true"/>
-            <property name="allowUndeclaredRTE" value="true"/>
-            <property name="allowMissingPropertyJavadoc" value="true"/>
-        </module>
-
-        <!-- Custom Checkstyle Check to validate Javadoc. -->
-        <module name="JavadocStyle">
-            <property name="checkEmptyJavadoc" value="true"/>
-        </module>
-
-        <!-- Checks the Javadoc of a type. -->
-        <module name="JavadocType">
-            <property name="scope" value="public"/>
-        </module>
-
-        <!-- Checks that a variable has Javadoc comment. -->
-        <module name="JavadocVariable">
-            <property name="scope" value="public"/>
-            <property name="ignoreNamePattern" value="Counter..*|Tracer..*|Gauge..*"/>
-        </module>
-
         <!-- Checks the placement of left curly braces on types, methods and other blocks. -->
         <module name="LeftCurly"/>
 
@@ -175,11 +140,6 @@
 
         <!-- Checks that instance variable names conform to a format specified by the format property. -->
         <module name="MemberName"/>
-
-        <!-- Checks for long methods. -->
-        <module name="MethodLength">
-            <property name="max" value="200"/>
-        </module>
 
         <!-- Checks that method names conform to a format specified by the format property. -->
         <module name="MethodName"/>
@@ -259,12 +219,6 @@
 
         <!-- Checks that string literals are not used with == or !=. -->
         <module name="StringLiteralEquality"/>
-
-        <!-- A check for TODO comments. -->
-        <!--<module name="TodoComment">-->
-        <!--<property name="format" value="TODO"/>-->
-        <!--<property name="severity" value="info"/>-->
-        <!--</module>-->
 
         <!-- Checks the padding of parentheses for typecasts. -->
         <module name="TypecastParenPad"/>

--- a/codequality/checkstyle/checkstyle.xml
+++ b/codequality/checkstyle/checkstyle.xml
@@ -51,9 +51,7 @@
         <module name="AvoidStarImport"/>
 
         <!-- Check that finds static imports. -->
-        <module name="AvoidStaticImport">
-            <property name="excludes" value="org.mockito.Mockito.*,org.assertj.core.api.Assertions.*"/>
-        </module>
+        <module name="AvoidStaticImport"/>
 
         <!-- Checks that constant names conform to a format specified by the format property. -->
         <module name="ConstantName"/>

--- a/metacat-connector-hive/src/test/groovy/com/netflix/metacat/connector/hive/iceberg/IcebergTableHandlerSpec.groovy
+++ b/metacat-connector-hive/src/test/groovy/com/netflix/metacat/connector/hive/iceberg/IcebergTableHandlerSpec.groovy
@@ -2,15 +2,20 @@ package com.netflix.metacat.connector.hive.iceberg
 
 import com.google.common.collect.ImmutableMap
 import com.netflix.metacat.common.QualifiedName
+import com.netflix.metacat.common.dto.Sort
+import com.netflix.metacat.common.dto.SortOrder
 import com.netflix.metacat.common.server.connectors.ConnectorContext
 import com.netflix.metacat.common.server.connectors.ConnectorRequestContext
 import com.netflix.metacat.common.server.connectors.exception.TableNotFoundException
 import com.netflix.metacat.common.server.connectors.exception.TablePreconditionFailedException
+import com.netflix.metacat.common.server.connectors.model.AuditInfo
 import com.netflix.metacat.common.server.connectors.model.TableInfo
 import com.netflix.metacat.connector.hive.configs.HiveConnectorFastServiceConfig
 import com.netflix.metacat.connector.hive.sql.DirectSqlTable
 import com.netflix.metacat.connector.hive.util.HiveConfigConstants
 import com.netflix.metacat.testdata.provider.DataDtoProvider
+import org.apache.iceberg.ScanSummary
+import org.apache.iceberg.Table
 import spock.lang.Specification
 
 class IcebergTableHandlerSpec extends Specification{
@@ -23,7 +28,7 @@ class IcebergTableHandlerSpec extends Specification{
     ConnectorContext connectorContext = DataDtoProvider.newContext(null, ImmutableMap.of(HiveConfigConstants.ALLOW_RENAME_TABLE, "true"))
 
     IcebergTableHandler icebergTableHandler =
-        new IcebergTableHandler(connectorContext, null, null, new HiveConnectorFastServiceConfig().icebergTableOps())
+        Spy(new IcebergTableHandler(connectorContext, null, null, new HiveConnectorFastServiceConfig().icebergTableOps()))
     DirectSqlTable directSqlTable = Mock(DirectSqlTable)
 
     def "Test iceberg table handleUpdate"() {
@@ -51,5 +56,49 @@ class IcebergTableHandlerSpec extends Specification{
         thrown(TablePreconditionFailedException)
         directSqlTable.updateIcebergTable(_) >> { throw new TablePreconditionFailedException(qualifiedName, '', 'x', 'p')}
         icebergTableHandler.update(_) >> true
+    }
+
+    def "test get partitions"() {
+        given:
+        def tableInfo = new TableInfo(
+            name: qualifiedName,
+            metadata: [
+                'table_type': 'ICEBERG',
+                'metadata_location':'s3:/c/d/t1',
+                'previous_metadata_location':'s3:/c/d/t'
+            ],
+            audit: new AuditInfo(createdBy: "ssarma")
+        )
+
+        def icebergTableWrapper = Mock(IcebergTableWrapper)
+        def icebergTable = Mock(Table)
+
+        icebergTableWrapper.getTable() >> icebergTable
+
+        icebergTableHandler.getIcebergTable(qualifiedName, "s3:/c/d/t1", false) >> icebergTableWrapper
+
+        icebergTableHandler.getIcebergTablePartitionMap(qualifiedName, "filter", icebergTable) >> [
+            "p=1": new ScanSummary.PartitionMetrics(fileCount: 1, dataTimestampMillis: 1),
+            "p=2": new ScanSummary.PartitionMetrics(fileCount: 2, dataTimestampMillis: 2),
+            "p=3": new ScanSummary.PartitionMetrics(fileCount: 3, dataTimestampMillis: 3),
+            "p=4": new ScanSummary.PartitionMetrics(fileCount: 4, dataTimestampMillis: 4),
+            "p=5": new ScanSummary.PartitionMetrics(fileCount: 5, dataTimestampMillis: 5)
+        ]
+
+        when:
+        def partitions = icebergTableHandler.getPartitions(
+            tableInfo, connectorContext, "filter", partitionIds as List<String>, sort as Sort
+        )
+
+        then:
+        partitions.collect {it -> it.getName().getPartitionName()} == expected
+
+        where:
+        partitionIds   | sort                                    || expected
+        ["p=4", "p=1"] | new Sort("dateCreated", SortOrder.ASC)  || ["p=1", "p=4"]
+        ["p=1", "p=3"] | new Sort("dateCreated", SortOrder.DESC) || ["p=3", "p=1"]
+        ["p=3", "p=1"] | null                                    || ["p=1", "p=3"]
+        null           | null                                    || ["p=1", "p=2", "p=3", "p=4", "p=5"]
+        []             | null                                    || []
     }
 }

--- a/metacat-connector-hive/src/test/groovy/com/netflix/metacat/connector/hive/util/IcebergFilterSpec.groovy
+++ b/metacat-connector-hive/src/test/groovy/com/netflix/metacat/connector/hive/util/IcebergFilterSpec.groovy
@@ -106,7 +106,7 @@ class IcebergFilterSpec extends Specification{
         def icebergUtil = new IcebergTableHandler(DataDtoProvider.newContext(null, ImmutableMap.of(HiveConfigConstants.ALLOW_RENAME_TABLE, "true")), icebergTableCriteria, icebergOpWrapper, new HiveConnectorFastServiceConfig().icebergTableOps())
 
         when:
-        icebergUtil.getIcebergTablePartitionMap(QualifiedName.fromString("tableName"), partRequest, icebergTable)
+        icebergUtil.getIcebergTablePartitionMap(QualifiedName.fromString("tableName"), null, icebergTable)
 
         then:
         noExceptionThrown()
@@ -122,11 +122,10 @@ class IcebergFilterSpec extends Specification{
         def dateint = Mock(Types.NestedField)
         def type = Mock(Type)
         def app = Mock(Types.NestedField)
-        def partRequest = new PartitionListRequest('dateint==1', [], false, null, null, false)
         def icebergUtil = new IcebergTableHandler(DataDtoProvider.newContext(null, ImmutableMap.of(HiveConfigConstants.ALLOW_RENAME_TABLE, "true")), icebergTableCriteria, icebergTableHelper, new HiveConnectorFastServiceConfig().icebergTableOps())
 
         when:
-        icebergUtil.getIcebergTablePartitionMap(QualifiedName.fromString("tableName"),partRequest, icebergTable)
+        icebergUtil.getIcebergTablePartitionMap(QualifiedName.fromString("tableName"), "dateint==1", icebergTable)
 
         then:
         noExceptionThrown()

--- a/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/PolarisConnectorFactory.java
+++ b/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/PolarisConnectorFactory.java
@@ -3,6 +3,7 @@ package com.netflix.metacat.connector.polaris;
 import com.netflix.metacat.common.server.connectors.ConnectorContext;
 import com.netflix.metacat.common.server.connectors.ConnectorDatabaseService;
 import com.netflix.metacat.common.server.connectors.ConnectorInfoConverter;
+import com.netflix.metacat.common.server.connectors.ConnectorPartitionService;
 import com.netflix.metacat.common.server.connectors.ConnectorTableService;
 import com.netflix.metacat.common.server.connectors.SpringConnectorFactory;
 import com.netflix.metacat.connector.polaris.configs.PolarisConnectorConfig;
@@ -32,6 +33,11 @@ class PolarisConnectorFactory extends SpringConnectorFactory {
         super.addEnvProperties(new MapPropertySource(
                 "polaris_connector", Collections.unmodifiableMap(connectorContext.getConfiguration())));
         super.refresh();
+    }
+
+    @Override
+    public ConnectorPartitionService getPartitionService() {
+        return ctx.getBean(PolarisConnectorPartitionService.class);
     }
 
     /**

--- a/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/PolarisConnectorPartitionService.java
+++ b/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/PolarisConnectorPartitionService.java
@@ -20,10 +20,7 @@ import java.util.stream.Collectors;
 /**
  * Partition service for Iceberg tables in Polaris.
  *
- * Delegates to the Hive implementation that has support for Iceberg tables
- * for specific methods. For all other methods that are not supported in the
- * Hive service for iceberg tables, we use the default implementation which
- * throws {@link UnsupportedOperationException}.
+ * Currently, supports read-only methods with the exception of getPartitionNames.
  */
 @RequiredArgsConstructor
 public class PolarisConnectorPartitionService implements ConnectorPartitionService {

--- a/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/PolarisConnectorPartitionService.java
+++ b/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/PolarisConnectorPartitionService.java
@@ -1,0 +1,123 @@
+package com.netflix.metacat.connector.polaris;
+
+import com.netflix.metacat.common.QualifiedName;
+import com.netflix.metacat.common.server.connectors.ConnectorContext;
+import com.netflix.metacat.common.server.connectors.ConnectorPartitionService;
+import com.netflix.metacat.common.server.connectors.ConnectorRequestContext;
+import com.netflix.metacat.common.server.connectors.ConnectorUtils;
+import com.netflix.metacat.common.server.connectors.exception.PartitionNotFoundException;
+import com.netflix.metacat.common.server.connectors.model.PartitionInfo;
+import com.netflix.metacat.common.server.connectors.model.PartitionListRequest;
+import com.netflix.metacat.common.server.connectors.model.TableInfo;
+import com.netflix.metacat.connector.hive.iceberg.IcebergTableHandler;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Partition service for Iceberg tables in Polaris.
+ *
+ * Delegates to the Hive implementation that has support for Iceberg tables
+ * for specific methods. For all other methods that are not supported in the
+ * Hive service for iceberg tables, we use the default implementation which
+ * throws {@link UnsupportedOperationException}.
+ */
+@RequiredArgsConstructor
+public class PolarisConnectorPartitionService implements ConnectorPartitionService {
+    private final ConnectorContext context;
+    private final IcebergTableHandler icebergTableHandler;
+    private final PolarisConnectorTableService tableService;
+
+    /**
+     * {@inheritDoc}.
+     */
+    @Override
+    public List<PartitionInfo> getPartitions(@NonNull final ConnectorRequestContext requestContext,
+                                             @NonNull final QualifiedName tableName,
+                                             @NonNull final PartitionListRequest partitionsRequest,
+                                             @NonNull final TableInfo tableInfo) {
+        return ConnectorUtils.paginate(
+            icebergTableHandler.getPartitions(
+                tableInfo,
+                context,
+                partitionsRequest.getFilter(),
+                partitionsRequest.getPartitionNames(),
+                partitionsRequest.getSort()
+            ),
+            partitionsRequest.getPageable()
+        );
+    }
+
+    /**
+     * {@inheritDoc}.
+     */
+    @Override
+    public List<String> getPartitionKeys(@NonNull final ConnectorRequestContext requestContext,
+                                         @NonNull final QualifiedName tableName,
+                                         @NonNull final PartitionListRequest partitionsRequest,
+                                         @NonNull final TableInfo tableInfo) {
+        return getPartitions(requestContext, tableName, partitionsRequest, tableInfo).stream()
+                   .map(info -> info.getName().getPartitionName())
+                   .collect(Collectors.toList());
+    }
+
+    /**
+     * {@inheritDoc}.
+     */
+    @Override
+    public int getPartitionCount(@NonNull final ConnectorRequestContext requestContext,
+                                 @NonNull final QualifiedName table,
+                                 @NonNull final TableInfo tableInfo) {
+        return icebergTableHandler.getPartitions(
+            tableInfo,
+            context,
+            null, // filer expression
+            null, // partition ids
+            null // sort
+        ).size();
+    }
+
+    /**
+     * {@inheritDoc}.
+     */
+    @Override
+    public List<String> getPartitionUris(@NonNull final ConnectorRequestContext requestContext,
+                                         @NonNull final QualifiedName table,
+                                         @NonNull final PartitionListRequest partitionsRequest,
+                                         @NonNull final TableInfo tableInfo) {
+        return getPartitions(requestContext, table, partitionsRequest, tableInfo).stream()
+                   .map(partitionInfo -> partitionInfo.getSerde().getUri())
+                   .collect(Collectors.toList());
+    }
+
+    /**
+     * {@inheritDoc}.
+     */
+    @Override
+    public PartitionInfo get(@NonNull final ConnectorRequestContext requestContext,
+                             @NonNull final QualifiedName partitionName) {
+        final QualifiedName tableName = QualifiedName.ofTable(
+            partitionName.getCatalogName(),
+            partitionName.getDatabaseName(),
+            partitionName.getTableName()
+        );
+
+        final TableInfo tableInfo = tableService.get(requestContext, tableName);
+
+        final List<PartitionInfo> partitions = icebergTableHandler.getPartitions(
+            tableInfo,
+            context,
+            null,
+            Collections.singletonList(partitionName.getPartitionName()),
+            null
+        );
+
+        return partitions.stream()
+                   .filter(partitionInfo -> partitionInfo.getName().equals(partitionName))
+                   .findFirst()
+                   .orElseThrow(() -> new PartitionNotFoundException(tableName, partitionName.getPartitionName()));
+    }
+}

--- a/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/configs/PolarisConnectorConfig.java
+++ b/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/configs/PolarisConnectorConfig.java
@@ -10,6 +10,7 @@ import com.netflix.metacat.connector.hive.iceberg.IcebergTableHandler;
 import com.netflix.metacat.connector.hive.iceberg.IcebergTableOpWrapper;
 import com.netflix.metacat.connector.hive.iceberg.IcebergTableOpsProxy;
 import com.netflix.metacat.connector.polaris.PolarisConnectorDatabaseService;
+import com.netflix.metacat.connector.polaris.PolarisConnectorPartitionService;
 import com.netflix.metacat.connector.polaris.PolarisConnectorTableService;
 import com.netflix.metacat.connector.polaris.common.PolarisConnectorConsts;
 import com.netflix.metacat.connector.polaris.common.TransactionRetryAspect;
@@ -27,6 +28,22 @@ import org.springframework.retry.support.RetryTemplate;
  * Config for polaris connector.
  */
 public class PolarisConnectorConfig {
+    /**
+     * Creates a new instance of a polaris connector partition service.
+     *
+     * @param icebergTableHandler iceberg table handler
+     * @param connectorContext connector context
+     * @param polarisTableService polaris table service
+     * @return PolarisConnectorPartitionService
+     */
+    @Bean
+    public PolarisConnectorPartitionService polarisConnectorPartitionService(
+        final IcebergTableHandler icebergTableHandler,
+        final ConnectorContext connectorContext,
+        final PolarisConnectorTableService polarisTableService) {
+        return new PolarisConnectorPartitionService(connectorContext, icebergTableHandler, polarisTableService);
+    }
+
     /**
      * Create polaris connector database service.
      *

--- a/metacat-connector-polaris/src/test/java/com/netflix/metacat/connector/polaris/PolarisConnectorPartitionServiceTest.java
+++ b/metacat-connector-polaris/src/test/java/com/netflix/metacat/connector/polaris/PolarisConnectorPartitionServiceTest.java
@@ -1,0 +1,215 @@
+package com.netflix.metacat.connector.polaris;
+
+import com.netflix.metacat.common.QualifiedName;
+import com.netflix.metacat.common.dto.Pageable;
+import com.netflix.metacat.common.dto.Sort;
+import com.netflix.metacat.common.server.connectors.ConnectorContext;
+import com.netflix.metacat.common.server.connectors.ConnectorRequestContext;
+import com.netflix.metacat.common.server.connectors.model.PartitionInfo;
+import com.netflix.metacat.common.server.connectors.model.PartitionListRequest;
+import com.netflix.metacat.common.server.connectors.model.PartitionsSaveRequest;
+import com.netflix.metacat.common.server.connectors.model.StorageInfo;
+import com.netflix.metacat.common.server.connectors.model.TableInfo;
+import com.netflix.metacat.connector.hive.iceberg.IcebergTableHandler;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.same;
+
+public class PolarisConnectorPartitionServiceTest {
+    private QualifiedName tableName;
+    private QualifiedName partitionName;
+    private QualifiedName partitionName2;
+    private TableInfo tableInfo;
+    private PartitionListRequest partitionsListRequest;
+    private PartitionsSaveRequest partitionsSaveRequest;
+    private List<String> partitionNames;
+    private List<String> uris;
+    private PartitionInfo partitionInfo;
+    private PartitionInfo partitionInfo2;
+    private Sort sort;
+
+    @Mock
+    private ConnectorRequestContext requestContext;
+    @Mock
+    private ConnectorContext connectorContext;
+    @Mock
+    private IcebergTableHandler icebergTableHandler;
+    @Mock
+    private PolarisConnectorTableService tableService;
+
+    private PolarisConnectorPartitionService polaris;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+
+        tableName = QualifiedName.fromString("catalog/db/table");
+        partitionName = QualifiedName.fromString("catalog/db/table/dateint=20230101");
+        partitionName2 = QualifiedName.fromString("catalog/db/table/dateint=20230102");
+        tableInfo = TableInfo.builder().name(tableName).build();
+        partitionsListRequest = new PartitionListRequest();
+        partitionsSaveRequest = new PartitionsSaveRequest();
+        partitionNames = Arrays.asList("p1", "p2");
+        uris = Arrays.asList("u1", "u2");
+        partitionInfo = new PartitionInfo();
+        partitionInfo2 = new PartitionInfo();
+        sort = new Sort();
+
+        polaris = new PolarisConnectorPartitionService(connectorContext, icebergTableHandler, tableService);
+    }
+
+    @Test
+    public void getPartitions() {
+
+        partitionsListRequest.setFilter("filter");
+        partitionsListRequest.setPartitionNames(Collections.singletonList("dateint=20230101"));
+        partitionsListRequest.setPageable(new Pageable(1, 0));
+        partitionsListRequest.setSort(sort);
+
+        doReturn(Arrays.asList(partitionInfo, partitionInfo2))
+            .when(icebergTableHandler).getPartitions(
+                same(tableInfo),
+                same(connectorContext),
+                eq("filter"),
+                eq(Collections.singletonList("dateint=20230101")),
+                same(sort));
+
+        final List<PartitionInfo> partitions
+            = polaris.getPartitions(requestContext, tableName, partitionsListRequest, tableInfo);
+
+        assertThat(partitions).isEqualTo(Collections.singletonList(partitionInfo));
+    }
+
+    @Test
+    public void getPartitionKeys() {
+
+        partitionInfo.setName(partitionName);
+        partitionInfo2.setName(partitionName2);
+
+        partitionsListRequest.setFilter("filter");
+        partitionsListRequest.setPartitionNames(Collections.singletonList("dateint=20230101"));
+        partitionsListRequest.setPageable(new Pageable(2, 0));
+        partitionsListRequest.setSort(sort);
+
+        doReturn(Arrays.asList(partitionInfo, partitionInfo2))
+            .when(icebergTableHandler).getPartitions(
+                same(tableInfo),
+                same(connectorContext),
+                eq("filter"),
+                eq(Collections.singletonList("dateint=20230101")),
+                same(sort));
+
+        final List<String> partitionKeys
+            = polaris.getPartitionKeys(requestContext, tableName, partitionsListRequest, tableInfo);
+
+        assertThat(partitionKeys).isEqualTo(Arrays.asList("dateint=20230101", "dateint=20230102"));
+    }
+
+    @Test
+    public void get() {
+        partitionInfo.setName(partitionName);
+        partitionInfo2.setName(partitionName2);
+
+        doReturn(tableInfo).when(tableService)
+            .get(requestContext, QualifiedName.ofTable("catalog", "db", "table"));
+
+        doReturn(Arrays.asList(partitionInfo, partitionInfo2))
+            .when(icebergTableHandler).getPartitions(
+                same(tableInfo),
+                same(connectorContext),
+                eq(null),
+                eq(Collections.singletonList("dateint=20230101")),
+                eq(null));
+
+        final PartitionInfo partition = polaris.get(requestContext, partitionName);
+
+        assertThat(partition).isSameAs(partitionInfo);
+    }
+
+    @Test
+    public void getPartitionNames() {
+        assertThatThrownBy(() -> polaris.getPartitionNames(requestContext, uris, true))
+            .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    public void getPartitionUris() {
+        partitionInfo.setName(partitionName);
+        partitionInfo2.setName(partitionName2);
+
+        partitionInfo.setSerde(StorageInfo.builder().uri("uri1").build());
+        partitionInfo2.setSerde(StorageInfo.builder().uri("uri2").build());
+
+        doReturn(Arrays.asList(partitionInfo, partitionInfo2))
+            .when(icebergTableHandler).getPartitions(
+                same(tableInfo),
+                same(connectorContext),
+                eq("filter"),
+                eq(Collections.singletonList("dateint=20230101")),
+                same(sort));
+
+        partitionsListRequest.setFilter("filter");
+        partitionsListRequest.setPartitionNames(Collections.singletonList("dateint=20230101"));
+        partitionsListRequest.setPageable(new Pageable(1, 1));
+        partitionsListRequest.setSort(sort);
+
+        final List<String> partitionUris
+            = polaris.getPartitionUris(requestContext, tableName, partitionsListRequest, tableInfo);
+
+        assertThat(partitionUris).isEqualTo(Collections.singletonList("uri2"));
+    }
+
+    @Test
+    public void getPartitionCount() {
+        doReturn(Arrays.asList(partitionInfo, partitionInfo2))
+            .when(icebergTableHandler).getPartitions(
+                same(tableInfo),
+                same(connectorContext),
+                eq(null),
+                eq(null),
+                eq(null));
+
+        assertThat(polaris.getPartitionCount(requestContext, tableName, tableInfo)).isEqualTo(2);
+    }
+
+    @Test
+    public void create() {
+        assertThatThrownBy(() -> polaris.create(requestContext, partitionInfo))
+            .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    public void update() {
+        assertThatThrownBy(() -> polaris.update(requestContext, partitionInfo))
+            .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    public void delete() {
+        assertThatThrownBy(() -> polaris.delete(requestContext, partitionName))
+            .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    public void savePartitions() {
+        assertThatThrownBy(() -> polaris.savePartitions(requestContext, tableName, partitionsSaveRequest))
+            .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    public void deletePartitions() {
+        assertThatThrownBy(() -> polaris.deletePartitions(requestContext, tableName, partitionNames, tableInfo))
+            .isInstanceOf(UnsupportedOperationException.class);
+    }
+}


### PR DESCRIPTION
* Implemented the read-only APIs except the getPartitionNames.
* All write APIs throw unsupported operation exception
* Moved some common Iceberg specific code to IcebergTableHandler from the hive connector so we can reuse them in the polaris connector
* Split the checkstyle rules for test with some rules relaxed:
  * Allow static imports
  * No need of Javadoc for tests
  * Relax rules on final local variable and method parameters