### PR TITLE
Publish new name on table rename event

### DIFF
--- a/metacat-common/src/main/java/com/netflix/metacat/common/dto/notifications/sns/messages/RenameTableMessage.java
+++ b/metacat-common/src/main/java/com/netflix/metacat/common/dto/notifications/sns/messages/RenameTableMessage.java
@@ -26,6 +26,8 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 
+import javax.annotation.Nullable;
+
 /**
  * A message sent when a table is renamed.
  *
@@ -35,6 +37,7 @@ import lombok.ToString;
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
 public class RenameTableMessage extends UpdateOrRenameTableMessageBase {
+    private final String newName;
 
     /**
      * Create a new RenameTableMessage.
@@ -42,7 +45,8 @@ public class RenameTableMessage extends UpdateOrRenameTableMessageBase {
      * @param id        The unique id of the message
      * @param timestamp The number of milliseconds since epoch that this message occurred
      * @param requestId The id of the API request that generated this and possibly other messages. Used for grouping
-     * @param name      The qualified name of the resource that this notification is being generated for
+     * @param name      The previous qualified name of the resource that this notification is being generated for
+     * @param newName   The new qualified name of the resource that this notification is being generated for
      * @param payload   The payload of the notification
      */
     @JsonCreator
@@ -51,8 +55,10 @@ public class RenameTableMessage extends UpdateOrRenameTableMessageBase {
         @JsonProperty("timestamp") final long timestamp,
         @JsonProperty("requestId") final String requestId,
         @JsonProperty("name") final String name,
-        @JsonProperty("payload") final UpdatePayload<TableDto> payload
+        @JsonProperty("newName") final String newName,
+        @Nullable @JsonProperty("payload") final UpdatePayload<TableDto> payload
     ) {
         super(id, timestamp, requestId, name, payload, SNSMessageType.TABLE_RENAME);
+        this.newName = newName;
     }
 }

--- a/metacat-common/src/main/java/com/netflix/metacat/common/dto/notifications/sns/messages/UpdateOrRenameTableMessageBase.java
+++ b/metacat-common/src/main/java/com/netflix/metacat/common/dto/notifications/sns/messages/UpdateOrRenameTableMessageBase.java
@@ -27,6 +27,8 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 
+import javax.annotation.Nullable;
+
 /**
  * Base message type for Update and Rename messages.
  *
@@ -53,7 +55,7 @@ public abstract class UpdateOrRenameTableMessageBase extends SNSMessage<UpdatePa
         @JsonProperty("timestamp") final long timestamp,
         @JsonProperty("requestId") final String requestId,
         @JsonProperty("name") final String name,
-        @JsonProperty("payload") final UpdatePayload<TableDto> payload,
+        @Nullable @JsonProperty("payload") final UpdatePayload<TableDto> payload,
         final SNSMessageType messageType
     ) {
         super(id, timestamp, requestId, messageType, name, payload);

--- a/metacat-common/src/test/groovy/com/netflix/metacat/common/dto/notifications/sns/SNSMessageFactorySpec.groovy
+++ b/metacat-common/src/test/groovy/com/netflix/metacat/common/dto/notifications/sns/SNSMessageFactorySpec.groovy
@@ -92,6 +92,7 @@ class SNSMessageFactorySpec extends Specification {
                 Instant.now().toEpochMilli(),
                 UUID.randomUUID().toString(),
                 UUID.randomUUID().toString(),
+                UUID.randomUUID().toString(),
                 new UpdatePayload<TableDto>(
                     new TableDto(),
                     JsonDiff.asJsonPatch(


### PR DESCRIPTION
Publish new name on table rename event, and add publish of new name in case of SNS message send failure as well. This allows clients to properly be notified of new name after rename event even in case of initial send failure.