### PR TITLE
attempt to fix CVE-2017-5645

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -161,6 +161,7 @@ configure(javaProjects) {
         all*.exclude module: "slf4j-log4j12"
         all*.exclude module: "log4j-to-slf4j"
         all*.exclude group: "asm"
+        all*.exclude group: 'org.mortbay.jetty'
     }
 
     dependencies {


### PR DESCRIPTION
The pig dependency brings in jetty dependency which brings in ant:1.6.5 that contains CVE-2017-5645
So the fix is to exclude the jetty library that brings the bad ant version