### PR TITLE
improveTestAndSetBackSnowFlakeJDBC

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -146,7 +146,7 @@ configure(javaProjects) {
             dependency("org.codehaus.gpars:gpars:1.2.1")
             /**es 5.4.1 dependencies*/
             dependency("org.elasticsearch.client:transport:5.4.1")
-            dependency("net.snowflake:snowflake-jdbc:3.15.0")
+            dependency("net.snowflake:snowflake-jdbc:3.4.2")
             dependency("com.esotericsoftware.kryo:kryo:2.22")
             dependency("org.apache.iceberg:iceberg-spark-runtime:${iceberg_version}")
             dependency("com.datastax.cassandra:cassandra-driver-core:3.7.2")

--- a/metacat-functional-tests/src/functionalTest/groovy/com/netflix/metacat/MySqlLookupServiceSpec.groovy
+++ b/metacat-functional-tests/src/functionalTest/groovy/com/netflix/metacat/MySqlLookupServiceSpec.groovy
@@ -138,15 +138,15 @@ class MySqlLookupServiceSpec extends Specification{
 
     def "test setValue for different id"(){
         when:
-        def mock1LookUp = mySqlLookupService.setValues("mock1", ["1", "2", "3"] as Set<String>)
-        def mock2LookUp = mySqlLookupService.setValues("mock2", ["4", "5", "6"] as Set<String>)
+        def mock1LookUp = mySqlLookupService.setValue("setValue_mock1", "1")
+        def mock2LookUp = mySqlLookupService.setValue("setValue_mock2",  "2")
         then:
-        mock1LookUp.values == ["1", "2", "3"] as Set<String>
-        mock1LookUp.values == mySqlLookupService.getValues("mock1")
-        areLookupsEqual(mock1LookUp, mySqlLookupService.get("mock1", true))
-        mock2LookUp.values == ["4", "5", "6"] as Set<String>
-        mock2LookUp.values == mySqlLookupService.getValues("mock2")
-        areLookupsEqual(mock2LookUp, mySqlLookupService.get("mock2", true))
+        mock1LookUp.values == ["1"] as Set<String>
+        mock1LookUp.values == mySqlLookupService.getValues("setValue_mock1")
+        areLookupsEqual(mock1LookUp, mySqlLookupService.get("setValue_mock1", true))
+        mock2LookUp.values == ["2"] as Set<String>
+        mock2LookUp.values == mySqlLookupService.getValues("setValue_mock2")
+        areLookupsEqual(mock2LookUp, mySqlLookupService.get("setValue_mock2", true))
     }
 }
 


### PR DESCRIPTION
This PR includes two changes:

1. Improve the tag functional test, where we add a new functional test for setValue since we already had another functional test for setValues.
2. Set back the snowflake jdbc version to minimize the potential impact for the setTagRollout (previous PR which hasn't landed to production yet: https://github.com/Netflix/metacat/commit/2bf2a0be167a887c08d3066259070edf2099f0c8). We will have another rollout for snowflake jdbc