### PR TITLE
Yingjianw/list db with follower reader timestamp

### DIFF
--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/Config.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/Config.java
@@ -555,16 +555,30 @@ public interface Config {
     /**
      * Get the page size when listing table entities.
      *
-     * @return True if it is.
+     * @return size of the page
      */
     int getListTableEntitiesPageSize();
 
     /**
      * Get the page size when listing table names.
      *
-     * @return True if it is.
+     * @return size of the page
      */
     int getListTableNamesPageSize();
+
+    /**
+     * Get the page size when listing db entities.
+     *
+     * @return size of the page
+     */
+    int getListDatabaseEntitiesPageSize();
+
+    /**
+     * Get the page size when listing db names.
+     *
+     * @return size of the page
+     */
+    int getListDatabaseNamesPageSize();
 
     /**
      * Metadata query timeout in seconds.

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/DefaultConfigImpl.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/DefaultConfigImpl.java
@@ -650,6 +650,16 @@ public class DefaultConfigImpl implements Config {
     }
 
     @Override
+    public int getListDatabaseEntitiesPageSize() {
+        return this.metacatProperties.getService().getListDatabaseEntitiesPageSize();
+    }
+
+    @Override
+    public int getListDatabaseNamesPageSize() {
+        return this.metacatProperties.getService().getListDatabaseNamesPageSize();
+    }
+
+    @Override
     public int getMetadataQueryTimeout() {
         return this.metacatProperties.getUsermetadata().getQueryTimeoutInSeconds();
     }

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/ServiceProperties.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/ServiceProperties.java
@@ -39,6 +39,8 @@ public class ServiceProperties {
     private boolean listDatabaseNameByDefaultOnGetCatalog = true;
     private int listTableEntitiesPageSize = 1000;
     private int listTableNamesPageSize = 10000;
+    private int listDatabaseEntitiesPageSize = 1000;
+    private int listDatabaseNamesPageSize = 10000;
 
     /**
      * Max related properties.

--- a/metacat-connector-polaris/src/functionalTest/java/com/netflix/metacat/connector/polaris/PolarisConnectorDatabaseServiceFunctionalTest.java
+++ b/metacat-connector-polaris/src/functionalTest/java/com/netflix/metacat/connector/polaris/PolarisConnectorDatabaseServiceFunctionalTest.java
@@ -1,0 +1,165 @@
+
+package com.netflix.metacat.connector.polaris;
+
+import com.netflix.metacat.common.QualifiedName;
+import com.netflix.metacat.common.dto.Pageable;
+import com.netflix.metacat.common.dto.Sort;
+import com.netflix.metacat.common.dto.SortOrder;
+import com.netflix.metacat.common.server.connectors.model.DatabaseInfo;
+import com.netflix.metacat.connector.polaris.configs.PolarisPersistenceConfig;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.Arrays;
+import java.util.List;
+
+
+/**
+ * Test PolarisConnectorTableService.
+ */
+@Slf4j
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(classes = {PolarisPersistenceConfig.class})
+@ActiveProfiles(profiles = {"polaris_functional_test"})
+@AutoConfigureDataJpa
+public class PolarisConnectorDatabaseServiceFunctionalTest extends PolarisConnectorDatabaseServiceTest {
+    private void simulateDelay() {
+        try {
+            Thread.sleep(10000); // 10 seconds delay
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt(); // Restore the interrupted status
+            log.debug("Sleep was interrupted", e);
+        }
+    }
+
+    /**
+     * Test SimpleDBList.
+     */
+    @Test
+    public void testSimpleListDb() {
+        // Simulate a delay so that the dbs schema is visible
+        simulateDelay();
+        final DatabaseInfo db1 = DatabaseInfo.builder().name(DB1_QUALIFIED_NAME).uri("uri1").build();
+        final DatabaseInfo db2 = DatabaseInfo.builder().name(DB2_QUALIFIED_NAME).uri("uri2").build();
+        getPolarisDBService().create(getRequestContext(), db1);
+        getPolarisDBService().create(getRequestContext(), db2);
+        Assert.assertTrue(getPolarisDBService().exists(getRequestContext(), DB1_QUALIFIED_NAME));
+        Assert.assertTrue(getPolarisDBService().exists(getRequestContext(), DB2_QUALIFIED_NAME));
+
+        // Since now list dbs use follower_read_timestamp, we will not immediately get the newly created dbs
+        List<QualifiedName> dbNames =
+            getPolarisDBService().listNames(
+                getRequestContext(), QualifiedName.ofCatalog(CATALOG_NAME), null, null, null);
+        List<DatabaseInfo> dbs =
+            getPolarisDBService().list(
+                getRequestContext(), QualifiedName.ofCatalog(CATALOG_NAME), null, null, null);
+        Assert.assertTrue("Expected dbNames to be empty", dbNames.isEmpty());
+        Assert.assertTrue("Expected dbs to be empty", dbs.isEmpty());
+
+
+        // After sufficient time, the dbs should return using follower_read_timestamp
+        simulateDelay();
+        dbNames = getPolarisDBService().listNames(
+            getRequestContext(), QualifiedName.ofCatalog(CATALOG_NAME), null, null, null);
+        Assert.assertEquals(dbNames, Arrays.asList(DB1_QUALIFIED_NAME, DB2_QUALIFIED_NAME));
+        dbs = getPolarisDBService().list(
+            getRequestContext(), QualifiedName.ofCatalog(CATALOG_NAME), null, null, null);
+        Assert.assertEquals(dbs, Arrays.asList(db1, db2));
+
+        // Test Prefix
+        dbNames = getPolarisDBService().listNames(
+            getRequestContext(),
+            QualifiedName.ofCatalog(CATALOG_NAME), QualifiedName.ofDatabase(CATALOG_NAME, "db"),
+            null,
+            null);
+        Assert.assertEquals(dbNames, Arrays.asList(DB1_QUALIFIED_NAME, DB2_QUALIFIED_NAME));
+        dbs = getPolarisDBService().list(
+            getRequestContext(),
+            QualifiedName.ofCatalog(CATALOG_NAME),
+            QualifiedName.ofDatabase(CATALOG_NAME, "db"),
+            null,
+            null);
+        Assert.assertEquals(dbs, Arrays.asList(db1, db2));
+
+        dbNames = getPolarisDBService().listNames(
+            getRequestContext(),
+            QualifiedName.ofCatalog(CATALOG_NAME),
+            QualifiedName.ofDatabase(CATALOG_NAME, "db1_"),
+            null,
+            null);
+        Assert.assertEquals(dbNames, Arrays.asList(DB1_QUALIFIED_NAME));
+        dbs = getPolarisDBService().list(
+            getRequestContext(),
+            QualifiedName.ofCatalog(CATALOG_NAME),
+            QualifiedName.ofDatabase(CATALOG_NAME, "db1_"),
+            null,
+            null);
+        Assert.assertEquals(dbs, Arrays.asList(db1));
+
+        // Test Order desc
+        dbNames = getPolarisDBService().listNames(
+            getRequestContext(),
+            QualifiedName.ofCatalog(CATALOG_NAME),
+            null,
+            new Sort("name", SortOrder.DESC),
+            null);
+        Assert.assertEquals(dbNames, Arrays.asList(DB2_QUALIFIED_NAME, DB1_QUALIFIED_NAME));
+        dbs = getPolarisDBService().list(
+            getRequestContext(),
+            QualifiedName.ofCatalog(CATALOG_NAME),
+            null,
+            new Sort("name", SortOrder.DESC),
+            null);
+        Assert.assertEquals(dbs, Arrays.asList(db2, db1));
+
+        // Test pageable
+        dbNames = getPolarisDBService().listNames(
+            getRequestContext(),
+            QualifiedName.ofCatalog(CATALOG_NAME),
+            null,
+            null,
+            new Pageable(5, 0));
+        Assert.assertEquals(dbNames, Arrays.asList(DB1_QUALIFIED_NAME, DB2_QUALIFIED_NAME));
+        dbs = getPolarisDBService().list(
+            getRequestContext(),
+            QualifiedName.ofCatalog(CATALOG_NAME),
+            null,
+            null,
+            new Pageable(5, 0));
+        Assert.assertEquals(dbs, Arrays.asList(db1, db2));
+
+        dbNames = getPolarisDBService().listNames(
+            getRequestContext(),
+            QualifiedName.ofCatalog(CATALOG_NAME), null, null, new Pageable(1, 0));
+        Assert.assertEquals(dbNames, Arrays.asList(DB1_QUALIFIED_NAME));
+        dbs = getPolarisDBService().list(
+            getRequestContext(),
+            QualifiedName.ofCatalog(CATALOG_NAME), null, null, new Pageable(1, 0));
+        Assert.assertEquals(dbs, Arrays.asList(db1));
+
+        dbNames = getPolarisDBService().listNames(
+            getRequestContext(),
+            QualifiedName.ofCatalog(CATALOG_NAME), null, null, new Pageable(1, 1));
+        Assert.assertEquals(dbNames, Arrays.asList(DB2_QUALIFIED_NAME));
+        dbs = getPolarisDBService().list(
+            getRequestContext(),
+            QualifiedName.ofCatalog(CATALOG_NAME), null, null, new Pageable(1, 1));
+        Assert.assertEquals(dbs, Arrays.asList(db2));
+
+        dbNames = getPolarisDBService().listNames(
+            getRequestContext(),
+            QualifiedName.ofCatalog(CATALOG_NAME), null, null, new Pageable(5, 1));
+        Assert.assertEquals(dbNames, Arrays.asList(DB2_QUALIFIED_NAME));
+        dbs = getPolarisDBService().list(
+            getRequestContext(),
+            QualifiedName.ofCatalog(CATALOG_NAME), null, null, new Pageable(5, 1));
+        Assert.assertEquals(dbs, Arrays.asList(db2));
+    }
+}
+

--- a/metacat-connector-polaris/src/functionalTest/java/com/netflix/metacat/connector/polaris/PolarisConnectorDatabaseServiceFunctionalTest.java
+++ b/metacat-connector-polaris/src/functionalTest/java/com/netflix/metacat/connector/polaris/PolarisConnectorDatabaseServiceFunctionalTest.java
@@ -29,22 +29,13 @@ import java.util.List;
 @ActiveProfiles(profiles = {"polaris_functional_test"})
 @AutoConfigureDataJpa
 public class PolarisConnectorDatabaseServiceFunctionalTest extends PolarisConnectorDatabaseServiceTest {
-    private void simulateDelay() {
-        try {
-            Thread.sleep(10000); // 10 seconds delay
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt(); // Restore the interrupted status
-            log.debug("Sleep was interrupted", e);
-        }
-    }
-
     /**
      * Test SimpleDBList.
      */
     @Test
     public void testSimpleListDb() {
         // Simulate a delay so that the dbs schema is visible
-        simulateDelay();
+        TestUtil.simulateDelay();
         final DatabaseInfo db1 = DatabaseInfo.builder().name(DB1_QUALIFIED_NAME).uri("uri1").build();
         final DatabaseInfo db2 = DatabaseInfo.builder().name(DB2_QUALIFIED_NAME).uri("uri2").build();
         getPolarisDBService().create(getRequestContext(), db1);
@@ -64,7 +55,7 @@ public class PolarisConnectorDatabaseServiceFunctionalTest extends PolarisConnec
 
 
         // After sufficient time, the dbs should return using follower_read_timestamp
-        simulateDelay();
+        TestUtil.simulateDelay();
         dbNames = getPolarisDBService().listNames(
             getRequestContext(), QualifiedName.ofCatalog(CATALOG_NAME), null, null, null);
         Assert.assertEquals(dbNames, Arrays.asList(DB1_QUALIFIED_NAME, DB2_QUALIFIED_NAME));

--- a/metacat-connector-polaris/src/functionalTest/java/com/netflix/metacat/connector/polaris/PolarisConnectorTableServiceFunctionalTest.java
+++ b/metacat-connector-polaris/src/functionalTest/java/com/netflix/metacat/connector/polaris/PolarisConnectorTableServiceFunctionalTest.java
@@ -57,12 +57,7 @@ public class PolarisConnectorTableServiceFunctionalTest extends PolarisConnector
             .build();
         getPolarisTableService().create(getRequestContext(), tableInfo3);
 
-        try {
-            // pause execution for 10000 milliseconds (10 seconds)
-            Thread.sleep(10000);
-        } catch (InterruptedException e) {
-            log.debug("Sleep was interrupted");
-        }
+        TestUtil.simulateDelay();
 
         final List<QualifiedName> tables = getPolarisTableService()
             .getTableNames(getRequestContext(), DB_QUALIFIED_NAME, "", -1);
@@ -77,12 +72,7 @@ public class PolarisConnectorTableServiceFunctionalTest extends PolarisConnector
     public void testListTablesEmpty() {
         final QualifiedName qualifiedName = QualifiedName.ofTable(CATALOG_NAME, DB_NAME, "");
 
-        try {
-            // pause execution for 10000 milliseconds (10 seconds)
-            Thread.sleep(10000);
-        } catch (InterruptedException e) {
-            log.debug("Sleep was interrupted");
-        }
+        TestUtil.simulateDelay();
 
         final List<QualifiedName> names = getPolarisTableService().listNames(
             getRequestContext(), DB_QUALIFIED_NAME, qualifiedName,
@@ -102,12 +92,7 @@ public class PolarisConnectorTableServiceFunctionalTest extends PolarisConnector
             .build();
         getPolarisTableService().create(getRequestContext(), tableInfo);
 
-        try {
-            // pause execution for 10000 milliseconds (10 seconds)
-            Thread.sleep(10000);
-        } catch (InterruptedException e) {
-            log.debug("Sleep was interrupted");
-        }
+        TestUtil.simulateDelay();
 
         final List<QualifiedName> names = getPolarisTableService().listNames(
             getRequestContext(), DB_QUALIFIED_NAME, qualifiedName,
@@ -136,12 +121,7 @@ public class PolarisConnectorTableServiceFunctionalTest extends PolarisConnector
 
         final QualifiedName qualifiedName = QualifiedName.ofTable(CATALOG_NAME, DB_NAME, "");
 
-        try {
-            // pause execution for 10000 milliseconds (10 seconds)
-            Thread.sleep(10000);
-        } catch (InterruptedException e) {
-            log.debug("Sleep was interrupted");
-        }
+        TestUtil.simulateDelay();
 
         List<TableInfo> tables = this.getPolarisTableService().list(
             this.getRequestContext(), DB_QUALIFIED_NAME, qualifiedName, new Sort(null, SortOrder.ASC),

--- a/metacat-connector-polaris/src/functionalTest/java/com/netflix/metacat/connector/polaris/PolarisStoreConnectorFunctionalTest.java
+++ b/metacat-connector-polaris/src/functionalTest/java/com/netflix/metacat/connector/polaris/PolarisStoreConnectorFunctionalTest.java
@@ -28,15 +28,6 @@ import java.util.stream.Collectors;
 @AutoConfigureDataJpa
 public class PolarisStoreConnectorFunctionalTest extends PolarisStoreConnectorTest {
 
-    private void simulateDelay() {
-        try {
-            Thread.sleep(10000); // 10 seconds delay
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt(); // Restore the interrupted status
-            log.debug("Sleep was interrupted", e);
-        }
-    }
-
     /**
      * Test to verify that table names fetch works.
      */
@@ -54,7 +45,7 @@ public class PolarisStoreConnectorFunctionalTest extends PolarisStoreConnectorTe
         createTable(dbName, tblNameB);
         createTable(dbName, tblNameC);
 
-        simulateDelay();
+        TestUtil.simulateDelay();
 
         tblNames = getPolarisConnector().getTables(dbName, "", 1000);
         Assert.assertEquals(3, tblNames.size());
@@ -72,7 +63,7 @@ public class PolarisStoreConnectorFunctionalTest extends PolarisStoreConnectorTe
         final String dbName = generateDatabaseName();
         createDB(dbName);
 
-        simulateDelay();
+        TestUtil.simulateDelay();
 
         // Test when db is empty
         List<PolarisTableEntity> entities = getPolarisConnector().getTableEntities(dbName, "", 1);
@@ -87,12 +78,7 @@ public class PolarisStoreConnectorFunctionalTest extends PolarisStoreConnectorTe
         createTable(dbName, tblNameB);
         createTable(dbName, tblNameC);
 
-        try {
-            // pause execution for 10000 milliseconds (10 seconds)
-            Thread.sleep(10000);
-        } catch (InterruptedException e) {
-            log.debug("Sleep was interrupted");
-        }
+        TestUtil.simulateDelay();
 
         // Test pagination and sort
         entities = getPolarisConnector().getTableEntities(dbName, "", 1);
@@ -129,7 +115,7 @@ public class PolarisStoreConnectorFunctionalTest extends PolarisStoreConnectorTe
         createDB("db2");
         createDB("db3");
 
-        simulateDelay();
+        TestUtil.simulateDelay();
 
         List<String> dbNames = getPolarisConnector().getDatabaseNames("db", null, 1);
         List<PolarisDatabaseEntity> dbs = getPolarisConnector().getDatabases("db", null, 1);

--- a/metacat-connector-polaris/src/functionalTest/java/com/netflix/metacat/connector/polaris/TestUtil.java
+++ b/metacat-connector-polaris/src/functionalTest/java/com/netflix/metacat/connector/polaris/TestUtil.java
@@ -1,0 +1,29 @@
+package com.netflix.metacat.connector.polaris;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Utility class containing methods to aid in testing by simulating various conditions.
+ */
+@Slf4j
+public final class TestUtil {
+
+    /**
+     * Private constructor to prevent instantiation of this utility class.
+     */
+    private TestUtil() {
+        throw new UnsupportedOperationException("This is a utility class and cannot be instantiated");
+    }
+
+    /**
+     * Simulates a delay for a fixed period of time.
+     */
+    public static void simulateDelay() {
+        try {
+            Thread.sleep(5000); // 5 seconds delay
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt(); // Restore the interrupted status
+            log.debug("Sleep was interrupted", e);
+        }
+    }
+}

--- a/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/PolarisConnectorTableService.java
+++ b/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/PolarisConnectorTableService.java
@@ -388,7 +388,9 @@ public class PolarisConnectorTableService implements ConnectorTableService {
                 log.warn(String.format("Calling Polaris getTableNames with nonempty filter %s", filter));
             }
             final List<String> databaseNames = name.isDatabaseDefinition() ? ImmutableList.of(name.getDatabaseName())
-                : polarisStoreService.getDatabaseNames(null, null, 1000);
+                : polarisStoreService.getDatabaseNames(null, null,
+                connectorContext.getConfig().getListDatabaseNamesPageSize()
+            );
             int limitSize = limit == null || limit < 0 ? Integer.MAX_VALUE : limit;
             final List<QualifiedName> result = Lists.newArrayList();
             for (int i = 0; i < databaseNames.size() && limitSize > 0; i++) {

--- a/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/PolarisConnectorTableService.java
+++ b/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/PolarisConnectorTableService.java
@@ -388,7 +388,7 @@ public class PolarisConnectorTableService implements ConnectorTableService {
                 log.warn(String.format("Calling Polaris getTableNames with nonempty filter %s", filter));
             }
             final List<String> databaseNames = name.isDatabaseDefinition() ? ImmutableList.of(name.getDatabaseName())
-                : polarisStoreService.getAllDatabases().stream().map(d -> d.getDbName()).collect(Collectors.toList());
+                : polarisStoreService.getDatabaseNames(null, null, 1000);
             int limitSize = limit == null || limit < 0 ? Integer.MAX_VALUE : limit;
             final List<QualifiedName> result = Lists.newArrayList();
             for (int i = 0; i < databaseNames.size() && limitSize > 0; i++) {

--- a/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/store/PolarisStoreConnector.java
+++ b/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/store/PolarisStoreConnector.java
@@ -1,19 +1,17 @@
 package com.netflix.metacat.connector.polaris.store;
 
+import com.netflix.metacat.common.dto.Sort;
 import com.netflix.metacat.connector.polaris.store.entities.AuditEntity;
 import com.netflix.metacat.connector.polaris.store.entities.PolarisDatabaseEntity;
 import com.netflix.metacat.connector.polaris.store.entities.PolarisTableEntity;
 import com.netflix.metacat.connector.polaris.store.repos.PolarisDatabaseRepository;
 import com.netflix.metacat.connector.polaris.store.repos.PolarisTableRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
+import javax.annotation.Nullable;
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -60,27 +58,22 @@ public class PolarisStoreConnector implements PolarisStoreService {
         dbRepo.deleteByName(dbName);
     }
 
-    /**
-     * Fetches all database entities.
-     *
-     * @return Polaris Database entities
-     */
     @Override
     @Transactional(propagation = Propagation.SUPPORTS)
-    public List<PolarisDatabaseEntity> getAllDatabases() {
-        final int pageFetchSize = 1000;
-        final List<PolarisDatabaseEntity> retval = new ArrayList<>();
-        Pageable page = PageRequest.of(0, pageFetchSize);
-        boolean hasNext;
-        do {
-            final Slice<PolarisDatabaseEntity> dbs = dbRepo.getDatabases(page);
-            retval.addAll(dbs.toList());
-            hasNext = dbs.hasNext();
-            if (hasNext) {
-                page = dbs.nextPageable();
-            }
-        } while (hasNext);
-        return retval;
+    public List<PolarisDatabaseEntity> getDatabases(
+        @Nullable final String dbNamePrefix,
+        @Nullable final Sort sort,
+        final int pageSize) {
+        return (List<PolarisDatabaseEntity>) dbRepo.getAllDatabases(dbNamePrefix, sort, pageSize, true);
+    }
+
+    @Override
+    @Transactional(propagation = Propagation.SUPPORTS)
+    public List<String> getDatabaseNames(
+        @Nullable final String dbNamePrefix,
+        @Nullable final Sort sort,
+        final int pageSize) {
+        return (List<String>) dbRepo.getAllDatabases(dbNamePrefix, sort, pageSize, false);
     }
 
     /**

--- a/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/store/PolarisStoreService.java
+++ b/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/store/PolarisStoreService.java
@@ -1,5 +1,6 @@
 package com.netflix.metacat.connector.polaris.store;
 
+import com.netflix.metacat.common.dto.Sort;
 import com.netflix.metacat.connector.polaris.store.entities.PolarisDatabaseEntity;
 import com.netflix.metacat.connector.polaris.store.entities.PolarisTableEntity;
 
@@ -35,9 +36,21 @@ public interface PolarisStoreService {
 
     /**
      * Fetches all database entities.
+     * @param dbNamePrefix dbNamePrefix to return
+     * @param pageSize db page size
+     * @param sort the order of the result
      * @return Polaris Database entities
      */
-    List<PolarisDatabaseEntity> getAllDatabases();
+    List<PolarisDatabaseEntity> getDatabases(String dbNamePrefix, Sort sort, int pageSize);
+
+    /**
+     * Fetches all database entities.
+     * @param dbNamePrefix dbNamePrefix to return
+     * @param sort the order of the result
+     * @param pageSize db page size
+     * @return Polaris Database entities
+     */
+    List<String> getDatabaseNames(String dbNamePrefix, Sort sort, int pageSize);
 
     /**
      * Checks if database with the name exists.

--- a/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/store/repos/PolarisDatabaseCustomRepository.java
+++ b/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/store/repos/PolarisDatabaseCustomRepository.java
@@ -1,0 +1,20 @@
+package com.netflix.metacat.connector.polaris.store.repos;
+
+import com.netflix.metacat.common.dto.Sort;
+
+import java.util.List;
+
+/**
+ * Custom JPA repository implementation for storing PolarisDatabaseEntity.
+ */
+public interface PolarisDatabaseCustomRepository {
+    /**
+     * Fetch db entities for given database using AS OF SYSTEM TIME follower_read_timestamp().
+     * @param dbNamePrefix db name prefix. can be empty.
+     * @param sort sort
+     * @param pageSize db pageSize
+     * @param selectAllColumns if true return the PolarisEntity else return name of the entity
+     * @return table entities in the database.
+     */
+    List<?> getAllDatabases(String dbNamePrefix, Sort sort, int pageSize, boolean selectAllColumns);
+}

--- a/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/store/repos/PolarisDatabaseCustomRepositoryImpl.java
+++ b/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/store/repos/PolarisDatabaseCustomRepositoryImpl.java
@@ -1,0 +1,100 @@
+package com.netflix.metacat.connector.polaris.store.repos;
+
+import com.netflix.metacat.common.dto.SortOrder;
+import com.netflix.metacat.connector.polaris.store.entities.PolarisDatabaseEntity;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.annotation.Nullable;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import javax.persistence.Query;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Implementation for Custom JPA repository implementation for interacting with PolarisDatabaseEntity.
+ */
+public class PolarisDatabaseCustomRepositoryImpl implements PolarisDatabaseCustomRepository {
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    private <T> Slice<T> getAllDatabasesForCurrentPage(
+        final String dbNamePrefix, final Pageable page, final boolean selectAllColumns) {
+
+        // Generate ORDER BY clause
+        String orderBy = "";
+        if (page.getSort().isSorted()) {
+            orderBy = page.getSort().stream()
+                .map(order -> order.getProperty() + " " + order.getDirection())
+                .collect(Collectors.joining(", "));
+            orderBy = " ORDER BY " + orderBy;
+        }
+
+        final String selectClause = selectAllColumns ? "d.*" : "d.name";
+        final String sql = "SELECT " + selectClause + " FROM DBS d "
+            + "WHERE d.name LIKE :dbNamePrefix" + orderBy;
+
+        Query query;
+        if (selectAllColumns) {
+            query = entityManager.createNativeQuery(sql, PolarisDatabaseEntity.class);
+        } else {
+            query = entityManager.createNativeQuery(sql);
+        }
+        query.setParameter("dbNamePrefix", dbNamePrefix + "%");
+        query.setFirstResult(page.getPageNumber() * page.getPageSize());
+        query.setMaxResults(page.getPageSize() + 1); // Fetch one extra result to determine if there is a next page
+        final List<T> resultList = query.getResultList();
+
+        // Check if there is a next page
+        final boolean hasNext = resultList.size() > page.getPageSize();
+
+        // If there is a next page, remove the last item from the list
+        if (hasNext) {
+            resultList.remove(resultList.size() - 1);
+        }
+        return new SliceImpl<>(resultList, page, hasNext);
+    }
+
+    @Override
+    @Transactional
+    public List<?> getAllDatabases(
+        @Nullable final String dbNamePrefix,
+        @Nullable final com.netflix.metacat.common.dto.Sort sort,
+        final int pageSize,
+        final boolean selectAllColumns) {
+        final List<Object> retval = new ArrayList<>();
+
+        final String dbPrefix =  dbNamePrefix == null ? "" : dbNamePrefix;
+
+        // by default sort name in ascending order
+        Sort dbSort = Sort.by("name").ascending();
+        if (sort != null && sort.hasSort()) {
+            if (sort.getOrder() == SortOrder.DESC) {
+                dbSort = Sort.by(sort.getSortBy()).descending();
+            } else {
+                dbSort = Sort.by(sort.getSortBy()).ascending();
+            }
+        }
+
+        Pageable page = PageRequest.of(0, pageSize, dbSort);
+        entityManager.createNativeQuery("SET TRANSACTION AS OF SYSTEM TIME follower_read_timestamp()")
+            .executeUpdate();
+        Slice<?> dbs;
+        boolean hasNext;
+        do {
+            dbs = getAllDatabasesForCurrentPage(dbPrefix, page, selectAllColumns);
+            retval.addAll(dbs.getContent());
+            hasNext = dbs.hasNext();
+            if (hasNext) {
+                page = dbs.nextPageable();
+            }
+        } while (hasNext);
+        return retval;
+    }
+}

--- a/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/store/repos/PolarisDatabaseRepository.java
+++ b/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/store/repos/PolarisDatabaseRepository.java
@@ -17,7 +17,7 @@ import java.util.Optional;
  */
 @Repository
 public interface PolarisDatabaseRepository extends JpaRepository<PolarisDatabaseEntity, String>,
-    JpaSpecificationExecutor {
+    JpaSpecificationExecutor, PolarisDatabaseCustomRepository {
 
     /**
      * Fetch database entry.

--- a/metacat-connector-polaris/src/test/java/com/netflix/metacat/connector/polaris/PolarisConnectorDatabaseServiceTest.java
+++ b/metacat-connector-polaris/src/test/java/com/netflix/metacat/connector/polaris/PolarisConnectorDatabaseServiceTest.java
@@ -2,7 +2,6 @@
 package com.netflix.metacat.connector.polaris;
 
 import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 import com.netflix.metacat.common.QualifiedName;
 import com.netflix.metacat.common.server.connectors.ConnectorContext;
 import com.netflix.metacat.common.server.connectors.ConnectorRequestContext;
@@ -15,6 +14,7 @@ import com.netflix.metacat.common.server.properties.MetacatProperties;
 import com.netflix.metacat.connector.polaris.configs.PolarisPersistenceConfig;
 import com.netflix.metacat.connector.polaris.store.PolarisStoreService;
 import com.netflix.spectator.api.NoopRegistry;
+import lombok.Getter;
 import org.junit.Assert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -29,7 +29,6 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import spock.lang.Shared;
 
 import java.util.Date;
-import java.util.List;
 
 
 /**
@@ -40,12 +39,13 @@ import java.util.List;
 @ActiveProfiles(profiles = {"polarisconnectortest"})
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 @AutoConfigureDataJpa
+@Getter
 public class PolarisConnectorDatabaseServiceTest {
-    private static final String CATALOG_NAME = "catalog_name";
-    private static final String DB1_NAME = "db1_name";
-    private static final String DB2_NAME = "db2_name";
-    private static final QualifiedName DB1_QUALIFIED_NAME = QualifiedName.ofDatabase(CATALOG_NAME, DB1_NAME);
-    private static final QualifiedName DB2_QUALIFIED_NAME = QualifiedName.ofDatabase(CATALOG_NAME, DB2_NAME);
+    public static final String CATALOG_NAME = "catalog_name";
+    public static final String DB1_NAME = "db1_name";
+    public static final String DB2_NAME = "db2_name";
+    public static final QualifiedName DB1_QUALIFIED_NAME = QualifiedName.ofDatabase(CATALOG_NAME, DB1_NAME);
+    public static final QualifiedName DB2_QUALIFIED_NAME = QualifiedName.ofDatabase(CATALOG_NAME, DB2_NAME);
 
     @Autowired
     private PolarisStoreService polarisStoreService;
@@ -165,25 +165,6 @@ public class PolarisConnectorDatabaseServiceTest {
         Assert.assertTrue(polarisDBService.exists(requestContext, DB1_QUALIFIED_NAME));
         polarisDBService.delete(requestContext, DB1_QUALIFIED_NAME);
         Assert.assertFalse(polarisDBService.exists(requestContext, DB1_QUALIFIED_NAME));
-    }
-
-    /**
-     * Test list databases.
-     */
-    @Test
-    public void testListDb() {
-        final DatabaseInfo db1 = DatabaseInfo.builder().name(DB1_QUALIFIED_NAME).uri("uri1").build();
-        final DatabaseInfo db2 = DatabaseInfo.builder().name(DB2_QUALIFIED_NAME).uri("uri2").build();
-        polarisDBService.create(requestContext, db1);
-        polarisDBService.create(requestContext, db2);
-        Assert.assertTrue(polarisDBService.exists(requestContext, DB1_QUALIFIED_NAME));
-        Assert.assertTrue(polarisDBService.exists(requestContext, DB2_QUALIFIED_NAME));
-        final List<QualifiedName> dbNames =
-            polarisDBService.listNames(requestContext, QualifiedName.ofCatalog(CATALOG_NAME), null, null, null);
-        Assert.assertEquals(Sets.newHashSet(dbNames), Sets.newHashSet(DB1_QUALIFIED_NAME, DB2_QUALIFIED_NAME));
-        final List<DatabaseInfo> dbs =
-            polarisDBService.list(requestContext, QualifiedName.ofCatalog(CATALOG_NAME), null, null, null);
-        Assert.assertEquals(Sets.newHashSet(dbs), Sets.newHashSet(db1, db2));
     }
 }
 

--- a/metacat-functional-tests/src/functionalTest/groovy/com/netflix/metacat/MetacatFunctionalSpec.groovy
+++ b/metacat-functional-tests/src/functionalTest/groovy/com/netflix/metacat/MetacatFunctionalSpec.groovy
@@ -226,6 +226,7 @@ class MetacatFunctionalSpec extends Specification {
 
         when:
         api.createDatabase(catalog.name, databaseName, dto)
+        Thread.sleep(5000)
         catalogResponse = api.getCatalog(catalog.name)
 
         then:
@@ -269,6 +270,7 @@ class MetacatFunctionalSpec extends Specification {
 
         when:
         api.createDatabase(catalog.name, databaseName, dto)
+        Thread.sleep(5000)
         catalogResponse = api.getCatalog(catalog.name)
 
         then:


### PR DESCRIPTION
As we see more dbs added to our metadata service, the load on crdb increases when there are many listDB calls, and we see only subset of certain nodes in our cluster experiencing high cpu usage.

Thus, in order to better spread the traffic, for list dbs operation, we are going to use the read_follower_timestamp.

Unfortunately, we need to rollback previous 2 commits as we don't want them to be included into the same rollout