### PR TITLE
Fix bug with hive column name with space replacement

### DIFF
--- a/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/converters/HiveTypeConverter.java
+++ b/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/converters/HiveTypeConverter.java
@@ -267,15 +267,15 @@ public class HiveTypeConverter implements ConnectorTypeConverter {
 
             // we cannot simply use matcher.matches() and matcher.replaceAll()
             // because that will replace the decimal declaration itself
-            // instead we use the region APIs to find the substring that matched
+            // instead we use the region APIs (start() and end()) to find the substring that matched
             // and then apply the replace function to remove spaces in the decimal declaration
             // we do this for all the matches in the type declaration and hence the usage of the while loop
             while (matcher.find()) {
                 // this index represents the start index (inclusive) of our current match
-                final int currMatchStart = matcher.regionStart();
+                final int currMatchStart = matcher.start();
 
                 // this represents the end index (exclusive) of our current match
-                final int currMatchEnd = matcher.regionEnd();
+                final int currMatchEnd = matcher.end();
 
                 replacedType
                     // first append any part of the string that did not match

--- a/metacat-connector-hive/src/test/groovy/com/netflix/metacat/connector/hive/converters/HiveTypeConverterSpec.groovy
+++ b/metacat-connector-hive/src/test/groovy/com/netflix/metacat/connector/hive/converters/HiveTypeConverterSpec.groovy
@@ -110,6 +110,15 @@ class HiveTypeConverterSpec extends Specification {
             "struct<prediction_date:int,lower_confidence_amt:decimal(30, 2),upper_confidence_amt:decimal(30,2),model_short_name:string>",
             "struct<prediction_date:int,lower_confidence_amt:decimal(30,2),upper_confidence_amt:decimal(30, 2),model_short_name:string>",
             "struct<prediction_date:int,lower_confidence_amt:decimal(30, 2),upper_confidence_amt:decimal(30, 2),model_short_name:string>",
+
+            "struct<prediction_cnt:int,first_prediction_date:int,last_prediction_date:int>",
+            "struct<prediction_date:int,lower_confidence_amt:decimal(30,2),upper_confidence_amt:decimal(30,2),model_short_name:string>",
+            "struct<prediction_date:int,lower_confidence_amt:decimal(30,2),upper_confidence_amt:decimal(30,2)>",
+            "struct<prediction_date:int,lower_confidence_amt:double,upper_confidence_amt:double,model_short_name:string,compression_factor:double>",
+            "struct<prediction_date:int,lower_confidence_amt:double,upper_confidence_amt:double,model_short_name:string,pmvs_sticker_pts:double,pmvs_sticker_pts_lower_confidence_amt:double,pmvs_sticker_pts_upper_confidence_amt:double,pmvs_dt_pts:double,pmvs_dt_pct:double,pmvs_baseline_dt_pct:double,thumber_cnt:int,thumber_threshold_met:boolean,pmvs_dt_pts_ignoring_threshold:double,pmvs_dt_rmse:double,pmvs_baseline_dt_rmse:double>",
+            "struct<prediction_date:int,lower_confidence_amt:double,upper_confidence_amt:double,model_short_name:string>",
+            "struct<prediction_date:int,lower_confidence_amt:int,upper_confidence_amt:int,model_short_name:string>",
+            "struct<prediction_date:int,prediction_source:string>",
         ]
     }
 
@@ -196,11 +205,19 @@ class HiveTypeConverterSpec extends Specification {
         "struct<field1:string,field2:decimal (38),field3:bigint>"     || "struct<field1:string,field2:decimal(38),field3:bigint>"
         "struct<field1:string,field2:decimal(38 ),field3:bigint>"     || "struct<field1:string,field2:decimal(38),field3:bigint>"
 
-
         "struct<prediction_date:int,lower_confidence_amt:decimal(30, 2),upper_confidence_amt:decimal(30,2),model_short_name:string>" || "struct<prediction_date:int,lower_confidence_amt:decimal(30,2),upper_confidence_amt:decimal(30,2),model_short_name:string>"
         "struct<prediction_date:int,lower_confidence_amt:decimal(30,2),upper_confidence_amt:decimal(30, 2),model_short_name:string>" || "struct<prediction_date:int,lower_confidence_amt:decimal(30,2),upper_confidence_amt:decimal(30,2),model_short_name:string>"
         "struct<prediction_date:int,lower_confidence_amt:decimal(30, 2),upper_confidence_amt:decimal(30, 2),model_short_name:string>" || "struct<prediction_date:int,lower_confidence_amt:decimal(30,2),upper_confidence_amt:decimal(30,2),model_short_name:string>"
         "struct<prediction_date:int,lower_confidence_amt:decimal(30,2),upper_confidence_amt:decimal(30,2),model_short_name:string>" || "struct<prediction_date:int,lower_confidence_amt:decimal(30,2),upper_confidence_amt:decimal(30,2),model_short_name:string>"
+
+        "struct<prediction_cnt:int,first_prediction_date:int,last_prediction_date:int>" || "struct<prediction_cnt:int,first_prediction_date:int,last_prediction_date:int>"
+        "struct<prediction_date:int,lower_confidence_amt:decimal(30,2),upper_confidence_amt:decimal(30,2),model_short_name:string>" || "struct<prediction_date:int,lower_confidence_amt:decimal(30,2),upper_confidence_amt:decimal(30,2),model_short_name:string>"
+        "struct<prediction_date:int,lower_confidence_amt:decimal(30,2),upper_confidence_amt:decimal(30,2)>" || "struct<prediction_date:int,lower_confidence_amt:decimal(30,2),upper_confidence_amt:decimal(30,2)>"
+        "struct<prediction_date:int,lower_confidence_amt:double,upper_confidence_amt:double,model_short_name:string,compression_factor:double>" || "struct<prediction_date:int,lower_confidence_amt:double,upper_confidence_amt:double,model_short_name:string,compression_factor:double>"
+        "struct<prediction_date:int,lower_confidence_amt:double,upper_confidence_amt:double,model_short_name:string,pmvs_sticker_pts:double,pmvs_sticker_pts_lower_confidence_amt:double,pmvs_sticker_pts_upper_confidence_amt:double,pmvs_dt_pts:double,pmvs_dt_pct:double,pmvs_baseline_dt_pct:double,thumber_cnt:int,thumber_threshold_met:boolean,pmvs_dt_pts_ignoring_threshold:double,pmvs_dt_rmse:double,pmvs_baseline_dt_rmse:double>" || "struct<prediction_date:int,lower_confidence_amt:double,upper_confidence_amt:double,model_short_name:string,pmvs_sticker_pts:double,pmvs_sticker_pts_lower_confidence_amt:double,pmvs_sticker_pts_upper_confidence_amt:double,pmvs_dt_pts:double,pmvs_dt_pct:double,pmvs_baseline_dt_pct:double,thumber_cnt:int,thumber_threshold_met:boolean,pmvs_dt_pts_ignoring_threshold:double,pmvs_dt_rmse:double,pmvs_baseline_dt_rmse:double>"
+        "struct<prediction_date:int,lower_confidence_amt:double,upper_confidence_amt:double,model_short_name:string>" || "struct<prediction_date:int,lower_confidence_amt:double,upper_confidence_amt:double,model_short_name:string>"
+        "struct<prediction_date:int,lower_confidence_amt:int,upper_confidence_amt:int,model_short_name:string>" || "struct<prediction_date:int,lower_confidence_amt:int,upper_confidence_amt:int,model_short_name:string>"
+        "struct<prediction_date:int,prediction_source:string>" || "struct<prediction_date:int,prediction_source:string>"
     }
 
     @Unroll

--- a/metacat-connector-hive/src/test/groovy/com/netflix/metacat/connector/hive/converters/HiveTypeConverterSpec.groovy
+++ b/metacat-connector-hive/src/test/groovy/com/netflix/metacat/connector/hive/converters/HiveTypeConverterSpec.groovy
@@ -105,6 +105,11 @@ class HiveTypeConverterSpec extends Specification {
             "struct<field1:string,field2:decimal (38,9 ),field3:bigint>",
             "struct<field1:string,field2:decimal (38),field3:bigint>",
             "struct<field1:string,field2:decimal(38 ),field3:bigint>",
+
+            "struct<prediction_date:int,lower_confidence_amt:decimal(30,2),upper_confidence_amt:decimal(30,2),model_short_name:string>",
+            "struct<prediction_date:int,lower_confidence_amt:decimal(30, 2),upper_confidence_amt:decimal(30,2),model_short_name:string>",
+            "struct<prediction_date:int,lower_confidence_amt:decimal(30,2),upper_confidence_amt:decimal(30, 2),model_short_name:string>",
+            "struct<prediction_date:int,lower_confidence_amt:decimal(30, 2),upper_confidence_amt:decimal(30, 2),model_short_name:string>",
         ]
     }
 
