### PR TITLE
upgrade snowflake-jdbc from 3.4.2 to 3.15.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -146,7 +146,7 @@ configure(javaProjects) {
             dependency("org.codehaus.gpars:gpars:1.2.1")
             /**es 5.4.1 dependencies*/
             dependency("org.elasticsearch.client:transport:5.4.1")
-            dependency("net.snowflake:snowflake-jdbc:3.4.2")
+            dependency("net.snowflake:snowflake-jdbc:3.15.0")
             dependency("com.esotericsoftware.kryo:kryo:2.22")
             dependency("org.apache.iceberg:iceberg-spark-runtime:${iceberg_version}")
             dependency("com.datastax.cassandra:cassandra-driver-core:3.7.2")


### PR DESCRIPTION
We previously have a PR to do the upgrade
https://github.com/Netflix/metacat/commit/2bf2a0be167a887c08d3066259070edf2099f0c8

But we decided to not roll it out at the same time as the setTag call for safety concern https://github.com/Netflix/metacat/commit/2b1dd01a02d6c322af17357359ed26ce937ce236

So this PR basically contains the changes for snowflake-jdbc upgrade.

