### PR TITLE
Publish Snapshot on dev-snapshot branch

### DIFF
--- a/.github/workflows/nebula-snapshot.yml
+++ b/.github/workflows/nebula-snapshot.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - dev-snapshot
 
 jobs:
   build:


### PR DESCRIPTION
Adding another target branch to this GH Action, which allows us to publish snapshots on unmerged code in the `dev-snapshot` branch