@@ -190,6 +195,12 @@ class HiveTypeConverterSpec extends Specification {
         "struct<field1:string,field2:decimal (38,9 ),field3:bigint>"  || "struct<field1:string,field2:decimal(38,9),field3:bigint>"
         "struct<field1:string,field2:decimal (38),field3:bigint>"     || "struct<field1:string,field2:decimal(38),field3:bigint>"
         "struct<field1:string,field2:decimal(38 ),field3:bigint>"     || "struct<field1:string,field2:decimal(38),field3:bigint>"
+
+
+        "struct<prediction_date:int,lower_confidence_amt:decimal(30, 2),upper_confidence_amt:decimal(30,2),model_short_name:string>" || "struct<prediction_date:int,lower_confidence_amt:decimal(30,2),upper_confidence_amt:decimal(30,2),model_short_name:string>"
+        "struct<prediction_date:int,lower_confidence_amt:decimal(30,2),upper_confidence_amt:decimal(30, 2),model_short_name:string>" || "struct<prediction_date:int,lower_confidence_amt:decimal(30,2),upper_confidence_amt:decimal(30,2),model_short_name:string>"
+        "struct<prediction_date:int,lower_confidence_amt:decimal(30, 2),upper_confidence_amt:decimal(30, 2),model_short_name:string>" || "struct<prediction_date:int,lower_confidence_amt:decimal(30,2),upper_confidence_amt:decimal(30,2),model_short_name:string>"
+        "struct<prediction_date:int,lower_confidence_amt:decimal(30,2),upper_confidence_amt:decimal(30,2),model_short_name:string>" || "struct<prediction_date:int,lower_confidence_amt:decimal(30,2),upper_confidence_amt:decimal(30,2),model_short_name:string>"
     }
 
     @Unroll


### PR DESCRIPTION
We were using the wrong method from the matcher. regionStart actually gives you the start index of the input being matched. The right method to use here is `start` and `end`.

Also added test cases for all the column types for the table that was affected.