### PR TITLE
Refactor connector decorator

### DIFF
--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/connectors/ConnectorFactoryDecorator.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/connectors/ConnectorFactoryDecorator.java
@@ -1,8 +1,10 @@
 package com.netflix.metacat.common.server.connectors;
 
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
 import com.netflix.metacat.common.server.api.ratelimiter.RateLimiter;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -10,72 +12,75 @@ import lombok.extern.slf4j.Slf4j;
  * to all connector services.
  */
 @Slf4j
-@RequiredArgsConstructor
 public class ConnectorFactoryDecorator implements ConnectorFactory {
-    private final ConnectorPlugin connectorPlugin;
     @Getter
     private final ConnectorFactory delegate;
-    private final ConnectorContext connectorContext;
-    private final RateLimiter rateLimiter;
+    private final Supplier<ConnectorCatalogService> catalogService;
+    private final Supplier<ConnectorDatabaseService> databaseService;
+    private final Supplier<ConnectorTableService> tableService;
+    private final Supplier<ConnectorPartitionService> partitionService;
 
-    @Override
-    public ConnectorCatalogService getCatalogService() {
-        ConnectorCatalogService service = delegate.getCatalogService();
+    /**
+     * Creates the decorated connector factory that wraps connector services
+     * with additional wrappers.
+     *
+     * @param connectorPlugin the underlying plugin
+     * @param connectorContext the connector context for the underlying plugin
+     */
+    public ConnectorFactoryDecorator(@NonNull final ConnectorPlugin connectorPlugin,
+                                     @NonNull final ConnectorContext connectorContext) {
+        this.delegate = connectorPlugin.create(connectorContext);
 
-        if (isRateLimiterEnabled()) {
-            log.info("Creating rate-limited connector catalog services for connector-type: {}, "
+        if (isRateLimiterEnabled(connectorContext)) {
+            log.info("Creating rate-limited connector services for connector-type: {}, "
                          + "plugin-type: {}, catalog: {}, shard: {}",
                 connectorContext.getConnectorType(), connectorPlugin.getType(),
                 connectorContext.getCatalogName(), connectorContext.getCatalogShardName());
-            service = new ThrottlingConnectorCatalogService(service, rateLimiter);
-        }
 
-        return service;
+            final RateLimiter rateLimiter = connectorContext.getApplicationContext().getBean(RateLimiter.class);
+
+            // not all connectors implement these methods;
+            // calling these eagerly may throw an unsupported operation exception;
+            // hence we only memoize these for now and call them at runtime when they are needed
+            catalogService = memoize(
+                () -> new ThrottlingConnectorCatalogService(delegate.getCatalogService(), rateLimiter));
+            databaseService = memoize(
+                () -> new ThrottlingConnectorDatabaseService(delegate.getDatabaseService(), rateLimiter));
+            tableService = memoize(
+                () -> new ThrottlingConnectorTableService(delegate.getTableService(), rateLimiter));
+            partitionService = memoize(
+                () -> new ThrottlingConnectorPartitionService(delegate.getPartitionService(), rateLimiter));
+        } else {
+            log.info("Creating non rate-limited connector services for connector-type: {}, "
+                         + "plugin-type: {}, catalog: {}, shard: {}",
+                connectorContext.getConnectorType(), connectorPlugin.getType(),
+                connectorContext.getCatalogName(), connectorContext.getCatalogShardName());
+
+            catalogService = memoize(delegate::getCatalogService);
+            databaseService = memoize(delegate::getDatabaseService);
+            tableService = memoize(delegate::getTableService);
+            partitionService = memoize(delegate::getPartitionService);
+        }
+    }
+
+    @Override
+    public ConnectorCatalogService getCatalogService() {
+        return catalogService.get();
     }
 
     @Override
     public ConnectorDatabaseService getDatabaseService() {
-        ConnectorDatabaseService service = delegate.getDatabaseService();
-
-        if (isRateLimiterEnabled()) {
-            log.info("Creating rate-limited connector database services for connector-type: {}, "
-                         + "plugin-type: {}, catalog: {}, shard: {}",
-                connectorContext.getConnectorType(), connectorPlugin.getType(),
-                connectorContext.getCatalogName(), connectorContext.getCatalogShardName());
-            service = new ThrottlingConnectorDatabaseService(service, rateLimiter);
-        }
-
-        return service;
+        return databaseService.get();
     }
 
     @Override
     public ConnectorTableService getTableService() {
-        ConnectorTableService service = delegate.getTableService();
-
-        if (isRateLimiterEnabled()) {
-            log.info("Creating rate-limited connector table services for connector-type: {}, "
-                         + "plugin-type: {}, catalog: {}, shard: {}",
-                connectorContext.getConnectorType(), connectorPlugin.getType(),
-                connectorContext.getCatalogName(), connectorContext.getCatalogShardName());
-            service = new ThrottlingConnectorTableService(service, rateLimiter);
-        }
-
-        return service;
+        return tableService.get();
     }
 
     @Override
     public ConnectorPartitionService getPartitionService() {
-        ConnectorPartitionService service = delegate.getPartitionService();
-
-        if (isRateLimiterEnabled()) {
-            log.info("Creating rate-limited connector partition services for connector-type: {}, "
-                         + "plugin-type: {}, catalog: {}, shard: {}",
-                connectorContext.getConnectorType(), connectorPlugin.getType(),
-                connectorContext.getCatalogName(), connectorContext.getCatalogShardName());
-            service = new ThrottlingConnectorPartitionService(service, rateLimiter);
-        }
-
-        return service;
+        return partitionService.get();
     }
 
     @Override
@@ -93,7 +98,11 @@ public class ConnectorFactoryDecorator implements ConnectorFactory {
         delegate.stop();
     }
 
-    private boolean isRateLimiterEnabled() {
+    private <T> Supplier<T> memoize(final Supplier<T> supplier) {
+        return Suppliers.memoize(supplier::get)::get;
+    }
+
+    private boolean isRateLimiterEnabled(final ConnectorContext connectorContext) {
         if (connectorContext.getConfiguration() == null) {
             return true;
         }

--- a/metacat-main/src/main/java/com/netflix/metacat/main/configs/ManagerConfig.java
+++ b/metacat-main/src/main/java/com/netflix/metacat/main/configs/ManagerConfig.java
@@ -17,14 +17,13 @@
  */
 package com.netflix.metacat.main.configs;
 
-import com.netflix.metacat.common.server.api.ratelimiter.RateLimiter;
 import com.netflix.metacat.common.server.converter.TypeConverterFactory;
 import com.netflix.metacat.common.server.properties.Config;
 import com.netflix.metacat.common.type.TypeManager;
 import com.netflix.metacat.common.type.TypeRegistry;
 import com.netflix.metacat.main.manager.CatalogManager;
-import com.netflix.metacat.main.manager.DefaultCatalogManager;
 import com.netflix.metacat.main.manager.ConnectorManager;
+import com.netflix.metacat.main.manager.DefaultCatalogManager;
 import com.netflix.metacat.main.manager.PluginManager;
 import com.netflix.spectator.api.Registry;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -44,12 +43,11 @@ public class ManagerConfig {
      * Manager of the connectors.
      *
      * @param config System config
-     * @param rateLimiter the rate limiter
      * @return The connector manager instance to use.
      */
     @Bean
-    public ConnectorManager connectorManager(final Config config, final RateLimiter rateLimiter) {
-        return new ConnectorManager(config, rateLimiter);
+    public ConnectorManager connectorManager(final Config config) {
+        return new ConnectorManager(config);
     }
 
     /**

--- a/metacat-main/src/main/java/com/netflix/metacat/main/manager/ConnectorManager.java
+++ b/metacat-main/src/main/java/com/netflix/metacat/main/manager/ConnectorManager.java
@@ -32,7 +32,6 @@ import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.Sets;
 import com.google.common.collect.Table;
 import com.netflix.metacat.common.QualifiedName;
-import com.netflix.metacat.common.server.api.ratelimiter.RateLimiter;
 import com.netflix.metacat.common.server.connectors.ConnectorCatalogService;
 import com.netflix.metacat.common.server.connectors.ConnectorContext;
 import com.netflix.metacat.common.server.connectors.ConnectorDatabaseService;
@@ -89,7 +88,6 @@ public class ConnectorManager {
     private final AtomicBoolean stopped = new AtomicBoolean();
 
     private final Config config;
-    private final RateLimiter rateLimiter;
 
     /**
      * Stop.
@@ -146,11 +144,7 @@ public class ConnectorManager {
 
             catalogConfigs.add(catalogConfig);
 
-            final ConnectorFactory connectorFactory = new ConnectorFactoryDecorator(
-                connectorPlugin,
-                connectorPlugin.create(connectorContext),
-                connectorContext, rateLimiter
-            );
+            final ConnectorFactory connectorFactory = new ConnectorFactoryDecorator(connectorPlugin, connectorContext);
 
             try {
                 databaseServices.add(connectorFactory.getDatabaseService());


### PR DESCRIPTION
* In the current implementation, every dependency of the decorators would need to be plumbed into multiple places.
  * For instance, the rate limiter, had to be plumbed through the connector manager and would need similar plumbing in the migration connector factory.
 * With the new implementation, deciding what wrappers to use and what dependencies are needed is confined in the decorating connector factory.