### PR TITLE
onDelete MetadataInterceptor

### DIFF
--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/usermetadata/MetadataInterceptor.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/usermetadata/MetadataInterceptor.java
@@ -33,7 +33,7 @@ import javax.annotation.Nullable;
 public interface MetadataInterceptor {
 
     /**
-     * apply business rules before retrieving back. These rules may change or overriding existing
+     * Apply business rules before retrieving back. These rules may change or override existing
      * business metadata.
      *
      * @param userMetadataService user metadata service
@@ -47,14 +47,26 @@ public interface MetadataInterceptor {
     }
 
     /**
-     * Valide ObjectNode before storing it.
+     * Validate ObjectNode before storing it.
      * @param userMetadataService user metadata service
-     * @param name       qualified name
-     * @param objectNode input metadata object node
+     * @param name                qualified name
+     * @param objectNode          input metadata object node
      * @throws InvalidMetadataException business validation exception
      */
     default void onWrite(final UserMetadataService userMetadataService,
                          final QualifiedName name, final ObjectNode objectNode)
+        throws InvalidMetadataException {
+    }
+
+    /**
+     * Validate ObjectNode before deleting it.
+     * @param userMetadataService user metadata service
+     * @param name                qualified name
+     * @param objectNode          to-be-deleted metadata object node
+     * @throws InvalidMetadataException business validation exception
+     */
+    default void onDelete(final UserMetadataService userMetadataService,
+                          final QualifiedName name, final ObjectNode objectNode)
         throws InvalidMetadataException {
     }
 }

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/usermetadata/MetadataInterceptor.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/usermetadata/MetadataInterceptor.java
@@ -62,11 +62,10 @@ public interface MetadataInterceptor {
      * Validate ObjectNode before deleting it.
      * @param userMetadataService user metadata service
      * @param name                qualified name
-     * @param objectNode          to-be-deleted metadata object node
      * @throws InvalidMetadataException business validation exception
      */
     default void onDelete(final UserMetadataService userMetadataService,
-                          final QualifiedName name, final ObjectNode objectNode)
+                          final QualifiedName name)
         throws InvalidMetadataException {
     }
 }

--- a/metacat-metadata-mysql/src/main/java/com/netflix/metacat/metadata/mysql/MysqlUserMetadataService.java
+++ b/metacat-metadata-mysql/src/main/java/com/netflix/metacat/metadata/mysql/MysqlUserMetadataService.java
@@ -223,7 +223,6 @@ public class MysqlUserMetadataService extends BaseUserMetadataService {
                         .filter(m -> m instanceof HasDataMetadata && ((HasDataMetadata) m).isDataExternal())
                         .map(m -> ((HasDataMetadata) m).getDataUri()).collect(Collectors.toList());
                     if (!uris.isEmpty()) {
-                        // TODO amboz determine if its OK to delete data metadata when DM fails onDelete
                         _softDeleteDataMetadata(userId, uris);
                     }
                 }
@@ -249,10 +248,8 @@ public class MysqlUserMetadataService extends BaseUserMetadataService {
                 try {
                     // apply interceptor to validate the object node
                     this.metadataInterceptor.onDelete(this, name);
-                    // add valid names to validNames
                     validNames.add(name);
                 } catch (Exception e) {
-                    // if onDelete throws an exception, remove this name from aNames and log it
                     final String message = String.format(
                         "metadata onDelete for name %s encountered an exception", name
                     );
@@ -270,7 +267,6 @@ public class MysqlUserMetadataService extends BaseUserMetadataService {
                 .toArray(SqlParameterValue[]::new);
             if (aNames.length > 0) {
                 final List<String> paramVariables = Arrays.stream(aNames).map(s -> "?").collect(Collectors.toList());
-                // At this point, only aNames that did not encounter an exception onDelete will be deleted
                 jdbcTemplate.update(
                     String.format(SQL.DELETE_DEFINITION_METADATA, Joiner.on(",").skipNulls().join(paramVariables)),
                     (Object[]) aNames);
@@ -278,7 +274,6 @@ public class MysqlUserMetadataService extends BaseUserMetadataService {
             if (aPartitionNames.length > 0) {
                 final List<String> paramVariables =
                     Arrays.stream(aPartitionNames).map(s -> "?").collect(Collectors.toList());
-                // At this point, only aPartitionNames that did not encounter an exception onDelete will be deleted
                 jdbcTemplate.update(
                     String.format(SQL.DELETE_PARTITION_DEFINITION_METADATA,
                         Joiner.on(",").skipNulls().join(paramVariables)), (Object[]) aPartitionNames);

--- a/metacat-metadata-mysql/src/main/java/com/netflix/metacat/metadata/mysql/MysqlUserMetadataService.java
+++ b/metacat-metadata-mysql/src/main/java/com/netflix/metacat/metadata/mysql/MysqlUserMetadataService.java
@@ -46,7 +46,13 @@ import org.springframework.transaction.annotation.Transactional;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.sql.Types;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -237,22 +243,20 @@ public class MysqlUserMetadataService extends BaseUserMetadataService {
     private void _deleteDefinitionMetadata(
         @Nullable final List<QualifiedName> names
     ) {
-        List<QualifiedName> validNames = new ArrayList<>();
+        final List<QualifiedName> validNames = new ArrayList<>();
         if (names != null && !names.isEmpty()) {
             for (QualifiedName name : names) {
-                // For each name in aNames, fetch existing data
-                final Optional<ObjectNode> existingData = getDefinitionMetadata(name);
-                if (existingData.isPresent()) {
-                    try {
-                        // apply interceptor to validate the object node
-                        this.metadataInterceptor.onDelete(this, name, existingData.get());
-                        // add valid names to validNames
-                        validNames.add(name);
-                    } catch (Exception e) {
-                        // if onDelete throws an exception, remove this name from aNames and log it
-                        final String message = String.format("metadata onDelete for name %s encountered an exception", name);
-                        log.error(message, e);
-                    }
+                try {
+                    // apply interceptor to validate the object node
+                    this.metadataInterceptor.onDelete(this, name);
+                    // add valid names to validNames
+                    validNames.add(name);
+                } catch (Exception e) {
+                    // if onDelete throws an exception, remove this name from aNames and log it
+                    final String message = String.format(
+                        "metadata onDelete for name %s encountered an exception", name
+                    );
+                    log.error(message, e);
                 }
             }
         }


### PR DESCRIPTION
This PR adds a method `onDelete` to the `MetadataInterceptor`. Implementations of `MetadataInterceptor` can add specific business logic and/or validation to `onDelete` before deleting metadata.

Implementations of `UserMetadataService` that register a `MetadataInterceptor` can choose to apply `onDelete` as needed to execute pre-delete business logic.

Here,`onDelete` is called for all QualifiedNames passed to `MysqlUserMetadataService._deleteDefinitionMetadata`.