### PR TITLE
Fix setTag logic to prevent high cpu load on rds

### DIFF
--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/usermetadata/LookupService.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/usermetadata/LookupService.java
@@ -31,12 +31,14 @@ import java.util.Set;
 public interface LookupService {
     /**
      * Returns the lookup for the given <code>name</code>.
+     * If includeValues = true, we will set the Lookup values with the associated name, otherwise empty set
      *
      * @param name lookup name
+     * @param includeValues whether we should set the values or not in the Lookup Object
      * @return lookup
      */
     @Nullable
-    default Lookup get(final String name) {
+    default Lookup get(final String name, final boolean includeValues) {
         return null;
     }
 
@@ -75,22 +77,20 @@ public interface LookupService {
      *
      * @param name   lookup name
      * @param values multiple values
+     * @param includeValues whether to populate the values field in the Lookup Object
      * @return updated lookup
      */
-    @Nullable
-    default Lookup setValues(final String name, final Set<String> values) {
-        return null;
-    }
 
     /**
      * Saves the lookup value.
      *
      * @param name   lookup name
      * @param values multiple values
+     * @param includeValues whether to include values in the final Lookup Object
      * @return updated lookup
      */
     @Nullable
-    default Lookup addValues(final String name, final Set<String> values) {
+    default Lookup addValues(final String name, final Set<String> values, boolean includeValues) {
         return null;
     }
 
@@ -99,11 +99,7 @@ public interface LookupService {
      *
      * @param name  lookup name
      * @param value lookup value
+     * @param includeValues whether to return lookup value in the Lookup Object
      * @return updated lookup
      */
-    @Nullable
-    default Lookup setValue(final String name, final String value) {
-        return null;
-    }
-
 }

--- a/metacat-metadata-mysql/src/main/java/com/netflix/metacat/metadata/mysql/MySqlLookupService.java
+++ b/metacat-metadata-mysql/src/main/java/com/netflix/metacat/metadata/mysql/MySqlLookupService.java
@@ -50,8 +50,7 @@ public class MySqlLookupService implements LookupService {
     private static final String SQL_INSERT_LOOKUP_VALUES =
         "insert into lookup_values( lookup_id, values_string) values (?,?)";
     private static final String SQL_INSERT_LOOKUP_VALUE_IF_NOT_EXIST =
-        "INSERT INTO lookup_values(lookup_id, values_string) VALUES (?,?) "
-            + "ON DUPLICATE KEY UPDATE lookup_id=lookup_id, values_string=values_string";
+        "INSERT IGNORE INTO lookup_values (lookup_id, values_string) VALUES (?, ?)";
 
     private static final String SQL_GET_LOOKUP_VALUES =
         "select values_string value from lookup_values where lookup_id=?";

--- a/metacat-metadata-mysql/src/main/java/com/netflix/metacat/metadata/mysql/MySqlLookupService.java
+++ b/metacat-metadata-mysql/src/main/java/com/netflix/metacat/metadata/mysql/MySqlLookupService.java
@@ -13,7 +13,6 @@
 
 package com.netflix.metacat.metadata.mysql;
 
-import com.google.common.base.Joiner;
 import com.google.common.collect.Sets;
 import com.netflix.metacat.common.server.model.Lookup;
 import com.netflix.metacat.common.server.properties.Config;
@@ -23,7 +22,6 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.jdbc.core.SqlParameterValue;
 import org.springframework.jdbc.support.GeneratedKeyHolder;
 import org.springframework.jdbc.support.KeyHolder;
 import org.springframework.transaction.annotation.Transactional;
@@ -32,6 +30,7 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Types;
+import java.util.Collections;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -50,8 +49,10 @@ public class MySqlLookupService implements LookupService {
             + " values (?,0,?,?,?,now(),now())";
     private static final String SQL_INSERT_LOOKUP_VALUES =
         "insert into lookup_values( lookup_id, values_string) values (?,?)";
-    private static final String SQL_DELETE_LOOKUP_VALUES =
-        "delete from lookup_values where lookup_id=? and values_string in (%s)";
+    private static final String SQL_INSERT_LOOKUP_VALUE_IF_NOT_EXIST =
+        "INSERT INTO lookup_values(lookup_id, values_string) VALUES (?,?) "
+            + "ON DUPLICATE KEY UPDATE lookup_id=lookup_id, values_string=values_string";
+
     private static final String SQL_GET_LOOKUP_VALUES =
         "select values_string value from lookup_values where lookup_id=?";
     private static final String SQL_GET_LOOKUP_VALUES_BY_NAME =
@@ -79,7 +80,7 @@ public class MySqlLookupService implements LookupService {
      */
     @Override
     @Transactional(readOnly = true)
-    public Lookup get(final String name) {
+    public Lookup get(final String name, final boolean includeValues) {
         try {
             return jdbcTemplate.queryForObject(
                 SQL_GET_LOOKUP,
@@ -93,7 +94,7 @@ public class MySqlLookupService implements LookupService {
                     lookup.setLastUpdated(rs.getDate("lastUpdated"));
                     lookup.setLastUpdatedBy(rs.getString("lastUpdatedBy"));
                     lookup.setDateCreated(rs.getDate("dateCreated"));
-                    lookup.setValues(getValues(rs.getLong("id")));
+                    lookup.setValues(includeValues ? getValues(rs.getLong("id")) : Collections.EMPTY_SET);
                     return lookup;
                 });
         } catch (EmptyResultDataAccessException e) {
@@ -162,61 +163,22 @@ public class MySqlLookupService implements LookupService {
         }
     }
 
-    /**
-     * Saves the lookup value.
-     *
-     * @param name   lookup name
-     * @param values multiple values
-     * @return returns the lookup with the given name.
-     */
-    @Override
-    public Lookup setValues(final String name, final Set<String> values) {
-        try {
-            final Lookup lookup = findOrCreateLookupByName(name);
-            final Set<String> inserts;
-            Set<String> deletes = Sets.newHashSet();
-            final Set<String> lookupValues = lookup.getValues();
-            if (lookupValues == null || lookupValues.isEmpty()) {
-                inserts = values;
-            } else {
-                inserts = Sets.difference(values, lookupValues).immutableCopy();
-                deletes = Sets.difference(lookupValues, values).immutableCopy();
-            }
-            lookup.setValues(values);
-            if (!inserts.isEmpty()) {
-                insertLookupValues(lookup.getId(), inserts);
-            }
-            if (!deletes.isEmpty()) {
-                deleteLookupValues(lookup.getId(), deletes);
-            }
-            return lookup;
-        } catch (Exception e) {
-            final String message = String.format("Failed to set the lookup values for name %s", name);
-            log.error(message, e);
-            throw new UserMetadataServiceException(message, e);
-        }
-    }
-
-    private void insertLookupValues(final Long id, final Set<String> inserts) {
-        jdbcTemplate.batchUpdate(SQL_INSERT_LOOKUP_VALUES, inserts.stream().map(insert -> new Object[]{id, insert})
+    private void insertLookupValuesIfNotExist(final Long id, final Set<String> inserts) {
+        jdbcTemplate.batchUpdate(SQL_INSERT_LOOKUP_VALUE_IF_NOT_EXIST,
+            inserts.stream().map(insert -> new Object[]{id, insert})
             .collect(Collectors.toList()), new int[]{Types.BIGINT, Types.VARCHAR});
-    }
-
-    private void deleteLookupValues(final Long id, final Set<String> deletes) {
-        jdbcTemplate.update(
-            String.format(SQL_DELETE_LOOKUP_VALUES, "'" + Joiner.on("','").skipNulls().join(deletes) + "'"),
-            new SqlParameterValue(Types.BIGINT, id));
     }
 
     /**
      * findOrCreateLookupByName.
      *
      * @param name name to find or create
+     * @param includeValues whether to include the values in the Lookup Object
      * @return Look up object
      * @throws SQLException sql exception
      */
-    private Lookup findOrCreateLookupByName(final String name) throws SQLException {
-        Lookup lookup = get(name);
+    private Lookup findOrCreateLookupByName(final String name, final boolean includeValues) throws SQLException {
+        Lookup lookup = get(name, includeValues);
         if (lookup == null) {
             final KeyHolder holder = new GeneratedKeyHolder();
             jdbcTemplate.update(connection -> {
@@ -244,20 +206,14 @@ public class MySqlLookupService implements LookupService {
      * @return returns the lookup with the given name.
      */
     @Override
-    public Lookup addValues(final String name, final Set<String> values) {
+    public Lookup addValues(final String name, final Set<String> values, final boolean includeValues) {
         try {
-            final Lookup lookup = findOrCreateLookupByName(name);
-
-            final Set<String> inserts;
-            final Set<String> lookupValues = lookup.getValues();
-            if (lookupValues == null || lookupValues.isEmpty()) {
-                inserts = values;
-                lookup.setValues(values);
-            } else {
-                inserts = Sets.difference(values, lookupValues);
+            final Lookup lookup = findOrCreateLookupByName(name, includeValues);
+            if (!values.isEmpty()) {
+                insertLookupValuesIfNotExist(lookup.getId(), values);
             }
-            if (!inserts.isEmpty()) {
-                insertLookupValues(lookup.getId(), inserts);
+            if (includeValues) {
+                lookup.getValues().addAll(values);
             }
             return lookup;
         } catch (Exception e) {
@@ -265,17 +221,5 @@ public class MySqlLookupService implements LookupService {
             log.error(message, e);
             throw new UserMetadataServiceException(message, e);
         }
-    }
-
-    /**
-     * Saves the lookup value.
-     *
-     * @param name  lookup name
-     * @param value lookup value
-     * @return returns the lookup with the given name.
-     */
-    @Override
-    public Lookup setValue(final String name, final String value) {
-        return setValues(name, Sets.newHashSet(value));
     }
 }

--- a/metacat-metadata-mysql/src/main/java/com/netflix/metacat/metadata/mysql/MySqlTagService.java
+++ b/metacat-metadata-mysql/src/main/java/com/netflix/metacat/metadata/mysql/MySqlTagService.java
@@ -124,9 +124,9 @@ public class MySqlTagService implements TagService {
         this.userMetadataService = Preconditions.checkNotNull(userMetadataService, "userMetadataService is required");
     }
 
-    private Lookup addTags(final Set<String> tags) {
+    private Lookup addTags(final Set<String> tags, final boolean includeValues) {
         try {
-            return lookupService.addValues(LOOKUP_NAME_TAG, tags);
+            return lookupService.addValues(LOOKUP_NAME_TAG, tags, includeValues);
         } catch (Exception e) {
             final String message = String.format("Failed adding the tags %s", tags);
             log.error(message, e);
@@ -396,7 +396,7 @@ public class MySqlTagService implements TagService {
     @Override
     public Set<String> setTags(final QualifiedName name, final Set<String> tags,
                                final boolean updateUserMetadata) {
-        addTags(tags);
+        addTags(tags, false);
         try {
             final TagItem tagItem = findOrCreateTagItemByName(name.toString());
             final Set<String> inserts;

--- a/metacat-metadata-mysql/src/test/groovy/com/netflix/metacat/metadata/mysql/MySqlLookupServiceSpec.groovy
+++ b/metacat-metadata-mysql/src/test/groovy/com/netflix/metacat/metadata/mysql/MySqlLookupServiceSpec.groovy
@@ -1,0 +1,79 @@
+/*
+ *       Copyright 2017 Netflix, Inc.
+ *          Licensed under the Apache License, Version 2.0 (the "License");
+ *          you may not use this file except in compliance with the License.
+ *          You may obtain a copy of the License at
+ *              http://www.apache.org/licenses/LICENSE-2.0
+ *          Unless required by applicable law or agreed to in writing, software
+ *          distributed under the License is distributed on an "AS IS" BASIS,
+ *          WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *          See the License for the specific language governing permissions and
+ *          limitations under the License.
+ */
+
+package com.netflix.metacat.metadata.mysql
+
+import com.google.common.collect.Lists
+import com.netflix.metacat.common.QualifiedName
+import com.netflix.metacat.common.server.model.Lookup
+import com.netflix.metacat.common.server.properties.Config
+import com.netflix.metacat.testdata.provider.DataDtoProvider
+import org.springframework.jdbc.core.JdbcTemplate
+import spock.lang.Ignore
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import java.time.Instant
+
+/**
+ * Tests for MysqlUserMetadataService.
+ * TODO: Need to move this to integration-test
+ * @author amajumdar
+ */
+
+class MySqlLookupServiceSpec extends Specification {
+    MySqlLookupService mySqlLookupService
+
+    Config config
+    JdbcTemplate jdbcTemplate
+
+    def setup() {
+        config = Mock(Config)
+        jdbcTemplate = Mock(JdbcTemplate)
+
+        mySqlLookupService = new MySqlLookupService(config, jdbcTemplate)
+    }
+
+    @Unroll
+    def "test includeValues"() {
+        setup:
+        def lookupWithValues = new Lookup(
+            id: 1L,
+            name: 'Test1',
+            values: new HashSet<String>(['tag1', 'tag2']),
+            dateCreated: new Date(),
+            lastUpdated: new Date()
+        )
+        def lookupWithoutValues = new Lookup(
+            id: 2L,
+            name: 'Test2',
+            values: new HashSet<String>([]),
+            dateCreated: new Date(),
+            lastUpdated: new Date()
+        )
+        when:
+        jdbcTemplate.queryForObject(_, _, _, _) >> (includeValues ? lookupWithValues : lookupWithoutValues)
+        def lookUpResult = mySqlLookupService.addValues("tag", tagsToAdd, includeValues)
+
+        then:
+        lookUpResult.values == expectedValues
+        where:
+        tagsToAdd                       | includeValues | expectedValues
+        ['tag1', 'tag2'] as Set<String> |true           | ['tag1', 'tag2'] as Set<String>
+        ['tag1', 'tag2'] as Set<String> |false          | [] as Set<String>
+        ['tag1', 'tag3'] as Set<String> |true           | ['tag1', 'tag2', 'tag3'] as Set<String>
+        ['tag1', 'tag3'] as Set<String> |false          | [] as Set<String>
+        ['tag3', 'tag4'] as Set<String> |true           | ['tag1', 'tag2', 'tag3', 'tag4'] as Set<String>
+        ['tag3', 'tag4'] as Set<String> |false          | [] as Set<String>
+    }
+}

--- a/metacat-metadata-mysql/src/test/groovy/com/netflix/metacat/metadata/mysql/MySqlLookupServiceSpec.groovy
+++ b/metacat-metadata-mysql/src/test/groovy/com/netflix/metacat/metadata/mysql/MySqlLookupServiceSpec.groovy
@@ -50,7 +50,7 @@ class MySqlLookupServiceSpec extends Specification {
         def lookupWithValues = new Lookup(
             id: 1L,
             name: 'Test1',
-            values: new HashSet<String>(['tag1', 'tag2']),
+            values: new HashSet<String>(['tag1', 'tag1', 'tag2']),
             dateCreated: new Date(),
             lastUpdated: new Date()
         )
@@ -68,12 +68,13 @@ class MySqlLookupServiceSpec extends Specification {
         then:
         lookUpResult.values == expectedValues
         where:
-        tagsToAdd                       | includeValues | expectedValues
-        ['tag1', 'tag2'] as Set<String> |true           | ['tag1', 'tag2'] as Set<String>
-        ['tag1', 'tag2'] as Set<String> |false          | [] as Set<String>
-        ['tag1', 'tag3'] as Set<String> |true           | ['tag1', 'tag2', 'tag3'] as Set<String>
-        ['tag1', 'tag3'] as Set<String> |false          | [] as Set<String>
-        ['tag3', 'tag4'] as Set<String> |true           | ['tag1', 'tag2', 'tag3', 'tag4'] as Set<String>
-        ['tag3', 'tag4'] as Set<String> |false          | [] as Set<String>
+        tagsToAdd                               | includeValues | expectedValues
+        ['tag1', 'tag2'] as Set<String>         |true           | ['tag1', 'tag2'] as Set<String>
+        ['tag1', 'tag2'] as Set<String>         |false          | [] as Set<String>
+        ['tag1', 'tag3'] as Set<String>         |true           | ['tag1', 'tag2', 'tag3'] as Set<String>
+        ['tag1', 'tag3'] as Set<String>         |false          | [] as Set<String>
+        ['tag3', 'tag4'] as Set<String>         |true           | ['tag1', 'tag2', 'tag3', 'tag4'] as Set<String>
+        ['tag3', 'tag4'] as Set<String>         |false          | [] as Set<String>
+        ['tag3', 'tag3', 'tag4'] as Set<String> |true           | ['tag1', 'tag2', 'tag3', 'tag4'] as Set<String>
     }
 }


### PR DESCRIPTION
For now, whenever we want to set a tag on a resource, it will always fetch all tags from the dbs into memory, and then do a diff to figure out what tags never exist in the db. Loading all tags at once creates a lot of load on the rds if the number of tags is huge when number of setTag request is high. 

For this PR, I also remove some unused code.

Instead of fetching all tags into memory, we will instead do 
```
"INSERT INTO lookup_values(lookup_id, values_string) VALUES (?,?) "
            + "ON DUPLICATE KEY UPDATE lookup_id=lookup_id, values_string=values_string"; 
```


Even though, there is no unit test for tag component, there are lots of existing tests in the functional test, and I also add one more functional test to cover more scenarios.
Since the logic I change should have no impact on the core logic, we should expect the functionalTest to have the same result [before](https://github.com/Netflix/metacat/pull/573) and after this change.

Finally, in order to make this insert query fast, we will need to build a composite index on (lookup_id, values_string)