### PR TITLE
Metacat throttling refactor

### DIFF
--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/api/ratelimiter/RateLimiterRequestContext.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/api/ratelimiter/RateLimiterRequestContext.java
@@ -20,6 +20,7 @@ package com.netflix.metacat.common.server.api.ratelimiter;
 import com.netflix.metacat.common.QualifiedName;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 /**
@@ -30,6 +31,7 @@ import lombok.Getter;
 @AllArgsConstructor
 @Builder
 @Getter
+@EqualsAndHashCode
 public class RateLimiterRequestContext {
     /**
      * The API request. eg. getTable, updateTable etc.

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/api/traffic_control/DefaultRequestGateway.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/api/traffic_control/DefaultRequestGateway.java
@@ -1,0 +1,14 @@
+package com.netflix.metacat.common.server.api.traffic_control;
+
+import com.netflix.metacat.common.QualifiedName;
+import lombok.NonNull;
+
+/**
+ * A default no-op gateway.
+ */
+public class DefaultRequestGateway implements RequestGateway {
+    @Override
+    public void validateRequest(@NonNull final String requestName, @NonNull final QualifiedName resource) {
+        // no-op
+    }
+}

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/api/traffic_control/RequestGateway.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/api/traffic_control/RequestGateway.java
@@ -1,0 +1,19 @@
+package com.netflix.metacat.common.server.api.traffic_control;
+
+import com.netflix.metacat.common.QualifiedName;
+import lombok.NonNull;
+
+/**
+ * An interface to gate incoming requests against unauthorized operations,
+ * blocked resources/apis etc.
+ */
+public interface RequestGateway {
+    /**
+     * Validate whether the request is alloed or not for the given resource. Implementations
+     * are expected to throw the relevant exception with the right context and detail.
+     *
+     * @param requestName the name of the request (ex: getTable).
+     * @param resource the primary resource of the request; like a table.
+     */
+    void validateRequest(@NonNull String requestName, @NonNull QualifiedName resource);
+}

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/api/traffic_control/package-info.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/api/traffic_control/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Package for traffic control related classes like rate limiting
+ * and request validation against blocked lists.
+ */
+package com.netflix.metacat.common.server.api.traffic_control;

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/connectors/ConnectorFactoryDecorator.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/connectors/ConnectorFactoryDecorator.java
@@ -23,8 +23,8 @@ public class ConnectorFactoryDecorator implements ConnectorFactory {
         ConnectorCatalogService service = delegate.getCatalogService();
 
         if (isRateLimiterEnabled()) {
-            log.info("Creating rate-limited connector catalog services for connector-type: {}, " +
-                         "plugin-type: {}, catalog: {}, shard: {}",
+            log.info("Creating rate-limited connector catalog services for connector-type: {}, "
+                         + "plugin-type: {}, catalog: {}, shard: {}",
                 connectorContext.getConnectorType(), connectorPlugin.getType(),
                 connectorContext.getCatalogName(), connectorContext.getCatalogShardName());
             service = new ThrottlingConnectorCatalogService(service, rateLimiter);
@@ -38,8 +38,8 @@ public class ConnectorFactoryDecorator implements ConnectorFactory {
         ConnectorDatabaseService service = delegate.getDatabaseService();
 
         if (isRateLimiterEnabled()) {
-            log.info("Creating rate-limited connector database services for connector-type: {}, " +
-                         "plugin-type: {}, catalog: {}, shard: {}",
+            log.info("Creating rate-limited connector database services for connector-type: {}, "
+                         + "plugin-type: {}, catalog: {}, shard: {}",
                 connectorContext.getConnectorType(), connectorPlugin.getType(),
                 connectorContext.getCatalogName(), connectorContext.getCatalogShardName());
             service = new ThrottlingConnectorDatabaseService(service, rateLimiter);
@@ -53,8 +53,8 @@ public class ConnectorFactoryDecorator implements ConnectorFactory {
         ConnectorTableService service = delegate.getTableService();
 
         if (isRateLimiterEnabled()) {
-            log.info("Creating rate-limited connector table services for connector-type: {}, " +
-                         "plugin-type: {}, catalog: {}, shard: {}",
+            log.info("Creating rate-limited connector table services for connector-type: {}, "
+                         + "plugin-type: {}, catalog: {}, shard: {}",
                 connectorContext.getConnectorType(), connectorPlugin.getType(),
                 connectorContext.getCatalogName(), connectorContext.getCatalogShardName());
             service = new ThrottlingConnectorTableService(service, rateLimiter);
@@ -68,8 +68,8 @@ public class ConnectorFactoryDecorator implements ConnectorFactory {
         ConnectorPartitionService service = delegate.getPartitionService();
 
         if (isRateLimiterEnabled()) {
-            log.info("Creating rate-limited connector partition services for connector-type: {}, " +
-                         "plugin-type: {}, catalog: {}, shard: {}",
+            log.info("Creating rate-limited connector partition services for connector-type: {}, "
+                         + "plugin-type: {}, catalog: {}, shard: {}",
                 connectorContext.getConnectorType(), connectorPlugin.getType(),
                 connectorContext.getCatalogName(), connectorContext.getCatalogShardName());
             service = new ThrottlingConnectorPartitionService(service, rateLimiter);

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/connectors/ConnectorFactoryDecorator.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/connectors/ConnectorFactoryDecorator.java
@@ -1,0 +1,105 @@
+package com.netflix.metacat.common.server.connectors;
+
+import com.netflix.metacat.common.server.api.ratelimiter.RateLimiter;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * A decorator for a connector factory to add additional cross-cutting functionality
+ * to all connector services.
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class ConnectorFactoryDecorator implements ConnectorFactory {
+    private final ConnectorPlugin connectorPlugin;
+    @Getter
+    private final ConnectorFactory delegate;
+    private final ConnectorContext connectorContext;
+    private final RateLimiter rateLimiter;
+
+    @Override
+    public ConnectorCatalogService getCatalogService() {
+        ConnectorCatalogService service = delegate.getCatalogService();
+
+        if (isRateLimiterEnabled()) {
+            log.info("Creating rate-limited connector catalog services for connector-type: {}, " +
+                         "plugin-type: {}, catalog: {}, shard: {}",
+                connectorContext.getConnectorType(), connectorPlugin.getType(),
+                connectorContext.getCatalogName(), connectorContext.getCatalogShardName());
+            service = new ThrottlingConnectorCatalogService(service, rateLimiter);
+        }
+
+        return service;
+    }
+
+    @Override
+    public ConnectorDatabaseService getDatabaseService() {
+        ConnectorDatabaseService service = delegate.getDatabaseService();
+
+        if (isRateLimiterEnabled()) {
+            log.info("Creating rate-limited connector database services for connector-type: {}, " +
+                         "plugin-type: {}, catalog: {}, shard: {}",
+                connectorContext.getConnectorType(), connectorPlugin.getType(),
+                connectorContext.getCatalogName(), connectorContext.getCatalogShardName());
+            service = new ThrottlingConnectorDatabaseService(service, rateLimiter);
+        }
+
+        return service;
+    }
+
+    @Override
+    public ConnectorTableService getTableService() {
+        ConnectorTableService service = delegate.getTableService();
+
+        if (isRateLimiterEnabled()) {
+            log.info("Creating rate-limited connector table services for connector-type: {}, " +
+                         "plugin-type: {}, catalog: {}, shard: {}",
+                connectorContext.getConnectorType(), connectorPlugin.getType(),
+                connectorContext.getCatalogName(), connectorContext.getCatalogShardName());
+            service = new ThrottlingConnectorTableService(service, rateLimiter);
+        }
+
+        return service;
+    }
+
+    @Override
+    public ConnectorPartitionService getPartitionService() {
+        ConnectorPartitionService service = delegate.getPartitionService();
+
+        if (isRateLimiterEnabled()) {
+            log.info("Creating rate-limited connector partition services for connector-type: {}, " +
+                         "plugin-type: {}, catalog: {}, shard: {}",
+                connectorContext.getConnectorType(), connectorPlugin.getType(),
+                connectorContext.getCatalogName(), connectorContext.getCatalogShardName());
+            service = new ThrottlingConnectorPartitionService(service, rateLimiter);
+        }
+
+        return service;
+    }
+
+    @Override
+    public String getCatalogName() {
+        return delegate.getCatalogName();
+    }
+
+    @Override
+    public String getCatalogShardName() {
+        return delegate.getCatalogShardName();
+    }
+
+    @Override
+    public void stop() {
+        delegate.stop();
+    }
+
+    private boolean isRateLimiterEnabled() {
+        if (connectorContext.getConfiguration() == null) {
+            return true;
+        }
+
+        return !Boolean.parseBoolean(
+            connectorContext.getConfiguration().getOrDefault("connector.rate-limiter-exempted", "false")
+        );
+    }
+}

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/connectors/ThrottlingConnectorCatalogService.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/connectors/ThrottlingConnectorCatalogService.java
@@ -17,6 +17,11 @@ import lombok.extern.slf4j.Slf4j;
 import javax.annotation.Nullable;
 import java.util.List;
 
+/**
+ * Connector that throttles calls to the connector based on the contextual request name
+ * and the resource. Not all APIs can be throttles since we may not have a resource
+ * but those are a small monitory
+ */
 @Slf4j
 @RequiredArgsConstructor
 public class ThrottlingConnectorCatalogService implements ConnectorCatalogService {

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/connectors/ThrottlingConnectorCatalogService.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/connectors/ThrottlingConnectorCatalogService.java
@@ -1,0 +1,104 @@
+package com.netflix.metacat.common.server.connectors;
+
+import com.netflix.metacat.common.QualifiedName;
+import com.netflix.metacat.common.dto.Pageable;
+import com.netflix.metacat.common.dto.Sort;
+import com.netflix.metacat.common.exception.MetacatTooManyRequestsException;
+import com.netflix.metacat.common.server.api.ratelimiter.RateLimiter;
+import com.netflix.metacat.common.server.api.ratelimiter.RateLimiterRequestContext;
+import com.netflix.metacat.common.server.connectors.model.CatalogInfo;
+import com.netflix.metacat.common.server.util.MetacatContextManager;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+public class ThrottlingConnectorCatalogService implements ConnectorCatalogService {
+    @Getter
+    @NonNull
+    private final ConnectorCatalogService delegate;
+    @NonNull
+    private final RateLimiter rateLimiter;
+
+    @Override
+    public void create(final ConnectorRequestContext context, final CatalogInfo resource) {
+        checkThrottling(MetacatContextManager.getContext().getRequestName(), resource.getName());
+        delegate.create(context, resource);
+    }
+
+    @Override
+    public void update(final ConnectorRequestContext context, final CatalogInfo resource) {
+        checkThrottling(MetacatContextManager.getContext().getRequestName(), resource.getName());
+        delegate.update(context, resource);
+    }
+
+    @Override
+    public void delete(final ConnectorRequestContext context, final QualifiedName name) {
+        checkThrottling(MetacatContextManager.getContext().getRequestName(), name);
+        delegate.delete(context, name);
+    }
+
+    @Override
+    public CatalogInfo get(final ConnectorRequestContext context, final QualifiedName name) {
+        checkThrottling(MetacatContextManager.getContext().getRequestName(), name);
+        return delegate.get(context, name);
+    }
+
+    @Override
+    @SuppressFBWarnings
+    public boolean exists(final ConnectorRequestContext context, final QualifiedName name) {
+        checkThrottling(MetacatContextManager.getContext().getRequestName(), name);
+        return delegate.exists(context, name);
+    }
+
+    @Override
+    public List<CatalogInfo> list(final ConnectorRequestContext context, final QualifiedName name,
+                                  @Nullable final QualifiedName prefix,
+                                  @Nullable final Sort sort, @Nullable final Pageable pageable) {
+        checkThrottling(MetacatContextManager.getContext().getRequestName(), name);
+        return delegate.list(context, name, prefix, sort, pageable);
+    }
+
+    @Override
+    public List<QualifiedName> listNames(final ConnectorRequestContext context, final QualifiedName name,
+                                         @Nullable final QualifiedName prefix,
+                                         @Nullable final Sort sort, @Nullable final Pageable pageable) {
+        checkThrottling(MetacatContextManager.getContext().getRequestName(), name);
+        return delegate.listNames(context, name, prefix, sort, pageable);
+    }
+
+    @Override
+    public void rename(final ConnectorRequestContext context, final QualifiedName oldName,
+                       final QualifiedName newName) {
+        checkThrottling(MetacatContextManager.getContext().getRequestName(), oldName);
+        delegate.rename(context, oldName, newName);
+    }
+
+    private void checkThrottling(final String requestName, final QualifiedName resource) {
+        System.out.println("requestName = " + requestName);
+        System.out.println("resource = " + resource);
+        if (rateLimiter.hasExceededRequestLimit(new RateLimiterRequestContext(requestName, resource))) {
+            System.out.println("Too many");
+            final String errorMsg = String.format("Too many requests for resource %s. Request: %s",
+                resource, requestName);
+            log.warn(errorMsg);
+            throw new MetacatTooManyRequestsException(errorMsg);
+        }
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        return delegate.equals(o);
+    }
+
+    @Override
+    public int hashCode() {
+        return delegate.hashCode();
+    }
+}

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/connectors/ThrottlingConnectorCatalogService.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/connectors/ThrottlingConnectorCatalogService.java
@@ -86,10 +86,7 @@ public class ThrottlingConnectorCatalogService implements ConnectorCatalogServic
     }
 
     private void checkThrottling(final String requestName, final QualifiedName resource) {
-        System.out.println("requestName = " + requestName);
-        System.out.println("resource = " + resource);
         if (rateLimiter.hasExceededRequestLimit(new RateLimiterRequestContext(requestName, resource))) {
-            System.out.println("Too many");
             final String errorMsg = String.format("Too many requests for resource %s. Request: %s",
                 resource, requestName);
             log.warn(errorMsg);

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/connectors/ThrottlingConnectorDatabaseService.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/connectors/ThrottlingConnectorDatabaseService.java
@@ -1,0 +1,107 @@
+package com.netflix.metacat.common.server.connectors;
+
+import com.netflix.metacat.common.QualifiedName;
+import com.netflix.metacat.common.dto.Pageable;
+import com.netflix.metacat.common.dto.Sort;
+import com.netflix.metacat.common.exception.MetacatTooManyRequestsException;
+import com.netflix.metacat.common.server.api.ratelimiter.RateLimiter;
+import com.netflix.metacat.common.server.api.ratelimiter.RateLimiterRequestContext;
+import com.netflix.metacat.common.server.connectors.model.DatabaseInfo;
+import com.netflix.metacat.common.server.util.MetacatContextManager;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+public class ThrottlingConnectorDatabaseService implements ConnectorDatabaseService {
+    @Getter
+    @NonNull
+    private final ConnectorDatabaseService delegate;
+    @NonNull
+    private final RateLimiter rateLimiter;
+
+    @Override
+    public void create(final ConnectorRequestContext context, final DatabaseInfo resource) {
+        checkThrottling(MetacatContextManager.getContext().getRequestName(), resource.getName());
+        delegate.create(context, resource);
+    }
+
+    @Override
+    public void update(final ConnectorRequestContext context, final DatabaseInfo resource) {
+        checkThrottling(MetacatContextManager.getContext().getRequestName(), resource.getName());
+        delegate.update(context, resource);
+    }
+
+    @Override
+    public void delete(final ConnectorRequestContext context, final QualifiedName name) {
+        checkThrottling(MetacatContextManager.getContext().getRequestName(), name);
+        delegate.delete(context, name);
+    }
+
+    @Override
+    public DatabaseInfo get(final ConnectorRequestContext context, final QualifiedName name) {
+        checkThrottling(MetacatContextManager.getContext().getRequestName(), name);
+        return delegate.get(context, name);
+    }
+
+    @Override
+    @SuppressFBWarnings
+    public boolean exists(final ConnectorRequestContext context, final QualifiedName name) {
+        checkThrottling(MetacatContextManager.getContext().getRequestName(), name);
+        return delegate.exists(context, name);
+    }
+
+    @Override
+    public List<DatabaseInfo> list(final ConnectorRequestContext context, final QualifiedName name,
+                                   @Nullable final QualifiedName prefix, @Nullable final Sort sort,
+                                   @Nullable final Pageable pageable) {
+        checkThrottling(MetacatContextManager.getContext().getRequestName(), name);
+        return delegate.list(context, name, prefix, sort, pageable);
+    }
+
+    @Override
+    public List<QualifiedName> listNames(final ConnectorRequestContext context, final QualifiedName name,
+                                         @Nullable final QualifiedName prefix, @Nullable final Sort sort,
+                                         @Nullable final Pageable pageable) {
+        checkThrottling(MetacatContextManager.getContext().getRequestName(), name);
+        return delegate.listNames(context, name, prefix, sort, pageable);
+    }
+
+    @Override
+    public void rename(final ConnectorRequestContext context, final QualifiedName oldName,
+                       final QualifiedName newName) {
+        checkThrottling(MetacatContextManager.getContext().getRequestName(), oldName);
+        delegate.rename(context, oldName, newName);
+    }
+
+    @Override
+    public List<QualifiedName> listViewNames(final ConnectorRequestContext context, final QualifiedName databaseName) {
+        checkThrottling(MetacatContextManager.getContext().getRequestName(), databaseName);
+        return delegate.listViewNames(context, databaseName);
+    }
+
+    private void checkThrottling(final String requestName, final QualifiedName resource) {
+        if (rateLimiter.hasExceededRequestLimit(new RateLimiterRequestContext(requestName, resource))) {
+            final String errorMsg = String.format("Too many requests for resource %s. Request: %s",
+                resource, requestName);
+            log.warn(errorMsg);
+            throw new MetacatTooManyRequestsException(errorMsg);
+        }
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        return delegate.equals(o);
+    }
+
+    @Override
+    public int hashCode() {
+        return delegate.hashCode();
+    }
+}

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/connectors/ThrottlingConnectorDatabaseService.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/connectors/ThrottlingConnectorDatabaseService.java
@@ -17,6 +17,11 @@ import lombok.extern.slf4j.Slf4j;
 import javax.annotation.Nullable;
 import java.util.List;
 
+/**
+ * Connector that throttles calls to the connector based on the contextual request name
+ * and the resource. Not all APIs can be throttles since we may not have a resource
+ * but those are a small monitory
+ */
 @Slf4j
 @RequiredArgsConstructor
 public class ThrottlingConnectorDatabaseService implements ConnectorDatabaseService {

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/connectors/ThrottlingConnectorPartitionService.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/connectors/ThrottlingConnectorPartitionService.java
@@ -1,0 +1,166 @@
+package com.netflix.metacat.common.server.connectors;
+
+import com.netflix.metacat.common.QualifiedName;
+import com.netflix.metacat.common.dto.Pageable;
+import com.netflix.metacat.common.dto.Sort;
+import com.netflix.metacat.common.exception.MetacatTooManyRequestsException;
+import com.netflix.metacat.common.server.api.ratelimiter.RateLimiter;
+import com.netflix.metacat.common.server.api.ratelimiter.RateLimiterRequestContext;
+import com.netflix.metacat.common.server.connectors.model.PartitionInfo;
+import com.netflix.metacat.common.server.connectors.model.PartitionListRequest;
+import com.netflix.metacat.common.server.connectors.model.PartitionsSaveRequest;
+import com.netflix.metacat.common.server.connectors.model.PartitionsSaveResponse;
+import com.netflix.metacat.common.server.connectors.model.TableInfo;
+import com.netflix.metacat.common.server.util.MetacatContextManager;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@RequiredArgsConstructor
+public class ThrottlingConnectorPartitionService implements ConnectorPartitionService {
+    @Getter
+    @NonNull
+    private final ConnectorPartitionService delegate;
+    @NonNull
+    private final RateLimiter rateLimiter;
+
+    @Override
+    public List<PartitionInfo> getPartitions(final ConnectorRequestContext context,
+                                             final QualifiedName table,
+                                             final PartitionListRequest partitionsRequest,
+                                             final TableInfo tableInfo) {
+        checkThrottling(MetacatContextManager.getContext().getRequestName(), table);
+        return delegate.getPartitions(context, table, partitionsRequest, tableInfo);
+    }
+
+    @Override
+    public PartitionsSaveResponse savePartitions(final ConnectorRequestContext context,
+                                                 final QualifiedName table,
+                                                 final PartitionsSaveRequest partitionsSaveRequest) {
+        checkThrottling(MetacatContextManager.getContext().getRequestName(), table);
+        return delegate.savePartitions(context, table, partitionsSaveRequest);
+    }
+
+    @Override
+    public void deletePartitions(final ConnectorRequestContext context,
+                                 final QualifiedName tableName,
+                                 final List<String> partitionNames,
+                                 final TableInfo tableInfo) {
+        checkThrottling(MetacatContextManager.getContext().getRequestName(), tableName);
+        delegate.deletePartitions(context, tableName, partitionNames, tableInfo);
+    }
+
+    @Override
+    public int getPartitionCount(final ConnectorRequestContext context,
+                                 final QualifiedName table,
+                                 final TableInfo tableInfo) {
+        checkThrottling(MetacatContextManager.getContext().getRequestName(), table);
+        return delegate.getPartitionCount(context, table, tableInfo);
+    }
+
+    @Override
+    public Map<String, List<QualifiedName>> getPartitionNames(final ConnectorRequestContext context,
+                                                              final List<String> uris,
+                                                              final boolean prefixSearch) {
+        return delegate.getPartitionNames(context, uris, prefixSearch);
+    }
+
+    @Override
+    public List<String> getPartitionKeys(final ConnectorRequestContext context,
+                                         final QualifiedName table,
+                                         final PartitionListRequest partitionsRequest,
+                                         final TableInfo tableInfo) {
+        checkThrottling(MetacatContextManager.getContext().getRequestName(), table);
+        return delegate.getPartitionKeys(context, table, partitionsRequest, tableInfo);
+    }
+
+    @Override
+    public List<String> getPartitionUris(final ConnectorRequestContext context,
+                                         final QualifiedName table,
+                                         final PartitionListRequest partitionsRequest,
+                                         final TableInfo tableInfo) {
+        checkThrottling(MetacatContextManager.getContext().getRequestName(), table);
+        return delegate.getPartitionUris(context, table, partitionsRequest, tableInfo);
+    }
+
+    @Override
+    public void create(final ConnectorRequestContext context, final PartitionInfo resource) {
+        checkThrottling(MetacatContextManager.getContext().getRequestName(), resource.getName());
+        delegate.create(context, resource);
+    }
+
+    @Override
+    public void update(final ConnectorRequestContext context, final PartitionInfo resource) {
+        checkThrottling(MetacatContextManager.getContext().getRequestName(), resource.getName());
+        delegate.update(context, resource);
+    }
+
+    @Override
+    public void delete(final ConnectorRequestContext context, final QualifiedName name) {
+        checkThrottling(MetacatContextManager.getContext().getRequestName(), name);
+        delegate.delete(context, name);
+    }
+
+    @Override
+    public PartitionInfo get(final ConnectorRequestContext context, final QualifiedName name) {
+        checkThrottling(MetacatContextManager.getContext().getRequestName(), name);
+        return delegate.get(context, name);
+    }
+
+    @Override
+    @SuppressFBWarnings
+    public boolean exists(final ConnectorRequestContext context, final QualifiedName name) {
+        checkThrottling(MetacatContextManager.getContext().getRequestName(), name);
+        return delegate.exists(context, name);
+    }
+
+    @Override
+    public List<PartitionInfo> list(final ConnectorRequestContext context, final QualifiedName name,
+                                    @Nullable final QualifiedName prefix, @Nullable final Sort sort,
+                                    @Nullable final Pageable pageable) {
+        checkThrottling(MetacatContextManager.getContext().getRequestName(), name);
+        return delegate.list(context, name, prefix, sort, pageable);
+    }
+
+    @Override
+    public List<QualifiedName> listNames(final ConnectorRequestContext context, final QualifiedName name,
+                                         @Nullable final QualifiedName prefix,
+                                         @Nullable final Sort sort, @Nullable final Pageable pageable) {
+        checkThrottling(MetacatContextManager.getContext().getRequestName(), name);
+        return delegate.listNames(context, name, prefix, sort, pageable);
+    }
+
+    @Override
+    public void rename(final ConnectorRequestContext context, final QualifiedName oldName,
+                       final QualifiedName newName) {
+        checkThrottling(MetacatContextManager.getContext().getRequestName(), oldName);
+        delegate.rename(context, oldName, newName);
+    }
+
+    private void checkThrottling(final String requestName, final QualifiedName resource) {
+        if (rateLimiter.hasExceededRequestLimit(new RateLimiterRequestContext(requestName, resource))) {
+            final String errorMsg = String.format("Too many requests for resource %s. Request: %s",
+                resource, requestName);
+            log.warn(errorMsg);
+            throw new MetacatTooManyRequestsException(errorMsg);
+        }
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        return delegate.equals(o);
+    }
+
+    @Override
+    public int hashCode() {
+        return delegate.hashCode();
+    }
+}
+

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/connectors/ThrottlingConnectorPartitionService.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/connectors/ThrottlingConnectorPartitionService.java
@@ -22,6 +22,11 @@ import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Connector that throttles calls to the connector based on the contextual request name
+ * and the resource. Not all APIs can be throttles since we may not have a resource
+ * but those are a small monitory
+ */
 @Slf4j
 @RequiredArgsConstructor
 public class ThrottlingConnectorPartitionService implements ConnectorPartitionService {

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/connectors/ThrottlingConnectorTableService.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/connectors/ThrottlingConnectorTableService.java
@@ -1,0 +1,120 @@
+package com.netflix.metacat.common.server.connectors;
+
+import com.netflix.metacat.common.QualifiedName;
+import com.netflix.metacat.common.dto.Pageable;
+import com.netflix.metacat.common.dto.Sort;
+import com.netflix.metacat.common.exception.MetacatTooManyRequestsException;
+import com.netflix.metacat.common.server.api.ratelimiter.RateLimiter;
+import com.netflix.metacat.common.server.api.ratelimiter.RateLimiterRequestContext;
+import com.netflix.metacat.common.server.connectors.model.TableInfo;
+import com.netflix.metacat.common.server.util.MetacatContextManager;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@RequiredArgsConstructor
+public class ThrottlingConnectorTableService implements ConnectorTableService {
+    @Getter
+    @NonNull
+    private final ConnectorTableService delegate;
+    @NonNull
+    private final RateLimiter rateLimiter;
+
+    @Override
+    public TableInfo get(final ConnectorRequestContext context,
+                         final QualifiedName name) {
+        checkThrottling(MetacatContextManager.getContext().getRequestName(), name);
+        return delegate.get(context, name);
+    }
+
+    @Override
+    public Map<String, List<QualifiedName>> getTableNames(final ConnectorRequestContext context,
+                                                          final List<String> uris,
+                                                          final boolean prefixSearch) {
+        return delegate.getTableNames(context, uris, prefixSearch);
+    }
+
+    @Override
+    public List<QualifiedName> getTableNames(final ConnectorRequestContext context,
+                                             final QualifiedName name,
+                                             final String filter,
+                                             final Integer limit) {
+        checkThrottling(MetacatContextManager.getContext().getRequestName(), name);
+        return delegate.getTableNames(context, name, filter, limit);
+    }
+
+    @Override
+    public void create(final ConnectorRequestContext context, final TableInfo resource) {
+        checkThrottling(MetacatContextManager.getContext().getRequestName(), resource.getName());
+        delegate.create(context, resource);
+    }
+
+    @Override
+    public void update(final ConnectorRequestContext context, final TableInfo resource) {
+        checkThrottling(MetacatContextManager.getContext().getRequestName(), resource.getName());
+        delegate.update(context, resource);
+    }
+
+    @Override
+    public void delete(final ConnectorRequestContext context, final QualifiedName name) {
+        checkThrottling(MetacatContextManager.getContext().getRequestName(), name);
+        delegate.delete(context, name);
+    }
+
+    @Override
+    @SuppressFBWarnings
+    public boolean exists(final ConnectorRequestContext context, final QualifiedName name) {
+        checkThrottling(MetacatContextManager.getContext().getRequestName(), name);
+        return delegate.exists(context, name);
+    }
+
+    @Override
+    public List<TableInfo> list(final ConnectorRequestContext context, final QualifiedName name,
+                                @Nullable final QualifiedName prefix,
+                                @Nullable final Sort sort, @Nullable final Pageable pageable) {
+        checkThrottling(MetacatContextManager.getContext().getRequestName(), name);
+        return delegate.list(context, name, prefix, sort, pageable);
+    }
+
+    @Override
+    public List<QualifiedName> listNames(final ConnectorRequestContext context, final QualifiedName name,
+                                         @Nullable final QualifiedName prefix,
+                                         @Nullable final Sort sort, @Nullable final Pageable pageable) {
+        checkThrottling(MetacatContextManager.getContext().getRequestName(), name);
+        return delegate.listNames(context, name, prefix, sort, pageable);
+    }
+
+    @Override
+    public void rename(final ConnectorRequestContext context,
+                       final QualifiedName oldName,
+                       final QualifiedName newName) {
+        checkThrottling(MetacatContextManager.getContext().getRequestName(), oldName);
+        delegate.rename(context, oldName, newName);
+    }
+
+    private void checkThrottling(final String requestName, final QualifiedName resource) {
+        if (rateLimiter.hasExceededRequestLimit(new RateLimiterRequestContext(requestName, resource))) {
+            final String errorMsg = String.format("Too many requests for resource %s. Request: %s",
+                resource, requestName);
+            log.warn(errorMsg);
+            throw new MetacatTooManyRequestsException(errorMsg);
+        }
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        return delegate.equals(o);
+    }
+
+    @Override
+    public int hashCode() {
+        return delegate.hashCode();
+    }
+}

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/connectors/ThrottlingConnectorTableService.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/connectors/ThrottlingConnectorTableService.java
@@ -18,6 +18,11 @@ import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Connector that throttles calls to the connector based on the contextual request name
+ * and the resource. Not all APIs can be throttles since we may not have a resource
+ * but those are a small monitory
+ */
 @Slf4j
 @RequiredArgsConstructor
 public class ThrottlingConnectorTableService implements ConnectorTableService {

--- a/metacat-common-server/src/test/groovy/com/netflix/metacat/common/server/connectors/ConnectorFactoryDecoratorSpec.groovy
+++ b/metacat-common-server/src/test/groovy/com/netflix/metacat/common/server/connectors/ConnectorFactoryDecoratorSpec.groovy
@@ -1,0 +1,106 @@
+package com.netflix.metacat.common.server.connectors
+
+import com.netflix.metacat.common.server.api.ratelimiter.RateLimiter
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class ConnectorFactoryDecoratorSpec extends Specification {
+    def connectorPlugin
+    def delegate
+    def connectorContext
+    def rateLimiter
+    def catalogService
+    def databaseService
+    def tableService
+    def partitionService
+
+    def factory
+
+    def setup() {
+        connectorPlugin = Mock(ConnectorPlugin)
+        delegate = Mock(ConnectorFactory)
+        connectorContext = Mock(ConnectorContext)
+        rateLimiter = Mock(RateLimiter)
+
+        catalogService = Mock(ConnectorCatalogService)
+        databaseService = Mock(ConnectorDatabaseService)
+        tableService = Mock(ConnectorTableService)
+        partitionService = Mock(ConnectorPartitionService)
+
+        delegate.getCatalogService() >> catalogService
+        delegate.getDatabaseService() >> databaseService
+        delegate.getTableService() >> tableService
+        delegate.getPartitionService() >> partitionService
+
+        factory = new ConnectorFactoryDecorator(connectorPlugin, delegate, connectorContext, rateLimiter)
+    }
+
+    def "when rate limiting is enabled"() {
+        given:
+        connectorContext.getConfiguration() >> ["connector.rate-limiter-exempted": "false"]
+
+        when:
+        def catalogSvc = factory.getCatalogService()
+
+        then:
+        catalogSvc instanceof ThrottlingConnectorCatalogService
+        (catalogSvc as ThrottlingConnectorCatalogService).getDelegate() == catalogService
+
+        when:
+        def dbSvc = factory.getDatabaseService()
+
+        then:
+        dbSvc instanceof ThrottlingConnectorDatabaseService
+        (dbSvc as ThrottlingConnectorDatabaseService).getDelegate() == databaseService
+
+        when:
+        def tblSvc = factory.getTableService()
+
+        then:
+        tblSvc instanceof ThrottlingConnectorTableService
+        (tblSvc as ThrottlingConnectorTableService).getDelegate() == tableService
+
+        when:
+        def partitionSvc = factory.getPartitionService()
+
+        then:
+        partitionSvc instanceof ThrottlingConnectorPartitionService
+        (partitionSvc as ThrottlingConnectorPartitionService).getDelegate() == partitionService
+    }
+
+    @Unroll
+    def "when rate limiting is disabled"() {
+        given:
+        connectorContext.getConfiguration() >> config
+
+        when:
+        def catalogSvc = factory.getCatalogService()
+
+        then:
+        catalogSvc == catalogService
+
+        when:
+        def dbSvc = factory.getDatabaseService()
+
+        then:
+        dbSvc == databaseService
+
+        when:
+        def tblSvc = factory.getTableService()
+
+        then:
+        tblSvc == tableService
+
+        when:
+        def partitionSvc = factory.getPartitionService()
+
+        then:
+        partitionSvc == partitionService
+
+        where:
+        config                                      | ignored
+        ["connector.rate-limiter-exempted": "true"] | null
+        null                                        | null
+    }
+}
+

--- a/metacat-common-server/src/test/groovy/com/netflix/metacat/common/server/connectors/ThrottlingConnectorCatalogServiceSpec.groovy
+++ b/metacat-common-server/src/test/groovy/com/netflix/metacat/common/server/connectors/ThrottlingConnectorCatalogServiceSpec.groovy
@@ -1,0 +1,193 @@
+package com.netflix.metacat.common.server.connectors
+
+import com.netflix.metacat.common.QualifiedName
+import com.netflix.metacat.common.exception.MetacatTooManyRequestsException
+import com.netflix.metacat.common.server.api.ratelimiter.RateLimiter
+import com.netflix.metacat.common.server.api.ratelimiter.RateLimiterRequestContext
+import com.netflix.metacat.common.server.connectors.model.CatalogInfo
+import com.netflix.metacat.common.server.util.MetacatContextManager
+import spock.lang.Specification
+
+class ThrottlingConnectorCatalogServiceSpec extends Specification {
+    def delegate
+    def rateLimiter
+    def context
+
+    def resource
+    def name
+    def newName
+    def rateLimiterContext
+    def service
+
+    class Success extends RuntimeException {}
+
+    def setup() {
+        delegate = Mock(ConnectorCatalogService)
+        rateLimiter = Mock(RateLimiter)
+        context = Mock(ConnectorRequestContext)
+
+        name = QualifiedName.ofCatalog("c")
+        newName = QualifiedName.ofCatalog("c2")
+        resource = new CatalogInfo(name: name)
+
+        rateLimiterContext = new RateLimiterRequestContext("r1", name)
+
+        service = new ThrottlingConnectorCatalogService(delegate, rateLimiter)
+    }
+
+    def "create"() {
+        given:
+        MetacatContextManager.getContext().setRequestName("r1")
+
+        when:
+        service.create(context, resource)
+        throw new Success()
+
+        then:
+        thrown(expectedException)
+        rateLimiter.hasExceededRequestLimit(rateLimiterContext) >> exceeded
+
+        if (!exceeded) {
+            1 * delegate.create(context, resource)
+        }
+
+        where:
+        exceeded | expectedException
+        true     | MetacatTooManyRequestsException
+        false    | Success
+    }
+
+    def "update"() {
+
+        when:
+        service.update(context, resource)
+        throw new Success()
+
+        then:
+        thrown(expectedException)
+        rateLimiter.hasExceededRequestLimit(rateLimiterContext) >> exceeded
+
+        if (!exceeded) {
+            1 * delegate.update(context, resource)
+        }
+
+        where:
+        exceeded | expectedException
+        true     | MetacatTooManyRequestsException
+        false    | Success
+    }
+
+    def "delete"() {
+        when:
+        service.delete(context, name)
+        throw new Success()
+
+        then:
+        thrown(expectedException)
+        rateLimiter.hasExceededRequestLimit(rateLimiterContext) >> exceeded
+
+        if (!exceeded) {
+            1 * delegate.delete(context, name)
+        }
+
+        where:
+        exceeded | expectedException
+        true     | MetacatTooManyRequestsException
+        false    | Success
+    }
+
+    def "get"() {
+        when:
+        service.get(context, name)
+        throw new Success()
+
+        then:
+        thrown(expectedException)
+        rateLimiter.hasExceededRequestLimit(rateLimiterContext) >> exceeded
+
+        if (!exceeded) {
+            1 * delegate.get(context, name)
+        }
+
+        where:
+        exceeded | expectedException
+        true     | MetacatTooManyRequestsException
+        false    | Success
+    }
+
+    def "exists"() {
+        when:
+        service.exists(context, name)
+        throw new Success()
+
+        then:
+        thrown(expectedException)
+        rateLimiter.hasExceededRequestLimit(rateLimiterContext) >> exceeded
+
+        if (!exceeded) {
+            1 * delegate.exists(context, name)
+        }
+
+        where:
+        exceeded | expectedException
+        true     | MetacatTooManyRequestsException
+        false    | Success
+    }
+
+    def "list"() {
+        when:
+        service.list(context, name, null, null, null)
+        throw new Success()
+
+        then:
+        thrown(expectedException)
+        rateLimiter.hasExceededRequestLimit(rateLimiterContext) >> exceeded
+
+        if (!exceeded) {
+            1 * delegate.list(context, name, null, null, null)
+        }
+
+        where:
+        exceeded | expectedException
+        true     | MetacatTooManyRequestsException
+        false    | Success
+    }
+
+    def "listNames"() {
+        when:
+        service.listNames(context, name, null, null, null)
+        throw new Success()
+
+        then:
+        thrown(expectedException)
+        rateLimiter.hasExceededRequestLimit(rateLimiterContext) >> exceeded
+
+        if (!exceeded) {
+            1 * delegate.listNames(context, name, null, null, null)
+        }
+
+        where:
+        exceeded | expectedException
+        true     | MetacatTooManyRequestsException
+        false    | Success
+    }
+
+    def "rename"() {
+        when:
+        service.rename(context, name, newName)
+        throw new Success()
+
+        then:
+        thrown(expectedException)
+        rateLimiter.hasExceededRequestLimit(rateLimiterContext) >> exceeded
+
+        if (!exceeded) {
+            1 * delegate.rename(context, name, newName)
+        }
+
+        where:
+        exceeded | expectedException
+        true     | MetacatTooManyRequestsException
+        false    | Success
+    }
+}

--- a/metacat-common-server/src/test/groovy/com/netflix/metacat/common/server/connectors/ThrottlingConnectorCatalogServiceSpec.groovy
+++ b/metacat-common-server/src/test/groovy/com/netflix/metacat/common/server/connectors/ThrottlingConnectorCatalogServiceSpec.groovy
@@ -33,12 +33,11 @@ class ThrottlingConnectorCatalogServiceSpec extends Specification {
         rateLimiterContext = new RateLimiterRequestContext("r1", name)
 
         service = new ThrottlingConnectorCatalogService(delegate, rateLimiter)
+
+        MetacatContextManager.getContext().setRequestName("r1")
     }
 
     def "create"() {
-        given:
-        MetacatContextManager.getContext().setRequestName("r1")
-
         when:
         service.create(context, resource)
         throw new Success()

--- a/metacat-common-server/src/test/groovy/com/netflix/metacat/common/server/connectors/ThrottlingConnectorDatabaseServiceSpec.groovy
+++ b/metacat-common-server/src/test/groovy/com/netflix/metacat/common/server/connectors/ThrottlingConnectorDatabaseServiceSpec.groovy
@@ -1,0 +1,212 @@
+package com.netflix.metacat.common.server.connectors
+
+import com.netflix.metacat.common.QualifiedName
+import com.netflix.metacat.common.exception.MetacatTooManyRequestsException
+import com.netflix.metacat.common.server.api.ratelimiter.RateLimiter
+import com.netflix.metacat.common.server.api.ratelimiter.RateLimiterRequestContext
+import com.netflix.metacat.common.server.connectors.model.DatabaseInfo
+import com.netflix.metacat.common.server.util.MetacatContextManager
+import spock.lang.Specification
+
+class ThrottlingConnectorDatabaseServiceSpec extends Specification {
+    def delegate
+    def rateLimiter
+    def context
+
+    def resource
+    def name
+    def newName
+    def rateLimiterContext
+    def service
+
+    class Success extends RuntimeException {}
+
+    def setup() {
+        delegate = Mock(ConnectorDatabaseService)
+        rateLimiter = Mock(RateLimiter)
+        context = Mock(ConnectorRequestContext)
+
+        name = QualifiedName.ofDatabase("c", "d")
+        newName = QualifiedName.ofDatabase("c2", "d2")
+        resource = new DatabaseInfo(name: name)
+
+        rateLimiterContext = new RateLimiterRequestContext("r1", name)
+
+        service = new ThrottlingConnectorDatabaseService(delegate, rateLimiter)
+    }
+
+    def "create"() {
+        given:
+        MetacatContextManager.getContext().setRequestName("r1")
+
+        when:
+        service.create(context, resource)
+        throw new Success()
+
+        then:
+        thrown(expectedException)
+        rateLimiter.hasExceededRequestLimit(rateLimiterContext) >> exceeded
+
+        if (!exceeded) {
+            1 * delegate.create(context, resource)
+        }
+
+        where:
+        exceeded | expectedException
+        true     | MetacatTooManyRequestsException
+        false    | Success
+    }
+
+    def "update"() {
+
+        when:
+        service.update(context, resource)
+        throw new Success()
+
+        then:
+        thrown(expectedException)
+        rateLimiter.hasExceededRequestLimit(rateLimiterContext) >> exceeded
+
+        if (!exceeded) {
+            1 * delegate.update(context, resource)
+        }
+
+        where:
+        exceeded | expectedException
+        true     | MetacatTooManyRequestsException
+        false    | Success
+    }
+
+    def "delete"() {
+        when:
+        service.delete(context, name)
+        throw new Success()
+
+        then:
+        thrown(expectedException)
+        rateLimiter.hasExceededRequestLimit(rateLimiterContext) >> exceeded
+
+        if (!exceeded) {
+            1 * delegate.delete(context, name)
+        }
+
+        where:
+        exceeded | expectedException
+        true     | MetacatTooManyRequestsException
+        false    | Success
+    }
+
+    def "get"() {
+        when:
+        service.get(context, name)
+        throw new Success()
+
+        then:
+        thrown(expectedException)
+        rateLimiter.hasExceededRequestLimit(rateLimiterContext) >> exceeded
+
+        if (!exceeded) {
+            1 * delegate.get(context, name)
+        }
+
+        where:
+        exceeded | expectedException
+        true     | MetacatTooManyRequestsException
+        false    | Success
+    }
+
+    def "exists"() {
+        when:
+        service.exists(context, name)
+        throw new Success()
+
+        then:
+        thrown(expectedException)
+        rateLimiter.hasExceededRequestLimit(rateLimiterContext) >> exceeded
+
+        if (!exceeded) {
+            1 * delegate.exists(context, name)
+        }
+
+        where:
+        exceeded | expectedException
+        true     | MetacatTooManyRequestsException
+        false    | Success
+    }
+
+    def "list"() {
+        when:
+        service.list(context, name, null, null, null)
+        throw new Success()
+
+        then:
+        thrown(expectedException)
+        rateLimiter.hasExceededRequestLimit(rateLimiterContext) >> exceeded
+
+        if (!exceeded) {
+            1 * delegate.list(context, name, null, null, null)
+        }
+
+        where:
+        exceeded | expectedException
+        true     | MetacatTooManyRequestsException
+        false    | Success
+    }
+
+    def "listNames"() {
+        when:
+        service.listNames(context, name, null, null, null)
+        throw new Success()
+
+        then:
+        thrown(expectedException)
+        rateLimiter.hasExceededRequestLimit(rateLimiterContext) >> exceeded
+
+        if (!exceeded) {
+            1 * delegate.listNames(context, name, null, null, null)
+        }
+
+        where:
+        exceeded | expectedException
+        true     | MetacatTooManyRequestsException
+        false    | Success
+    }
+
+    def "rename"() {
+        when:
+        service.rename(context, name, newName)
+        throw new Success()
+
+        then:
+        thrown(expectedException)
+        rateLimiter.hasExceededRequestLimit(rateLimiterContext) >> exceeded
+
+        if (!exceeded) {
+            1 * delegate.rename(context, name, newName)
+        }
+
+        where:
+        exceeded | expectedException
+        true     | MetacatTooManyRequestsException
+        false    | Success
+    }
+
+    def "listViewNames"() {
+        when:
+        service.listViewNames(context, name)
+        throw new Success()
+
+        then:
+        thrown(expectedException)
+        rateLimiter.hasExceededRequestLimit(rateLimiterContext) >> exceeded
+
+        if (!exceeded) {
+            1 * delegate.listViewNames(context, name)
+        }
+
+        where:
+        exceeded | expectedException
+        true     | MetacatTooManyRequestsException
+        false    | Success
+    }
+}

--- a/metacat-common-server/src/test/groovy/com/netflix/metacat/common/server/connectors/ThrottlingConnectorPartitionServiceSpec.groovy
+++ b/metacat-common-server/src/test/groovy/com/netflix/metacat/common/server/connectors/ThrottlingConnectorPartitionServiceSpec.groovy
@@ -1,0 +1,275 @@
+package com.netflix.metacat.common.server.connectors
+
+import com.netflix.metacat.common.QualifiedName
+import com.netflix.metacat.common.exception.MetacatTooManyRequestsException
+import com.netflix.metacat.common.server.api.ratelimiter.RateLimiter
+import com.netflix.metacat.common.server.api.ratelimiter.RateLimiterRequestContext
+import com.netflix.metacat.common.server.connectors.model.CatalogInfo
+import com.netflix.metacat.common.server.connectors.model.PartitionInfo
+import com.netflix.metacat.common.server.connectors.model.PartitionListRequest
+import com.netflix.metacat.common.server.connectors.model.PartitionsSaveRequest
+import com.netflix.metacat.common.server.connectors.model.TableInfo
+import com.netflix.metacat.common.server.util.MetacatContextManager
+import spock.lang.Specification
+
+class ThrottlingConnectorPartitionServiceSpec extends Specification {
+    def delegate
+    def rateLimiter
+    def context
+
+    def resource
+    def tableInfo
+    def name
+    def newName
+    def rateLimiterContext
+    def service
+
+    class Success extends RuntimeException {}
+
+    def setup() {
+        delegate = Mock(ConnectorPartitionService)
+        rateLimiter = Mock(RateLimiter)
+        context = Mock(ConnectorRequestContext)
+
+        name = QualifiedName.ofCatalog("c")
+        newName = QualifiedName.ofCatalog("c2")
+        resource = new PartitionInfo(name: name)
+        tableInfo = new TableInfo(name: name)
+
+        rateLimiterContext = new RateLimiterRequestContext("r1", name)
+
+        service = new ThrottlingConnectorPartitionService(delegate, rateLimiter)
+    }
+
+    def "create"() {
+        given:
+        MetacatContextManager.getContext().setRequestName("r1")
+
+        when:
+        service.create(context, resource)
+        throw new Success()
+
+        then:
+        thrown(expectedException)
+        rateLimiter.hasExceededRequestLimit(rateLimiterContext) >> exceeded
+
+        if (!exceeded) {
+            1 * delegate.create(context, resource)
+        }
+
+        where:
+        exceeded | expectedException
+        true     | MetacatTooManyRequestsException
+        false    | Success
+    }
+
+    def "update"() {
+
+        when:
+        service.update(context, resource)
+        throw new Success()
+
+        then:
+        thrown(expectedException)
+        rateLimiter.hasExceededRequestLimit(rateLimiterContext) >> exceeded
+
+        if (!exceeded) {
+            1 * delegate.update(context, resource)
+        }
+
+        where:
+        exceeded | expectedException
+        true     | MetacatTooManyRequestsException
+        false    | Success
+    }
+
+    def "delete"() {
+        when:
+        service.delete(context, name)
+        throw new Success()
+
+        then:
+        thrown(expectedException)
+        rateLimiter.hasExceededRequestLimit(rateLimiterContext) >> exceeded
+
+        if (!exceeded) {
+            1 * delegate.delete(context, name)
+        }
+
+        where:
+        exceeded | expectedException
+        true     | MetacatTooManyRequestsException
+        false    | Success
+    }
+
+    def "get"() {
+        when:
+        service.get(context, name)
+        throw new Success()
+
+        then:
+        thrown(expectedException)
+        rateLimiter.hasExceededRequestLimit(rateLimiterContext) >> exceeded
+
+        if (!exceeded) {
+            1 * delegate.get(context, name)
+        }
+
+        where:
+        exceeded | expectedException
+        true     | MetacatTooManyRequestsException
+        false    | Success
+    }
+
+    def "exists"() {
+        when:
+        service.exists(context, name)
+        throw new Success()
+
+        then:
+        thrown(expectedException)
+        rateLimiter.hasExceededRequestLimit(rateLimiterContext) >> exceeded
+
+        if (!exceeded) {
+            1 * delegate.exists(context, name)
+        }
+
+        where:
+        exceeded | expectedException
+        true     | MetacatTooManyRequestsException
+        false    | Success
+    }
+
+    def "list"() {
+        when:
+        service.list(context, name, null, null, null)
+        throw new Success()
+
+        then:
+        thrown(expectedException)
+        rateLimiter.hasExceededRequestLimit(rateLimiterContext) >> exceeded
+
+        if (!exceeded) {
+            1 * delegate.list(context, name, null, null, null)
+        }
+
+        where:
+        exceeded | expectedException
+        true     | MetacatTooManyRequestsException
+        false    | Success
+    }
+
+    def "listNames"() {
+        when:
+        service.listNames(context, name, null, null, null)
+        throw new Success()
+
+        then:
+        thrown(expectedException)
+        rateLimiter.hasExceededRequestLimit(rateLimiterContext) >> exceeded
+
+        if (!exceeded) {
+            1 * delegate.listNames(context, name, null, null, null)
+        }
+
+        where:
+        exceeded | expectedException
+        true     | MetacatTooManyRequestsException
+        false    | Success
+    }
+
+    def "rename"() {
+        when:
+        service.rename(context, name, newName)
+        throw new Success()
+
+        then:
+        thrown(expectedException)
+        rateLimiter.hasExceededRequestLimit(rateLimiterContext) >> exceeded
+
+        if (!exceeded) {
+            1 * delegate.rename(context, name, newName)
+        }
+
+        where:
+        exceeded | expectedException
+        true     | MetacatTooManyRequestsException
+        false    | Success
+    }
+
+    def "getPartitions"() {
+        when:
+        service.getPartitions(context, name, Mock(PartitionListRequest), tableInfo)
+        throw new Success()
+
+        then:
+        thrown(expectedException)
+        rateLimiter.hasExceededRequestLimit(rateLimiterContext) >> exceeded
+
+        if (!exceeded) {
+            1 * delegate.getPartitions(context, name, _, tableInfo)
+        }
+
+        where:
+        exceeded | expectedException
+        true     | MetacatTooManyRequestsException
+        false    | Success
+    }
+
+    def "savePartitions"() {
+        when:
+        service.savePartitions(context, name, Mock(PartitionsSaveRequest))
+        throw new Success()
+
+        then:
+        thrown(expectedException)
+        rateLimiter.hasExceededRequestLimit(rateLimiterContext) >> exceeded
+
+        if (!exceeded) {
+            1 * delegate.savePartitions(context, name, _,)
+        }
+
+        where:
+        exceeded | expectedException
+        true     | MetacatTooManyRequestsException
+        false    | Success
+    }
+
+    def "deletePartitions"() {
+        when:
+        service.deletePartitions(context, name, _, tableInfo)
+        throw new Success()
+
+        then:
+        thrown(expectedException)
+        rateLimiter.hasExceededRequestLimit(rateLimiterContext) >> exceeded
+
+        if (!exceeded) {
+            1 * delegate.deletePartitions(context, name, _, tableInfo)
+        }
+
+        where:
+        exceeded | expectedException
+        true     | MetacatTooManyRequestsException
+        false    | Success
+    }
+
+    def "getPartitionCount"() {
+        when:
+        service.getPartitionCount(context, name, tableInfo)
+        throw new Success()
+
+        then:
+        thrown(expectedException)
+        rateLimiter.hasExceededRequestLimit(rateLimiterContext) >> exceeded
+
+        if (!exceeded) {
+            1 * delegate.getPartitionCount(context, name, tableInfo)
+        }
+
+        where:
+        exceeded | expectedException
+        true     | MetacatTooManyRequestsException
+        false    | Success
+    }
+}

--- a/metacat-common-server/src/test/groovy/com/netflix/metacat/common/server/connectors/ThrottlingConnectorTableServiceSpec.groovy
+++ b/metacat-common-server/src/test/groovy/com/netflix/metacat/common/server/connectors/ThrottlingConnectorTableServiceSpec.groovy
@@ -1,0 +1,212 @@
+package com.netflix.metacat.common.server.connectors
+
+import com.netflix.metacat.common.QualifiedName
+import com.netflix.metacat.common.exception.MetacatTooManyRequestsException
+import com.netflix.metacat.common.server.api.ratelimiter.RateLimiter
+import com.netflix.metacat.common.server.api.ratelimiter.RateLimiterRequestContext
+import com.netflix.metacat.common.server.connectors.model.TableInfo
+import com.netflix.metacat.common.server.util.MetacatContextManager
+import spock.lang.Specification
+
+class ThrottlingConnectorTableServiceSpec extends Specification {
+    def delegate
+    def rateLimiter
+    def context
+
+    def resource
+    def name
+    def newName
+    def rateLimiterContext
+    def service
+
+    class Success extends RuntimeException {}
+
+    def setup() {
+        delegate = Mock(ConnectorTableService)
+        rateLimiter = Mock(RateLimiter)
+        context = Mock(ConnectorRequestContext)
+
+        name = QualifiedName.ofTable("c", "d", "t")
+        newName = QualifiedName.ofTable("c2", "d2", "t2")
+        resource = new TableInfo(name: name)
+
+        rateLimiterContext = new RateLimiterRequestContext("r1", name)
+
+        service = new ThrottlingConnectorTableService(delegate, rateLimiter)
+    }
+
+    def "create"() {
+        given:
+        MetacatContextManager.getContext().setRequestName("r1")
+
+        when:
+        service.create(context, resource)
+        throw new Success()
+
+        then:
+        thrown(expectedException)
+        rateLimiter.hasExceededRequestLimit(rateLimiterContext) >> exceeded
+
+        if (!exceeded) {
+            1 * delegate.create(context, resource)
+        }
+
+        where:
+        exceeded | expectedException
+        true     | MetacatTooManyRequestsException
+        false    | Success
+    }
+
+    def "update"() {
+
+        when:
+        service.update(context, resource)
+        throw new Success()
+
+        then:
+        thrown(expectedException)
+        rateLimiter.hasExceededRequestLimit(rateLimiterContext) >> exceeded
+
+        if (!exceeded) {
+            1 * delegate.update(context, resource)
+        }
+
+        where:
+        exceeded | expectedException
+        true     | MetacatTooManyRequestsException
+        false    | Success
+    }
+
+    def "delete"() {
+        when:
+        service.delete(context, name)
+        throw new Success()
+
+        then:
+        thrown(expectedException)
+        rateLimiter.hasExceededRequestLimit(rateLimiterContext) >> exceeded
+
+        if (!exceeded) {
+            1 * delegate.delete(context, name)
+        }
+
+        where:
+        exceeded | expectedException
+        true     | MetacatTooManyRequestsException
+        false    | Success
+    }
+
+    def "get"() {
+        when:
+        service.get(context, name)
+        throw new Success()
+
+        then:
+        thrown(expectedException)
+        rateLimiter.hasExceededRequestLimit(rateLimiterContext) >> exceeded
+
+        if (!exceeded) {
+            1 * delegate.get(context, name)
+        }
+
+        where:
+        exceeded | expectedException
+        true     | MetacatTooManyRequestsException
+        false    | Success
+    }
+
+    def "exists"() {
+        when:
+        service.exists(context, name)
+        throw new Success()
+
+        then:
+        thrown(expectedException)
+        rateLimiter.hasExceededRequestLimit(rateLimiterContext) >> exceeded
+
+        if (!exceeded) {
+            1 * delegate.exists(context, name)
+        }
+
+        where:
+        exceeded | expectedException
+        true     | MetacatTooManyRequestsException
+        false    | Success
+    }
+
+    def "list"() {
+        when:
+        service.list(context, name, null, null, null)
+        throw new Success()
+
+        then:
+        thrown(expectedException)
+        rateLimiter.hasExceededRequestLimit(rateLimiterContext) >> exceeded
+
+        if (!exceeded) {
+            1 * delegate.list(context, name, null, null, null)
+        }
+
+        where:
+        exceeded | expectedException
+        true     | MetacatTooManyRequestsException
+        false    | Success
+    }
+
+    def "listNames"() {
+        when:
+        service.listNames(context, name, null, null, null)
+        throw new Success()
+
+        then:
+        thrown(expectedException)
+        rateLimiter.hasExceededRequestLimit(rateLimiterContext) >> exceeded
+
+        if (!exceeded) {
+            1 * delegate.listNames(context, name, null, null, null)
+        }
+
+        where:
+        exceeded | expectedException
+        true     | MetacatTooManyRequestsException
+        false    | Success
+    }
+
+    def "rename"() {
+        when:
+        service.rename(context, name, newName)
+        throw new Success()
+
+        then:
+        thrown(expectedException)
+        rateLimiter.hasExceededRequestLimit(rateLimiterContext) >> exceeded
+
+        if (!exceeded) {
+            1 * delegate.rename(context, name, newName)
+        }
+
+        where:
+        exceeded | expectedException
+        true     | MetacatTooManyRequestsException
+        false    | Success
+    }
+
+    def "getTableNames"() {
+        when:
+        service.getTableNames(context, name, "filter", 10)
+        throw new Success()
+
+        then:
+        thrown(expectedException)
+        rateLimiter.hasExceededRequestLimit(rateLimiterContext) >> exceeded
+
+        if (!exceeded) {
+            1 * delegate.getTableNames(context, name, "filter", 10)
+        }
+
+        where:
+        exceeded | expectedException
+        true     | MetacatTooManyRequestsException
+        false    | Success
+    }
+}

--- a/metacat-common/src/main/java/com/netflix/metacat/common/MetacatRequestContext.java
+++ b/metacat-common/src/main/java/com/netflix/metacat/common/MetacatRequestContext.java
@@ -84,6 +84,9 @@ public class MetacatRequestContext implements Serializable {
     @Getter
     private final Map<String, String> additionalContext = new HashMap<>();
 
+    @Setter
+    private String requestName = UNKNOWN;
+
     /**
      * Constructor.
      */
@@ -141,6 +144,7 @@ public class MetacatRequestContext implements Serializable {
         sb.append(", apiUri='").append(apiUri).append('\'');
         sb.append(", scheme='").append(scheme).append('\'');
         sb.append(", additionalContext='").append(additionalContext).append('\'');
+        sb.append(", requestName='").append(requestName).append('\'');
         sb.append('}');
         return sb.toString();
     }

--- a/metacat-main/src/main/java/com/netflix/metacat/main/configs/ManagerConfig.java
+++ b/metacat-main/src/main/java/com/netflix/metacat/main/configs/ManagerConfig.java
@@ -17,6 +17,7 @@
  */
 package com.netflix.metacat.main.configs;
 
+import com.netflix.metacat.common.server.api.ratelimiter.RateLimiter;
 import com.netflix.metacat.common.server.converter.TypeConverterFactory;
 import com.netflix.metacat.common.server.properties.Config;
 import com.netflix.metacat.common.type.TypeManager;
@@ -43,11 +44,12 @@ public class ManagerConfig {
      * Manager of the connectors.
      *
      * @param config System config
+     * @param rateLimiter the rate limiter
      * @return The connector manager instance to use.
      */
     @Bean
-    public ConnectorManager connectorManager(final Config config) {
-        return new ConnectorManager(config);
+    public ConnectorManager connectorManager(final Config config, final RateLimiter rateLimiter) {
+        return new ConnectorManager(config, rateLimiter);
     }
 
     /**

--- a/metacat-main/src/main/java/com/netflix/metacat/main/configs/ServicesConfig.java
+++ b/metacat-main/src/main/java/com/netflix/metacat/main/configs/ServicesConfig.java
@@ -20,6 +20,8 @@ package com.netflix.metacat.main.configs;
 import com.netflix.metacat.common.json.MetacatJson;
 import com.netflix.metacat.common.server.api.ratelimiter.DefaultRateLimiter;
 import com.netflix.metacat.common.server.api.ratelimiter.RateLimiter;
+import com.netflix.metacat.common.server.api.traffic_control.DefaultRequestGateway;
+import com.netflix.metacat.common.server.api.traffic_control.RequestGateway;
 import com.netflix.metacat.common.server.converter.ConverterUtil;
 import com.netflix.metacat.common.server.events.MetacatEventBus;
 import com.netflix.metacat.common.server.properties.Config;
@@ -149,6 +151,17 @@ public class ServicesConfig {
     @ConditionalOnMissingBean(RateLimiter.class)
     public RateLimiter rateLimiter() {
         return new DefaultRateLimiter();
+    }
+
+    /**
+     * The default {@link RequestGateway} bean.
+     *
+     * @return the default {@link RequestGateway} bean.
+     */
+    @Bean
+    @ConditionalOnMissingBean(RequestGateway.class)
+    public RequestGateway requestGateway() {
+        return new DefaultRequestGateway();
     }
 
     /**


### PR DESCRIPTION
* Refactor connector manager to allow decorating connector services with common functionality
* Perform throttling at the connector layer
* Split request validation and rate limiting so that only request validation happens in the controller layer

Older related PR: https://github.com/Netflix/metacat/pull/531 which will now be discarded