### PR TITLE
add ParentChildRelationSqlService

### DIFF
--- a/metacat-client/src/main/java/com/netflix/metacat/client/Client.java
+++ b/metacat-client/src/main/java/com/netflix/metacat/client/Client.java
@@ -21,15 +21,16 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule;
 import com.google.common.base.Preconditions;
+import com.netflix.metacat.client.api.MetacatV1;
+import com.netflix.metacat.client.api.MetadataV1;
+import com.netflix.metacat.client.api.ParentChildRelV1;
+import com.netflix.metacat.client.api.PartitionV1;
+import com.netflix.metacat.client.api.ResolverV1;
 import com.netflix.metacat.client.api.TagV1;
 import com.netflix.metacat.client.module.JacksonDecoder;
 import com.netflix.metacat.client.module.JacksonEncoder;
 import com.netflix.metacat.client.module.MetacatErrorDecoder;
 import com.netflix.metacat.common.MetacatRequestContext;
-import com.netflix.metacat.client.api.MetacatV1;
-import com.netflix.metacat.client.api.MetadataV1;
-import com.netflix.metacat.client.api.PartitionV1;
-import com.netflix.metacat.client.api.ResolverV1;
 import com.netflix.metacat.common.json.MetacatJsonLocator;
 import feign.Feign;
 import feign.Request;
@@ -57,6 +58,8 @@ public final class Client {
     private final MetadataV1 metadataApi;
     private final ResolverV1 resolverApi;
     private final TagV1 tagApi;
+
+    private final ParentChildRelV1 parentChildRelApi;
 
     private Client(
         final String host,
@@ -93,6 +96,7 @@ public final class Client {
         metadataApi = getApiClient(MetadataV1.class);
         resolverApi = getApiClient(ResolverV1.class);
         tagApi = getApiClient(TagV1.class);
+        parentChildRelApi = getApiClient(ParentChildRelV1.class);
     }
 
     /**
@@ -161,6 +165,15 @@ public final class Client {
      */
     public TagV1 getTagApi() {
         return tagApi;
+    }
+
+    /**
+     * Return an API instance that can be used to interact with
+     * the metacat server for parent child relationship metadata.
+     * @return An instance api conforming to ParentChildRelV1 interface
+     */
+    public ParentChildRelV1 getParentChildRelApi() {
+        return parentChildRelApi;
     }
 
     /**

--- a/metacat-client/src/main/java/com/netflix/metacat/client/api/ParentChildRelV1.java
+++ b/metacat-client/src/main/java/com/netflix/metacat/client/api/ParentChildRelV1.java
@@ -1,0 +1,43 @@
+package com.netflix.metacat.client.api;
+
+import javax.ws.rs.Path;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.Produces;
+import javax.ws.rs.GET;
+import javax.ws.rs.PathParam;
+
+import javax.ws.rs.core.MediaType;
+import com.netflix.metacat.common.dto.notifications.ChildInfoDto;
+
+import java.util.Set;
+
+/**
+ * Metacat API for managing parent child relation.
+ *
+ * @author Yingjianw
+ */
+
+@Path("/mds/v1/parentChildRel")
+@Consumes(MediaType.APPLICATION_JSON)
+@Produces(MediaType.APPLICATION_JSON)
+public interface ParentChildRelV1 {
+    /**
+     * Return the list of children.
+     * @param catalogName catalogName
+     * @param databaseName databaseName
+     * @param tableName tableName
+     * @return list of childInfos
+     */
+    @GET
+    @Path("children/catalog/{catalog-name}/database/{database-name}/table/{table-name}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    Set<ChildInfoDto> getChildren(
+        @PathParam("catalog-name")
+        String catalogName,
+        @PathParam("database-name")
+        String databaseName,
+        @PathParam("table-name")
+        String tableName
+    );
+}

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/converter/ConverterUtil.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/converter/ConverterUtil.java
@@ -33,6 +33,7 @@ import com.netflix.metacat.common.dto.PartitionsSaveResponseDto;
 import com.netflix.metacat.common.dto.Sort;
 import com.netflix.metacat.common.dto.StorageDto;
 import com.netflix.metacat.common.dto.TableDto;
+import com.netflix.metacat.common.dto.notifications.ChildInfoDto;
 import com.netflix.metacat.common.server.connectors.ConnectorRequestContext;
 import com.netflix.metacat.common.server.connectors.model.AuditInfo;
 import com.netflix.metacat.common.server.connectors.model.CatalogInfo;
@@ -46,6 +47,7 @@ import com.netflix.metacat.common.server.connectors.model.PartitionsSaveRequest;
 import com.netflix.metacat.common.server.connectors.model.PartitionsSaveResponse;
 import com.netflix.metacat.common.server.connectors.model.StorageInfo;
 import com.netflix.metacat.common.server.connectors.model.TableInfo;
+import com.netflix.metacat.common.server.model.ChildInfo;
 import lombok.NonNull;
 import org.dozer.CustomConverter;
 import org.dozer.DozerBeanMapper;
@@ -276,5 +278,13 @@ public class ConverterUtil {
         return mapper.map(partitionsSaveResponse, PartitionsSaveResponseDto.class);
     }
 
-
+    /**
+     * Convert ChildInfo to ChildInfoDto.
+     *
+     * @param childInfo childInfo
+     * @return childInfo dto
+     */
+    public ChildInfoDto toChildInfoDto(final ChildInfo childInfo) {
+        return mapper.map(childInfo, ChildInfoDto.class);
+    }
 }

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/model/BaseRelEntityInfo.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/model/BaseRelEntityInfo.java
@@ -1,6 +1,8 @@
 package com.netflix.metacat.common.server.model;
 
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.io.Serializable;
 
@@ -8,28 +10,12 @@ import java.io.Serializable;
  * Base class to represent relation entity.
  */
 @Data
+@AllArgsConstructor
+@NoArgsConstructor
 public abstract class BaseRelEntityInfo implements Serializable {
     private static final long serialVersionUID = 9121109874202888889L;
     private String name;
     private String relationType;
     private String uuid;
 
-    /**
-     Empty Constructor.
-     */
-    public BaseRelEntityInfo() {
-
-    }
-
-    /**
-     Constructor with all params.
-     @param name name of the entity
-     @param relationType type of the relation
-     @param uuid uuid of the entity
-     */
-    public BaseRelEntityInfo(final String name, final String relationType, final String uuid) {
-        this.name = name;
-        this.relationType = relationType;
-        this.uuid = uuid;
-    }
 }

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/model/BaseRelEntityInfo.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/model/BaseRelEntityInfo.java
@@ -1,0 +1,32 @@
+package com.netflix.metacat.common.server.model;
+
+import lombok.Data;
+
+/**
+ * Base class to represent relation entity.
+ */
+@Data
+public abstract class BaseRelEntityInfo {
+    private String name;
+    private String relationType;
+    private String uuid;
+
+    /**
+     Empty Constructor.
+     */
+    public BaseRelEntityInfo() {
+
+    }
+
+    /**
+     Constructor with all params.
+     @param name name of the entity
+     @param relationType type of the relation
+     @param uuid uuid of the entity
+     */
+    public BaseRelEntityInfo(final String name, final String relationType, final String uuid) {
+        this.name = name;
+        this.relationType = relationType;
+        this.uuid = uuid;
+    }
+}

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/model/BaseRelEntityInfo.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/model/BaseRelEntityInfo.java
@@ -2,11 +2,14 @@ package com.netflix.metacat.common.server.model;
 
 import lombok.Data;
 
+import java.io.Serializable;
+
 /**
  * Base class to represent relation entity.
  */
 @Data
-public abstract class BaseRelEntityInfo {
+public abstract class BaseRelEntityInfo implements Serializable {
+    private static final long serialVersionUID = 9121109874202888889L;
     private String name;
     private String relationType;
     private String uuid;

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/model/ChildInfo.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/model/ChildInfo.java
@@ -1,0 +1,23 @@
+package com.netflix.metacat.common.server.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+/**
+ * ChildInfo.
+ */
+@EqualsAndHashCode(callSuper = true)
+@AllArgsConstructor
+@Data
+public class ChildInfo extends BaseRelEntityInfo {
+    /**
+     Constructor with all params.
+     @param name name of the entity
+     @param relationType type of the relation
+     @param uuid uuid of the entity
+     */
+    public ChildInfo(final String name, final String relationType, final String uuid) {
+        super(name, relationType, uuid);
+    }
+}

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/model/ParentInfo.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/model/ParentInfo.java
@@ -1,0 +1,29 @@
+package com.netflix.metacat.common.server.model;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+/**
+ * ParentInfo.
+ */
+@EqualsAndHashCode(callSuper = true)
+@Data
+public class ParentInfo extends BaseRelEntityInfo {
+
+    /**
+     Empty Constructor.
+     */
+    public ParentInfo() {
+
+    }
+
+    /**
+     Constructor with all params.
+     @param name name of the entity
+     @param relationType type of the relation
+     @param uuid uuid of the entity
+     */
+    public ParentInfo(final String name, final String relationType, final String uuid) {
+        super(name, relationType, uuid);
+    }
+}

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/usermetadata/ParentChildRelMetadataConstants.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/usermetadata/ParentChildRelMetadataConstants.java
@@ -7,37 +7,46 @@ package com.netflix.metacat.common.server.usermetadata;
  */
 public final class ParentChildRelMetadataConstants {
     /**
-     * During create, top level key specified in DefinitionMetadata that indicate the parent table name.
+     * During get and create, top level key specified in DefinitionMetadata that indicates the parent child infos.
      */
-    public static final String PARENTNAME = "root_table_name";
+    public static final String PARENT_CHILD_RELINFO = "parentChildRelationInfo";
     /**
-     * During create, top level key specified in DefinitionMetadata that indicates the parent table uuid.
+     * During create, nested level key specified in DefinitionMetadata['parentChildRelationInfo']
+     * that indicate the parent table name.
      */
-    public static final String PARENTUUID = "root_table_uuid";
+    public static final String PARENT_NAME = "root_table_name";
     /**
-     * During create, top level key specified in DefinitionMetadata that indicates the child table uuid.
+     * During create, nested level key specified in DefinitionMetadata['parentChildRelationInfo']
+     * that indicates the parent table uuid.
      */
-    public static final String CHILDUUID = "child_table_uuid";
+    public static final String PARENT_UUID = "root_table_uuid";
+    /**
+     * During create, nested level key specified in DefinitionMetadata['parentChildRelationInfo']
+     * that indicates the child table uuid.
+     */
+    public static final String CHILD_UUID = "child_table_uuid";
 
     /**
-     * During create, top level key specified in DefinitionMetadata that indicates relationType.
+     * During create, nested level key specified in DefinitionMetadata['parentChildRelationInfo']
+     * that indicates relationType.
      */
-    public static final String RELATIONTYPE = "relationType";
-
-    /**
-     * During get, top level key specified in DefinitionMetadata that indicates the parent child infos.
-     */
-    public static final String PARENTCHILDRELINFO = "parentChildRelationInfo";
+    public static final String RELATION_TYPE = "relationType";
 
     /**
      * During get, the nested key specified in DefinitionMetadata[PARENTCHILDRELINFO] that indicates parent infos.
      */
-    public static final String PARENTINFOS = "parentInfos";
+    public static final String PARENT_INFOS = "parentInfos";
 
     /**
      * During get, the nested key specified in DefinitionMetadata[PARENTCHILDRELINFO] that indicates child infos.
      */
-    public static final String CHILDINFOS = "childInfos";
+    public static final String CHILD_INFOS = "childInfos";
+
+    /**
+     * During get, the nested key specified in DefinitionMetadata[PARENTCHILDRELINFO]
+     * that indicates if a table is parent.
+     */
+    public static final String IS_PARENT = "isParent";
 
     private ParentChildRelMetadataConstants() {
 

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/usermetadata/ParentChildRelMetadataConstants.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/usermetadata/ParentChildRelMetadataConstants.java
@@ -1,0 +1,46 @@
+package com.netflix.metacat.common.server.usermetadata;
+
+/**
+ * ParentChildRelMetadataConstants.
+ *
+ * @author yingjianw
+ */
+public final class ParentChildRelMetadataConstants {
+    /**
+     * During create, top level key specified in DefinitionMetadata that indicate the parent table name.
+     */
+    public static final String PARENTNAME = "root_table_name";
+    /**
+     * During create, top level key specified in DefinitionMetadata that indicates the parent table uuid.
+     */
+    public static final String PARENTUUID = "root_table_uuid";
+    /**
+     * During create, top level key specified in DefinitionMetadata that indicates the child table uuid.
+     */
+    public static final String CHILDUUID = "child_table_uuid";
+
+    /**
+     * During create, top level key specified in DefinitionMetadata that indicates relationType.
+     */
+    public static final String RELATIONTYPE = "relationType";
+
+    /**
+     * During get, top level key specified in DefinitionMetadata that indicates the parent child infos.
+     */
+    public static final String PARENTCHILDRELINFO = "parentChildRelationInfo";
+
+    /**
+     * During get, the nested key specified in DefinitionMetadata[PARENTCHILDRELINFO] that indicates parent infos.
+     */
+    public static final String PARENTINFOS = "parentInfos";
+
+    /**
+     * During get, the nested key specified in DefinitionMetadata[PARENTCHILDRELINFO] that indicates child infos.
+     */
+    public static final String CHILDINFOS = "childInfos";
+
+    private ParentChildRelMetadataConstants() {
+
+    }
+
+}

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/usermetadata/ParentChildRelMetadataService.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/usermetadata/ParentChildRelMetadataService.java
@@ -1,5 +1,6 @@
 package com.netflix.metacat.common.server.usermetadata;
 import com.netflix.metacat.common.QualifiedName;
+import com.netflix.metacat.common.dto.notifications.ChildInfoDto;
 import com.netflix.metacat.common.server.model.ChildInfo;
 import com.netflix.metacat.common.server.model.ParentInfo;
 
@@ -91,6 +92,15 @@ public interface ParentChildRelMetadataService {
      * @return a set of ChildInfo
      */
     Set<ChildInfo> getChildren(
+        QualifiedName name
+    );
+
+    /**
+     * get the set of children dto for the input name.
+     * @param name name
+     * @return a set of ChildInfo
+     */
+    Set<ChildInfoDto> getChildrenDto(
         QualifiedName name
     );
 }

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/usermetadata/ParentChildRelMetadataService.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/usermetadata/ParentChildRelMetadataService.java
@@ -1,0 +1,96 @@
+package com.netflix.metacat.common.server.usermetadata;
+import com.netflix.metacat.common.QualifiedName;
+import com.netflix.metacat.common.server.model.ChildInfo;
+import com.netflix.metacat.common.server.model.ParentInfo;
+
+import java.util.Set;
+
+/**
+ * Parent-Child Relationship Metadata Service  API.
+ *
+ * @author yingjianw
+ */
+public interface ParentChildRelMetadataService {
+    /**
+     * Establishes a parent-child relationship with a specified relation type.
+     * Currently, exceptions are thrown in the following cases:
+     * 1. Attempting to create a child table as the parent of another child table.
+     * 2. Attempting to create a parent table on top of a parent table
+     * 3. A child table having more than one parent.
+     *
+     * @param parentName    the name of the parent entity
+     * @param parentUUID    the uuid of the parent
+     * @param childName     the name of the child entity
+     * @param childUUID     the uuid of the child
+     * @param relationType  the type of the relationship
+     */
+    void createParentChildRelation(
+        QualifiedName parentName,
+        String parentUUID,
+        QualifiedName childName,
+        String childUUID,
+        String relationType
+    );
+
+    /**
+     * Deletes a parent-child relationship with a specified relation type.
+     * This function is only called in the recovery process when
+     * we first create the parent-child relationship but fail to create the table.
+     *
+     * @param parentName    the name of the parent entity
+     * @param parentUUID    the uuid of the parent
+     * @param childName     the name of the child entity
+     * @param childUUID     the uuid of the child
+     * @param type  the type of the relationship
+     */
+    void deleteParentChildRelation(
+        QualifiedName parentName,
+        String parentUUID,
+        QualifiedName childName,
+        String childUUID,
+        String type
+    );
+
+    /**
+     * Renames `oldName` to `newName` in the parentChildRelationship store.
+     * This involves two steps:
+     * 1. Rename all records where the child is `oldName` to `newName`
+     * 2. Rename all records where the parent is `oldName` to `newName`
+     *
+     * @param oldName  the current name to be renamed
+     * @param newName  the new name to rename to
+     */
+    void rename(
+        QualifiedName oldName,
+        QualifiedName newName
+    );
+
+    /**
+     * Removes the entity from the parentChildRelationship store.
+     * This involves two steps:
+     * 1. drop all records where the child column = `name`
+     * 2. drop all records where the parent column = `name`
+     * @param name  the name of the entity to drop
+     */
+    void drop(
+        QualifiedName name
+    );
+
+    /**
+     * get the set of parent for the input name.
+     * @param name  name
+     * @return parentInfo
+     */
+    Set<ParentInfo> getParents(
+        QualifiedName name
+    );
+
+    /**
+     * get the set of children for the input name.
+     * @param name name
+     * @return a set of ChildInfo
+     */
+    Set<ChildInfo> getChildren(
+        QualifiedName name
+    );
+}

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/usermetadata/ParentChildRelServiceException.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/usermetadata/ParentChildRelServiceException.java
@@ -1,0 +1,25 @@
+package com.netflix.metacat.common.server.usermetadata;
+
+/**
+ * Parent Child Rel Service exception.
+ */
+public class ParentChildRelServiceException extends RuntimeException {
+    /**
+     * Constructor.
+     *
+     * @param m message
+     */
+    public ParentChildRelServiceException(final String m) {
+        super(m);
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param m message
+     * @param e exception
+     */
+    public ParentChildRelServiceException(final String m, final Exception e) {
+        super(m, e);
+    }
+}

--- a/metacat-common/src/main/java/com/netflix/metacat/common/dto/notifications/ChildInfoDto.java
+++ b/metacat-common/src/main/java/com/netflix/metacat/common/dto/notifications/ChildInfoDto.java
@@ -1,0 +1,31 @@
+package com.netflix.metacat.common.dto.notifications;
+
+import com.netflix.metacat.common.dto.BaseDto;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+/**
+ * ChildInfo information.
+ */
+@SuppressWarnings("unused")
+@Data
+@EqualsAndHashCode(callSuper = false)
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ChildInfoDto extends BaseDto {
+    private static final long serialVersionUID = 9121109874202088789L;
+    /* Name of the child */
+    @ApiModelProperty(value = "name of the child")
+    private String name;
+    /* Type of the relation */
+    @ApiModelProperty(value = "type of the relation")
+    private String relationType;
+    /* uuid of the table */
+    @ApiModelProperty(value = "uuid of the table")
+    private String uuid;
+}

--- a/metacat-functional-tests/metacat-test-cluster/datastores/mysql/docker-entrypoint-initdb.d/metacat.sql
+++ b/metacat-functional-tests/metacat-test-cluster/datastores/mysql/docker-entrypoint-initdb.d/metacat.sql
@@ -45,6 +45,21 @@ CREATE TABLE data_metadata_delete (
 ) DEFAULT CHARSET=latin1;
 
 --
+-- Table structure for table `parent_child_relation`
+--
+DROP TABLE IF EXISTS `parent_child_relation`;
+CREATE TABLE `parent_child_relation` (
+                                       `parent` varchar(255) NOT NULL,
+                                       `parent_uuid` varchar(255) NOT NULL,
+                                       `child` varchar(255) NOT NULL,
+                                       `child_uuid` varchar(255) NOT NULL,
+                                       `relation_type` varchar(255) NOT NULL,
+                                       PRIMARY KEY (`parent`, `child`, `parent_uuid`, `child_uuid`, `relation_type`),
+                                       INDEX `idx_child` (`child`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
 -- Table structure for table `definition_metadata`
 --
 

--- a/metacat-functional-tests/src/functionalTest/groovy/com/netflix/metacat/ParentChildRelMetadataServiceSpec.groovy
+++ b/metacat-functional-tests/src/functionalTest/groovy/com/netflix/metacat/ParentChildRelMetadataServiceSpec.groovy
@@ -1,0 +1,369 @@
+package com.netflix.metacat
+
+import com.netflix.metacat.common.QualifiedName
+import com.netflix.metacat.common.server.model.ChildInfo
+import com.netflix.metacat.common.server.model.ParentInfo
+import com.netflix.metacat.common.server.usermetadata.ParentChildRelMetadataService
+import com.netflix.metacat.metadata.mysql.MySqlParentChildRelMetaDataService
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.jdbc.datasource.DriverManagerDataSource
+import spock.lang.Shared
+import spock.lang.Specification
+
+import java.sql.Connection
+import java.sql.PreparedStatement
+
+class ParentChildRelMetadataServiceSpec extends Specification{
+    @Shared
+    private ParentChildRelMetadataService service;
+    @Shared
+    private JdbcTemplate jdbcTemplate;
+
+    @Shared
+    private String catalog = "prodhive"
+    @Shared
+    private String database = "testpc"
+
+    def setupSpec() {
+        String jdbcUrl = "jdbc:mysql://localhost:3306/metacat"
+        String username = "metacat_user"
+        String password = "metacat_user_password"
+
+        DriverManagerDataSource dataSource = new DriverManagerDataSource()
+        dataSource.setDriverClassName("com.mysql.cj.jdbc.Driver")
+        dataSource.setUrl(jdbcUrl)
+        dataSource.setUsername(username)
+        dataSource.setPassword(password)
+
+        jdbcTemplate = new JdbcTemplate(dataSource)
+        service = new MySqlParentChildRelMetaDataService(jdbcTemplate)
+    }
+
+    def cleanup() {
+        jdbcTemplate.update("DELETE FROM parent_child_relation")
+    }
+
+    def "Test CreateThenDelete - OneChildOneParent"() {
+        setup:
+        def parent = QualifiedName.ofTable(catalog, database, "p")
+        def child = QualifiedName.ofTable(catalog, database, "c")
+        def parentUUID = "p_uuid";
+        def childUUID = "c_uuid";
+        def type = "clone";
+        def child_parent_expected = [new ParentInfo(parent.toString(), type, parentUUID)] as Set
+        def parent_children_expected  = [new ChildInfo(child.toString(), type, childUUID)] as Set
+
+        when:
+        service.createParentChildRelation(parent, parentUUID, child, childUUID, type)
+
+        then:
+        // Test Parent
+        assert service.getParents(parent).isEmpty()
+        assert service.getParents(parent).isEmpty()
+
+        assert service.getChildren(parent) == parent_children_expected
+        assert service.getChildren(parent) == parent_children_expected
+
+        // Test Child
+        assert service.getParents(child) == child_parent_expected
+        assert service.getParents(child) == child_parent_expected
+
+        assert service.getChildren(child).isEmpty()
+        assert service.getParents(child) == child_parent_expected
+
+        when:
+        service.deleteParentChildRelation(parent, parentUUID, child, childUUID, type)
+
+        then:
+        // Test Parent
+        assert service.getParents(parent).isEmpty()
+        assert service.getParents(parent).isEmpty()
+        assert service.getChildren(parent).isEmpty()
+        assert service.getChildren(parent).isEmpty()
+
+        // Test Child
+        assert service.getParents(child).isEmpty()
+        assert service.getParents(child).isEmpty()
+        assert service.getChildren(child).isEmpty()
+        assert service.getParents(child).isEmpty()
+
+    }
+
+    def "Test Create - oneParentMultiChildren"() {
+        setup:
+        def parent = QualifiedName.ofTable(catalog, database, "p")
+        def parentUUID = "p_uuid";
+        def child1 = QualifiedName.ofTable(catalog, database, "c1")
+        def child1UUID = "c1_uuid";
+        def child2 = QualifiedName.ofTable(catalog, database, "c2")
+        def child2UUID = "c2_uuid";
+        def type = "clone";
+        def parent_children_expected  = [
+            new ChildInfo(child1.toString(), type, child1UUID),
+            new ChildInfo(child2.toString(), type, child2UUID),
+        ] as Set
+        def child_parent_expected = [new ParentInfo(parent.toString(), type, parentUUID)] as Set
+
+        when:
+        service.createParentChildRelation(parent, parentUUID, child1, child1UUID, type)
+        service.createParentChildRelation(parent, parentUUID, child2, child2UUID, type)
+
+        then:
+        // Test Parent
+        assert service.getParents(parent).isEmpty()
+        assert parent_children_expected == service.getChildren(parent)
+        assert parent_children_expected == service.getChildren(parent)
+
+        // Test Children
+        // Test Child 1
+        assert child_parent_expected == service.getParents(child1)
+        assert child_parent_expected == service.getParents(child1)
+        assert service.getChildren(child1).isEmpty()
+        assert service.getChildren(child1).isEmpty()
+
+        assert child_parent_expected == service.getParents(child2)
+        assert child_parent_expected == service.getParents(child2)
+        assert service.getChildren(child2).isEmpty()
+        assert service.getChildren(child2).isEmpty()
+    }
+
+    def "Test Create - oneChildMultiParentException"() {
+        setup:
+        def parent1 = QualifiedName.ofTable(catalog, database, "p1")
+        def parent1UUID = "p1_uuid";
+        def parent2 = QualifiedName.ofTable(catalog, database, "p2")
+        def parent2UUID = "p2_uuid";
+        def child = QualifiedName.ofTable(catalog, database, "c")
+        def childUUID = "c_uuid"
+        def type = "clone"
+        service.createParentChildRelation(parent1, parent1UUID, child, childUUID, type)
+
+        when:
+        service.createParentChildRelation(parent2, parent2UUID, child, childUUID, type)
+
+        then:
+        def e = thrown(RuntimeException)
+        assert e.message.contains("Cannot have a child table having more than one parent")
+
+        // Test Child
+        def child_parent_expected = [new ParentInfo(parent1.toString(), type, parent1UUID)] as Set
+        assert child_parent_expected == service.getParents(child)
+        assert child_parent_expected == service.getParents(child)
+
+        assert service.getChildren(child).isEmpty()
+        assert service.getChildren(child).isEmpty()
+    }
+
+    def "Test Create - oneChildAsParentOfAnotherException"() {
+        setup:
+        def parent = QualifiedName.ofTable(catalog, database, "p")
+        def parentUUID = "p_uuid"
+        def child = QualifiedName.ofTable(catalog, database, "c")
+        def childUUID = "c_uuid"
+        def grandChild = QualifiedName.ofTable(catalog, database, "gc")
+        def grandChildUUID = "gc_uuid"
+        def type = "clone"
+        service.createParentChildRelation(parent, parentUUID, child, childUUID, type)
+
+        when:
+        service.createParentChildRelation(child, childUUID, grandChild, grandChildUUID, type)
+
+        then:
+        def e = thrown(RuntimeException)
+        assert e.message.contains("Cannot create a child table as parent")
+
+        // Test Child
+        def child_parent_expected = [new ParentInfo(parent.toString(), type, parentUUID)] as Set
+        assert service.getParents(child) == child_parent_expected
+        assert service.getParents(child) == child_parent_expected
+
+        assert service.getChildren(child).isEmpty()
+        assert service.getChildren(child).isEmpty()
+    }
+
+    def "Test Create - oneParentAsChildOfAnother"() {
+        setup:
+        def parent = QualifiedName.ofTable(catalog, database, "p")
+        def parentUUID = "p_uuid"
+        def child = QualifiedName.ofTable(catalog, database, "c")
+        def childUUID = "c_uuid"
+        def grandChild = QualifiedName.ofTable(catalog, database, "gc")
+        def grandChildUUID = "gc_uuid"
+        def type = "clone"
+        service.createParentChildRelation(child, childUUID, grandChild, grandChildUUID, type)
+
+        when:
+        service.createParentChildRelation(parent, parentUUID, child, childUUID, type)
+
+        then:
+        def e = thrown(RuntimeException)
+        assert e.message.contains("Cannot create a parent table on top of another parent")
+    }
+
+    def "Test Rename Parent - One Child"() {
+        setup:
+        def parent = QualifiedName.ofTable(catalog, database, "p")
+        def parentUUID = "p_uuid"
+        def child = QualifiedName.ofTable(catalog, database, "c")
+        def childUUID = "c_uuid"
+        def type = "clone";
+        def newParent = QualifiedName.ofTable(catalog, database, "np")
+        service.createParentChildRelation(parent, parentUUID, child, childUUID, type)
+
+        when:
+        service.rename(parent, newParent)
+
+        then:
+        // Test Old Parent Name
+        assert service.getParents(parent).isEmpty()
+        assert service.getParents(parent).isEmpty()
+        assert service.getChildren(parent).isEmpty()
+        assert service.getChildren(parent).isEmpty()
+
+        // Test New Parent Name
+        assert service.getParents(newParent).isEmpty()
+        assert service.getParents(newParent).isEmpty()
+        def newParent_children_expected = [new ChildInfo(child.toString(), type, childUUID)] as Set
+        assert service.getChildren(newParent) == newParent_children_expected
+        assert service.getChildren(newParent) == newParent_children_expected
+
+        // Test Child
+        def child_parent_expected = [new ParentInfo(newParent.toString(), type, parentUUID)] as Set
+        assert child_parent_expected == service.getParents(child)
+        assert child_parent_expected == service.getParents(child)
+        assert service.getChildren(child).isEmpty()
+        assert service.getChildren(child).isEmpty()
+
+        // rename back
+        when:
+        service.rename(newParent, parent)
+        child_parent_expected = [new ParentInfo(parent.toString(), type, parentUUID)] as Set
+
+        then:
+        // Test new Parent Name
+        assert service.getParents(newParent).isEmpty()
+        assert service.getParents(newParent).isEmpty()
+        assert service.getChildren(newParent).isEmpty()
+        assert service.getChildren(newParent).isEmpty()
+
+        // Test old Parent Name
+        assert service.getParents(parent).isEmpty()
+        assert service.getParents(parent).isEmpty()
+        assert service.getChildren(parent) == newParent_children_expected
+        assert service.getChildren(parent) == [new ChildInfo(child.toString(), type, childUUID)] as Set
+
+        // Test Child
+        assert child_parent_expected == service.getParents(child)
+        assert child_parent_expected == service.getParents(child)
+        assert service.getChildren(child).isEmpty()
+        assert service.getChildren(child).isEmpty()
+    }
+
+    def "Test Rename Parent - Multi Child"() {
+        setup:
+        def parent = QualifiedName.ofTable(catalog, database, "p")
+        def parentUUID = "p_uuid"
+        def child1 = QualifiedName.ofTable(catalog, database, "c1")
+        def child1UUID = "c1_uuid"
+        def child2 = QualifiedName.ofTable(catalog, database, "c2")
+        def child2UUID = "c2_uuid"
+        def type = "clone";
+        service.createParentChildRelation(parent, parentUUID, child1, child1UUID, type)
+        service.createParentChildRelation(parent, parentUUID, child2, child2UUID, type)
+        def newParent = QualifiedName.ofTable(catalog, database, "np")
+        def child_parent_expected = [new ParentInfo(newParent.toString(), type, parentUUID)] as Set
+
+        when:
+        service.rename(parent, newParent)
+
+        then:
+        // Test Child1
+        assert service.getParents(child1) == child_parent_expected
+        assert service.getParents(child1) == child_parent_expected
+        //Test Child2
+        assert service.getParents(child2) == child_parent_expected
+        assert service.getParents(child2) == child_parent_expected
+    }
+
+    def "Test Rename Child"() {
+        setup:
+        def parent = QualifiedName.ofTable(catalog, database, "p")
+        def parentUUID = "p_uuid"
+        def child = QualifiedName.ofTable(catalog, database, "c")
+        def childUUID = "c_uuid"
+        def type = "clone"
+        service.createParentChildRelation(parent, parentUUID, child, childUUID, type)
+        def newChild = QualifiedName.ofTable(catalog, database, "nc")
+
+        when:
+        service.rename(child, newChild)
+        then:
+        // Test Parent
+        assert service.getParents(parent).isEmpty()
+        def parent_children_expected  = [new ChildInfo(newChild.toString(), type, childUUID)] as Set
+        assert parent_children_expected == service.getChildren(parent)
+        assert parent_children_expected == service.getChildren(parent)
+
+        // Test Child
+        assert service.getParents(child).isEmpty()
+        assert service.getParents(child).isEmpty()
+        assert service.getChildren(child).isEmpty()
+        assert service.getChildren(child).isEmpty()
+
+        // Test New Child
+        def child_parent_expected = [new ParentInfo(parent.toString(), type, parentUUID)] as Set
+        assert child_parent_expected == service.getParents(newChild)
+        assert child_parent_expected == service.getParents(newChild)
+        assert service.getChildren(child).isEmpty()
+        assert service.getChildren(child).isEmpty()
+
+        // rename back
+        when:
+        service.rename(newChild, child)
+        parent_children_expected  = [new ChildInfo(child.toString(), type, childUUID)] as Set
+
+        then:
+        // Test Parent
+        assert service.getParents(parent).isEmpty()
+        assert parent_children_expected == service.getChildren(parent)
+        assert parent_children_expected == service.getChildren(parent)
+
+        // Test New Child
+        assert service.getParents(newChild).isEmpty()
+        assert service.getParents(newChild).isEmpty()
+        assert service.getChildren(newChild).isEmpty()
+        assert service.getChildren(newChild).isEmpty()
+
+        // Test Child
+        assert child_parent_expected == service.getParents(child)
+        assert child_parent_expected == service.getParents(child)
+        assert service.getChildren(child).isEmpty()
+        assert service.getChildren(child).isEmpty()
+    }
+
+
+    def "Test Drop Child"() {
+        setup:
+        def parent = QualifiedName.ofTable(catalog, database, "p")
+        def parentUUID = "p_uuid"
+        def child = QualifiedName.ofTable(catalog, database, "c")
+        def childUUID = "c_uuid"
+        def type = "clone";
+        service.createParentChildRelation(parent, parentUUID, child, childUUID, type)
+        when:
+        service.drop(child)
+
+        then:
+        // Test Parent
+        assert service.getParents(parent).isEmpty()
+        assert service.getParents(parent).isEmpty()
+        assert service.getChildren(parent).isEmpty()
+        assert service.getChildren(parent).isEmpty()
+
+        // Test Child
+        assert service.getParents(child).isEmpty()
+        assert service.getParents(child).isEmpty()
+        assert service.getChildren(child).isEmpty()
+        assert service.getChildren(child).isEmpty()
+    }
+}

--- a/metacat-functional-tests/src/functionalTest/groovy/com/netflix/metacat/ParentChildRelMetadataServiceSpec.groovy
+++ b/metacat-functional-tests/src/functionalTest/groovy/com/netflix/metacat/ParentChildRelMetadataServiceSpec.groovy
@@ -66,16 +66,10 @@ class ParentChildRelMetadataServiceSpec extends Specification{
         then:
         // Test Parent
         assert service.getParents(parent).isEmpty()
-        assert service.getParents(parent).isEmpty()
-
-        assert service.getChildren(parent) == parent_children_expected
         assert service.getChildren(parent) == parent_children_expected
 
         // Test Child
         assert service.getParents(child) == child_parent_expected
-        assert service.getParents(child) == child_parent_expected
-
-        assert service.getChildren(child).isEmpty()
         assert service.getParents(child) == child_parent_expected
 
         when:
@@ -84,14 +78,10 @@ class ParentChildRelMetadataServiceSpec extends Specification{
         then:
         // Test Parent
         assert service.getParents(parent).isEmpty()
-        assert service.getParents(parent).isEmpty()
-        assert service.getChildren(parent).isEmpty()
         assert service.getChildren(parent).isEmpty()
 
         // Test Child
         assert service.getParents(child).isEmpty()
-        assert service.getParents(child).isEmpty()
-        assert service.getChildren(child).isEmpty()
         assert service.getParents(child).isEmpty()
 
     }
@@ -119,18 +109,13 @@ class ParentChildRelMetadataServiceSpec extends Specification{
         // Test Parent
         assert service.getParents(parent).isEmpty()
         assert parent_children_expected == service.getChildren(parent)
-        assert parent_children_expected == service.getChildren(parent)
 
         // Test Children
         // Test Child 1
         assert child_parent_expected == service.getParents(child1)
-        assert child_parent_expected == service.getParents(child1)
-        assert service.getChildren(child1).isEmpty()
         assert service.getChildren(child1).isEmpty()
 
         assert child_parent_expected == service.getParents(child2)
-        assert child_parent_expected == service.getParents(child2)
-        assert service.getChildren(child2).isEmpty()
         assert service.getChildren(child2).isEmpty()
     }
 
@@ -155,9 +140,6 @@ class ParentChildRelMetadataServiceSpec extends Specification{
         // Test Child
         def child_parent_expected = [new ParentInfo(parent1.toString(), type, parent1UUID)] as Set
         assert child_parent_expected == service.getParents(child)
-        assert child_parent_expected == service.getParents(child)
-
-        assert service.getChildren(child).isEmpty()
         assert service.getChildren(child).isEmpty()
     }
 
@@ -182,9 +164,6 @@ class ParentChildRelMetadataServiceSpec extends Specification{
         // Test Child
         def child_parent_expected = [new ParentInfo(parent.toString(), type, parentUUID)] as Set
         assert service.getParents(child) == child_parent_expected
-        assert service.getParents(child) == child_parent_expected
-
-        assert service.getChildren(child).isEmpty()
         assert service.getChildren(child).isEmpty()
     }
 
@@ -223,22 +202,16 @@ class ParentChildRelMetadataServiceSpec extends Specification{
         then:
         // Test Old Parent Name
         assert service.getParents(parent).isEmpty()
-        assert service.getParents(parent).isEmpty()
-        assert service.getChildren(parent).isEmpty()
         assert service.getChildren(parent).isEmpty()
 
         // Test New Parent Name
         assert service.getParents(newParent).isEmpty()
-        assert service.getParents(newParent).isEmpty()
         def newParent_children_expected = [new ChildInfo(child.toString(), type, childUUID)] as Set
-        assert service.getChildren(newParent) == newParent_children_expected
         assert service.getChildren(newParent) == newParent_children_expected
 
         // Test Child
         def child_parent_expected = [new ParentInfo(newParent.toString(), type, parentUUID)] as Set
         assert child_parent_expected == service.getParents(child)
-        assert child_parent_expected == service.getParents(child)
-        assert service.getChildren(child).isEmpty()
         assert service.getChildren(child).isEmpty()
 
         // rename back
@@ -249,20 +222,14 @@ class ParentChildRelMetadataServiceSpec extends Specification{
         then:
         // Test new Parent Name
         assert service.getParents(newParent).isEmpty()
-        assert service.getParents(newParent).isEmpty()
-        assert service.getChildren(newParent).isEmpty()
         assert service.getChildren(newParent).isEmpty()
 
         // Test old Parent Name
         assert service.getParents(parent).isEmpty()
-        assert service.getParents(parent).isEmpty()
         assert service.getChildren(parent) == newParent_children_expected
-        assert service.getChildren(parent) == [new ChildInfo(child.toString(), type, childUUID)] as Set
 
         // Test Child
         assert child_parent_expected == service.getParents(child)
-        assert child_parent_expected == service.getParents(child)
-        assert service.getChildren(child).isEmpty()
         assert service.getChildren(child).isEmpty()
     }
 
@@ -286,9 +253,7 @@ class ParentChildRelMetadataServiceSpec extends Specification{
         then:
         // Test Child1
         assert service.getParents(child1) == child_parent_expected
-        assert service.getParents(child1) == child_parent_expected
         //Test Child2
-        assert service.getParents(child2) == child_parent_expected
         assert service.getParents(child2) == child_parent_expected
     }
 
@@ -309,19 +274,14 @@ class ParentChildRelMetadataServiceSpec extends Specification{
         assert service.getParents(parent).isEmpty()
         def parent_children_expected  = [new ChildInfo(newChild.toString(), type, childUUID)] as Set
         assert parent_children_expected == service.getChildren(parent)
-        assert parent_children_expected == service.getChildren(parent)
 
         // Test Child
         assert service.getParents(child).isEmpty()
-        assert service.getParents(child).isEmpty()
-        assert service.getChildren(child).isEmpty()
         assert service.getChildren(child).isEmpty()
 
         // Test New Child
         def child_parent_expected = [new ParentInfo(parent.toString(), type, parentUUID)] as Set
         assert child_parent_expected == service.getParents(newChild)
-        assert child_parent_expected == service.getParents(newChild)
-        assert service.getChildren(child).isEmpty()
         assert service.getChildren(child).isEmpty()
 
         // rename back
@@ -333,18 +293,13 @@ class ParentChildRelMetadataServiceSpec extends Specification{
         // Test Parent
         assert service.getParents(parent).isEmpty()
         assert parent_children_expected == service.getChildren(parent)
-        assert parent_children_expected == service.getChildren(parent)
 
         // Test New Child
         assert service.getParents(newChild).isEmpty()
-        assert service.getParents(newChild).isEmpty()
-        assert service.getChildren(newChild).isEmpty()
         assert service.getChildren(newChild).isEmpty()
 
         // Test Child
         assert child_parent_expected == service.getParents(child)
-        assert child_parent_expected == service.getParents(child)
-        assert service.getChildren(child).isEmpty()
         assert service.getChildren(child).isEmpty()
     }
 
@@ -363,14 +318,38 @@ class ParentChildRelMetadataServiceSpec extends Specification{
         then:
         // Test Parent
         assert service.getParents(parent).isEmpty()
-        assert service.getParents(parent).isEmpty()
-        assert service.getChildren(parent).isEmpty()
         assert service.getChildren(parent).isEmpty()
 
         // Test Child
         assert service.getParents(child).isEmpty()
+        assert service.getChildren(child).isEmpty()
+    }
+
+    def "Test Rename and Drop Child"() {
+        setup:
+        def parent = QualifiedName.ofTable(catalog, database, "p")
+        def parentUUID = "p_uuid"
+        def child = QualifiedName.ofTable(catalog, database, "c")
+        def newChild = QualifiedName.ofTable(catalog, database, "nc")
+        def childUUID = "c_uuid"
+        def type = "clone";
+        service.createParentChildRelation(parent, parentUUID, child, childUUID, type)
+
+        when:
+        service.rename(child, newChild)
+        service.drop(newChild)
+
+        then:
+        // Test Parent
+        assert service.getParents(parent).isEmpty()
+        assert service.getChildren(parent).isEmpty()
+
+        // Test Child
         assert service.getParents(child).isEmpty()
         assert service.getChildren(child).isEmpty()
-        assert service.getChildren(child).isEmpty()
+
+        // Test newChild
+        assert service.getParents(newChild).isEmpty()
+        assert service.getChildren(newChild).isEmpty()
     }
 }

--- a/metacat-functional-tests/src/functionalTest/groovy/com/netflix/metacat/ParentChildRelMetadataServiceSpec.groovy
+++ b/metacat-functional-tests/src/functionalTest/groovy/com/netflix/metacat/ParentChildRelMetadataServiceSpec.groovy
@@ -1,6 +1,11 @@
 package com.netflix.metacat
 
 import com.netflix.metacat.common.QualifiedName
+import com.netflix.metacat.common.server.converter.ConverterUtil
+import com.netflix.metacat.common.server.converter.DefaultTypeConverter
+import com.netflix.metacat.common.server.converter.DozerJsonTypeConverter
+import com.netflix.metacat.common.server.converter.DozerTypeConverter
+import com.netflix.metacat.common.server.converter.TypeConverterFactory
 import com.netflix.metacat.common.server.model.ChildInfo
 import com.netflix.metacat.common.server.model.ParentInfo
 import com.netflix.metacat.common.server.usermetadata.ParentChildRelMetadataService
@@ -10,14 +15,14 @@ import org.springframework.jdbc.datasource.DriverManagerDataSource
 import spock.lang.Shared
 import spock.lang.Specification
 
-import java.sql.Connection
-import java.sql.PreparedStatement
-
 class ParentChildRelMetadataServiceSpec extends Specification{
     @Shared
     private ParentChildRelMetadataService service;
     @Shared
     private JdbcTemplate jdbcTemplate;
+
+    @Shared
+    private ConverterUtil converterUtil;
 
     @Shared
     private String catalog = "prodhive"
@@ -36,7 +41,9 @@ class ParentChildRelMetadataServiceSpec extends Specification{
         dataSource.setPassword(password)
 
         jdbcTemplate = new JdbcTemplate(dataSource)
-        service = new MySqlParentChildRelMetaDataService(jdbcTemplate)
+        def typeFactory = new TypeConverterFactory(new DefaultTypeConverter())
+        def converter = new ConverterUtil(new DozerTypeConverter(typeFactory), new DozerJsonTypeConverter(typeFactory))
+        service = new MySqlParentChildRelMetaDataService(jdbcTemplate, converter)
     }
 
     def cleanup() {

--- a/metacat-main/src/main/java/com/netflix/metacat/main/api/v1/ParentChildRelController.java
+++ b/metacat-main/src/main/java/com/netflix/metacat/main/api/v1/ParentChildRelController.java
@@ -22,7 +22,7 @@ import java.util.Set;
 /**
  * Parent Child Relation V1 API implementation.
  *
- * @author amajumdar
+ * @author Yingjian
  */
 
 @RestController

--- a/metacat-main/src/main/java/com/netflix/metacat/main/api/v1/ParentChildRelController.java
+++ b/metacat-main/src/main/java/com/netflix/metacat/main/api/v1/ParentChildRelController.java
@@ -1,0 +1,75 @@
+package com.netflix.metacat.main.api.v1;
+
+import com.netflix.metacat.common.QualifiedName;
+import com.netflix.metacat.common.dto.notifications.ChildInfoDto;
+import com.netflix.metacat.common.server.usermetadata.ParentChildRelMetadataService;
+import com.netflix.metacat.main.api.RequestWrapper;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import java.util.Set;
+
+/**
+ * Parent Child Relation V1 API implementation.
+ *
+ * @author amajumdar
+ */
+
+@RestController
+@RequestMapping(
+    path = "/mds/v1/parentChildRel",
+    produces = MediaType.APPLICATION_JSON_VALUE
+)
+@Api(
+    value = "ParentChildRelV1",
+    description = "Federated user metadata operations",
+    produces = MediaType.APPLICATION_JSON_VALUE,
+    consumes = MediaType.APPLICATION_JSON_VALUE
+)
+@DependsOn("metacatCoreInitService")
+@RequiredArgsConstructor
+public class ParentChildRelController {
+    private final RequestWrapper requestWrapper;
+    private final ParentChildRelMetadataService parentChildRelMetadataService;
+
+    /**
+     * Return the list of children for a given table.
+     * @param catalogName catalogName
+     * @param databaseName databaseName
+     * @param tableName tableName
+     * @return list of childInfoDto
+     */
+    @RequestMapping(method = RequestMethod.GET,
+        path = "/children/catalog/{catalog-name}/database/{database-name}/table/{table-name}")
+    @ResponseStatus(HttpStatus.OK)
+    @ApiOperation(
+        position = 0,
+        value = "Returns the children",
+        notes = "Returns the children"
+    )
+    public Set<ChildInfoDto> getChildren(
+        @ApiParam(value = "The name of the catalog", required = true)
+        @PathVariable("catalog-name") final String catalogName,
+        @ApiParam(value = "The name of the database", required = true)
+        @PathVariable("database-name") final String databaseName,
+        @ApiParam(value = "The name of the table", required = true)
+        @PathVariable("table-name") final String tableName
+    ) {
+        return this.requestWrapper.processRequest(
+            "ParentChildRelV1Resource.getChildren",
+            () -> this.parentChildRelMetadataService.getChildrenDto(
+                QualifiedName.ofTable(catalogName, databaseName, tableName)
+            )
+        );
+    }
+}

--- a/metacat-main/src/main/java/com/netflix/metacat/main/configs/ServicesConfig.java
+++ b/metacat-main/src/main/java/com/netflix/metacat/main/configs/ServicesConfig.java
@@ -35,6 +35,7 @@ import com.netflix.metacat.common.server.usermetadata.DefaultUserMetadataService
 import com.netflix.metacat.common.server.usermetadata.LookupService;
 import com.netflix.metacat.common.server.usermetadata.TagService;
 import com.netflix.metacat.common.server.usermetadata.UserMetadataService;
+import com.netflix.metacat.common.server.usermetadata.ParentChildRelMetadataService;
 import com.netflix.metacat.common.server.util.ThreadServiceManager;
 import com.netflix.metacat.main.manager.CatalogManager;
 import com.netflix.metacat.main.manager.ConnectorManager;
@@ -228,6 +229,7 @@ public class ServicesConfig {
      * @param converterUtil              converter utilities
      * @param authorizationService       authorization Service
      * @param ownerValidationService     owner validation service
+     * @param parentChildRelMetadataService parentChildRelMetadataService
      *
      * @return The table service bean
      */
@@ -244,7 +246,8 @@ public class ServicesConfig {
         final Config config,
         final ConverterUtil converterUtil,
         final AuthorizationService authorizationService,
-        final OwnerValidationService ownerValidationService) {
+        final OwnerValidationService ownerValidationService,
+        final ParentChildRelMetadataService parentChildRelMetadataService) {
         return new TableServiceImpl(
             connectorManager,
             connectorTableServiceProxy,
@@ -257,7 +260,8 @@ public class ServicesConfig {
             config,
             converterUtil,
             authorizationService,
-            ownerValidationService
+            ownerValidationService,
+            parentChildRelMetadataService
         );
     }
 

--- a/metacat-main/src/main/java/com/netflix/metacat/main/services/impl/TableServiceImpl.java
+++ b/metacat-main/src/main/java/com/netflix/metacat/main/services/impl/TableServiceImpl.java
@@ -13,6 +13,7 @@
 
 package com.netflix.metacat.main.services.impl;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -114,9 +115,9 @@ public class TableServiceImpl implements TableService {
         log.info("Creating table {}", name);
         eventBus.post(new MetacatCreateTablePreEvent(name, metacatRequestContext, this, tableDto));
 
-        final Optional<Runnable> unSaveOpOpt = saveParentChildRelationship(name, tableDto); //suceed
+        final Optional<Runnable> unSaveOpOpt = saveParentChildRelationship(name, tableDto);
         try {
-            connectorTableServiceProxy.create(name, converterUtil.fromTableDto(tableDto)); //failed
+            connectorTableServiceProxy.create(name, converterUtil.fromTableDto(tableDto));
         } catch (Exception e) {
             unSaveOpOpt.ifPresent(Runnable::run);
             throw e;
@@ -153,11 +154,12 @@ public class TableServiceImpl implements TableService {
         return dto;
     }
 
-    private ObjectNode createParentChildObjectNode(@Nullable final Set<ParentInfo> parentInfos) {
+    private ObjectNode createParentChildObjectNode(@Nullable final Set<ParentInfo> parentInfos,
+                                                   @Nullable final Set<ChildInfo> childInfos) {
         final ObjectMapper objectMapper = new ObjectMapper();
         final ObjectNode rootNode = objectMapper.createObjectNode();
 
-        // For now, we only populate parent information for a child table.
+        // For childTable, we will always populate the parent infos
         if (parentInfos != null && !parentInfos.isEmpty()) {
             final ArrayNode parentArrayNode = objectMapper.createArrayNode();
             for (ParentInfo parentInfo : parentInfos) {
@@ -167,7 +169,12 @@ public class TableServiceImpl implements TableService {
                 parentNode.put("uuid", parentInfo.getUuid());
                 parentArrayNode.add(parentNode);
             }
-            rootNode.set(ParentChildRelMetadataConstants.PARENTINFOS, parentArrayNode);
+            rootNode.set(ParentChildRelMetadataConstants.PARENT_INFOS, parentArrayNode);
+        }
+
+        // For parent table, if it has a child, we will put a field to indicate that the table is a parent table.
+        if (childInfos != null && !childInfos.isEmpty()) {
+            rootNode.put(ParentChildRelMetadataConstants.IS_PARENT, true);
         }
         return rootNode;
     }
@@ -176,42 +183,42 @@ public class TableServiceImpl implements TableService {
     private Optional<Runnable> saveParentChildRelationship(final QualifiedName child, final TableDto tableDto) {
         if (tableDto.getDefinitionMetadata() != null) {
             final ObjectNode definitionMetadata = tableDto.getDefinitionMetadata();
-            if (definitionMetadata.has(ParentChildRelMetadataConstants.PARENTNAME)) {
-                // fetch parent name
-                final String parentFullName = definitionMetadata.path(ParentChildRelMetadataConstants.PARENTNAME)
+            if (definitionMetadata.has(ParentChildRelMetadataConstants.PARENT_CHILD_RELINFO)) {
+                final JsonNode parentChildRelInfo =
+                    definitionMetadata.get(ParentChildRelMetadataConstants.PARENT_CHILD_RELINFO);
+
+                String parentName;
+                if (!parentChildRelInfo.has(ParentChildRelMetadataConstants.PARENT_NAME)) {
+                    throw new RuntimeException("parent name is not specified");
+                }
+                parentName = parentChildRelInfo.path(ParentChildRelMetadataConstants.PARENT_NAME)
                     .asText();
+                final QualifiedName parent = QualifiedName.fromString(parentName);
+                validate(parent);
+
+                // fetch parent and child uuid
                 String parentUUID;
                 String childUUID;
-
-                if (!definitionMetadata.has(ParentChildRelMetadataConstants.PARENTUUID)) {
-                    throw new RuntimeException("root_table_uuid is not specified for parent table=" + parentFullName);
+                if (!parentChildRelInfo.has(ParentChildRelMetadataConstants.PARENT_UUID)) {
+                    throw new RuntimeException("root_table_uuid is not specified for parent table="
+                            + parentName);
                 }
 
-                if (!definitionMetadata.has(ParentChildRelMetadataConstants.CHILDUUID)) {
+                if (!parentChildRelInfo.has(ParentChildRelMetadataConstants.CHILD_UUID)) {
                     throw new RuntimeException("child_table_uuid is not specified for child table=" + child);
                 }
-                parentUUID = definitionMetadata.path(ParentChildRelMetadataConstants.PARENTUUID).asText();
-                childUUID = definitionMetadata.path(ParentChildRelMetadataConstants.CHILDUUID).asText();
-
-                final String[] splits = parentFullName.split("\\.");
-                if (splits.length != 3) {
-                    throw new RuntimeException("Parent table identifier should pass in the following format "
-                        + "{catalog}.{db}.{parentTable}");
-                }
-                final QualifiedName parent = QualifiedName.ofTable(
-                    splits[0],
-                    splits[1],
-                    splits[2]
-                );
-                validate(parent);
+                parentUUID = parentChildRelInfo.path(ParentChildRelMetadataConstants.PARENT_UUID).asText();
+                childUUID = parentChildRelInfo.path(ParentChildRelMetadataConstants.CHILD_UUID).asText();
 
                 // fetch relationshipType
                 String relationType;
-                if (definitionMetadata.has(ParentChildRelMetadataConstants.RELATIONTYPE)) {
-                    relationType = definitionMetadata.path(ParentChildRelMetadataConstants.RELATIONTYPE).asText();
+                if (parentChildRelInfo.has(ParentChildRelMetadataConstants.RELATION_TYPE)) {
+                    relationType = parentChildRelInfo.path(ParentChildRelMetadataConstants.RELATION_TYPE).asText();
                 } else {
                     relationType = "CLONE";
                 }
+
+                // Create parent child relationship
                 parentChildRelMetadataService.createParentChildRelation(parent, parentUUID,
                     child, childUUID, relationType);
 
@@ -221,10 +228,9 @@ public class TableServiceImpl implements TableService {
                         parentChildRelMetadataService.deleteParentChildRelation(parent,
                             parentUUID, child, childUUID, relationType);
                     } catch (Exception e) {
-                        log.error("parentChildRelMetadataService: Fail to delete parent child relationship "
-                            + "after failing to create the table={}"
-                            + "with the following parameters: "
-                            + "parent={}, parentUUID={}, child={}, childUUID={}, relationType={}",
+                        log.error("parentChildRelMetadataService: Failed to delete parent child relationship "
+                                + "after failing to create the table={} with the following parameters: "
+                                + "parent={}, parentUUID={}, child={}, childUUID={}, relationType={}",
                             child, parent, parentUUID, child, childUUID, relationType, e);
                     }
                 });
@@ -363,7 +369,15 @@ public class TableServiceImpl implements TableService {
 
         final Set<ChildInfo> childInfos = parentChildRelMetadataService.getChildren(name);
         if (childInfos != null && !childInfos.isEmpty()) {
-            throw new RuntimeException("Fail to drop " + name + " because it still has child table");
+            final StringBuilder errorSb = new StringBuilder();
+            errorSb.append("Failed to drop ").append(name)
+                .append(" because it still has ")
+                .append(childInfos.size())
+                .append(" child table(s). One example is:");
+
+            errorSb.append("\n").append(childInfos.iterator().next().getName());
+
+            throw new RuntimeException(errorSb.toString());
         }
         try {
             connectorTableServiceProxy.delete(name);
@@ -386,7 +400,7 @@ public class TableServiceImpl implements TableService {
         try {
             parentChildRelMetadataService.drop(name);
         } catch (Exception e) {
-            log.error("parentChildRelMetadataService: Fail to drop relation for table={}", name, e);
+            log.error("parentChildRelMetadataService: Failed to drop relation for table={}", name, e);
         }
 
         if (canDeleteMetadata(name)) {
@@ -480,17 +494,19 @@ public class TableServiceImpl implements TableService {
                     : userMetadataService.getDefinitionMetadataWithInterceptor(name,
                     GetMetadataInterceptorParameters.builder().hasMetadata(tableInternal).build());
             // Always get the source of truth for parent child relation from the parentChildRelMetadataService
+            if (definitionMetadata.isPresent()
+                && definitionMetadata.get().has(ParentChildRelMetadataConstants.PARENT_CHILD_RELINFO)) {
+                definitionMetadata.get().remove(ParentChildRelMetadataConstants.PARENT_CHILD_RELINFO);
+            }
             final Set<ParentInfo> parentInfo = parentChildRelMetadataService.getParents(name);
-            final ObjectNode parentChildRelObjectNode = createParentChildObjectNode(parentInfo);
-            if (definitionMetadata.isPresent()) {
-                if (!parentChildRelObjectNode.isEmpty()) {
-                    definitionMetadata.get().set(ParentChildRelMetadataConstants.PARENTCHILDRELINFO,
-                        parentChildRelObjectNode);
+            final Set<ChildInfo> childInfos = parentChildRelMetadataService.getChildren(name);
+            final ObjectNode parentChildRelObjectNode = createParentChildObjectNode(parentInfo, childInfos);
+            if (!parentChildRelObjectNode.isEmpty()) {
+                if (!definitionMetadata.isPresent()) {
+                    definitionMetadata = Optional.of(new ObjectMapper().createObjectNode());
                 }
-            } else {
-                if (!parentChildRelObjectNode.isEmpty()) {
-                    definitionMetadata = Optional.of(parentChildRelObjectNode);
-                }
+                definitionMetadata.get().set(ParentChildRelMetadataConstants.PARENT_CHILD_RELINFO,
+                    parentChildRelObjectNode);
             }
             definitionMetadata.ifPresent(table::setDefinitionMetadata);
         }
@@ -562,7 +578,7 @@ public class TableServiceImpl implements TableService {
                     // if rename operation fail, rename back the parent child relation
                     parentChildRelMetadataService.rename(newName, oldName);
                 } catch (Exception renameException) {
-                    log.error("parentChildRelMetadataService: Fail to rename parent child relation "
+                    log.error("parentChildRelMetadataService: Failed to rename parent child relation "
                             + "after table fail to rename from {} to {} "
                             + "with the following parameters oldName={} to newName={}",
                         oldName, newName, oldName, newName, renameException);

--- a/metacat-main/src/main/java/com/netflix/metacat/main/services/impl/TableServiceImpl.java
+++ b/metacat-main/src/main/java/com/netflix/metacat/main/services/impl/TableServiceImpl.java
@@ -13,6 +13,8 @@
 
 package com.netflix.metacat.main.services.impl;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
@@ -42,14 +44,18 @@ import com.netflix.metacat.common.server.events.MetacatRenameTablePreEvent;
 import com.netflix.metacat.common.server.events.MetacatUpdateIcebergTablePostEvent;
 import com.netflix.metacat.common.server.events.MetacatUpdateTablePostEvent;
 import com.netflix.metacat.common.server.events.MetacatUpdateTablePreEvent;
+import com.netflix.metacat.common.server.model.ChildInfo;
+import com.netflix.metacat.common.server.model.ParentInfo;
 import com.netflix.metacat.common.server.monitoring.Metrics;
 import com.netflix.metacat.common.server.properties.Config;
 import com.netflix.metacat.common.server.spi.MetacatCatalogConfig;
 import com.netflix.metacat.common.server.usermetadata.AuthorizationService;
 import com.netflix.metacat.common.server.usermetadata.GetMetadataInterceptorParameters;
+import com.netflix.metacat.common.server.usermetadata.ParentChildRelMetadataConstants;
 import com.netflix.metacat.common.server.usermetadata.MetacatOperation;
 import com.netflix.metacat.common.server.usermetadata.TagService;
 import com.netflix.metacat.common.server.usermetadata.UserMetadataService;
+import com.netflix.metacat.common.server.usermetadata.ParentChildRelMetadataService;
 import com.netflix.metacat.common.server.util.MetacatContextManager;
 import com.netflix.metacat.common.server.util.MetacatUtils;
 import com.netflix.metacat.main.manager.ConnectorManager;
@@ -62,7 +68,6 @@ import com.netflix.spectator.api.Registry;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-
 import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
@@ -70,6 +75,8 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+
+
 
 /**
  * Table service implementation.
@@ -89,6 +96,7 @@ public class TableServiceImpl implements TableService {
     private final ConverterUtil converterUtil;
     private final AuthorizationService authorizationService;
     private final OwnerValidationService ownerValidationService;
+    private final ParentChildRelMetadataService parentChildRelMetadataService;
 
     /**
      * {@inheritDoc}
@@ -106,7 +114,13 @@ public class TableServiceImpl implements TableService {
         log.info("Creating table {}", name);
         eventBus.post(new MetacatCreateTablePreEvent(name, metacatRequestContext, this, tableDto));
 
-        connectorTableServiceProxy.create(name, converterUtil.fromTableDto(tableDto));
+        final Optional<Runnable> unSaveOpOpt = saveParentChildRelationship(name, tableDto); //suceed
+        try {
+            connectorTableServiceProxy.create(name, converterUtil.fromTableDto(tableDto)); //failed
+        } catch (Exception e) {
+            unSaveOpOpt.ifPresent(Runnable::run);
+            throw e;
+        }
 
         if (tableDto.getDataMetadata() != null || tableDto.getDefinitionMetadata() != null) {
             log.info("Saving user metadata for table {}", name);
@@ -137,6 +151,98 @@ public class TableServiceImpl implements TableService {
             handleExceptionOnCreate(name, "postEvent", e);
         }
         return dto;
+    }
+
+    private ObjectNode createParentChildObjectNode(@Nullable final Set<ParentInfo> parentInfos,
+                                                   @Nullable final Set<ChildInfo> childInfos) {
+        final ObjectMapper objectMapper = new ObjectMapper();
+        final ObjectNode rootNode = objectMapper.createObjectNode();
+
+        if (parentInfos != null && !parentInfos.isEmpty()) {
+            final ArrayNode parentArrayNode = objectMapper.createArrayNode();
+            for (ParentInfo parentInfo : parentInfos) {
+                final ObjectNode parentNode = objectMapper.createObjectNode();
+                parentNode.put("name", parentInfo.getName());
+                parentNode.put("relationType", parentInfo.getRelationType());
+                parentNode.put("uuid", parentInfo.getUuid());
+                parentArrayNode.add(parentNode);
+            }
+            rootNode.set(ParentChildRelMetadataConstants.PARENTINFOS, parentArrayNode);
+        }
+
+        if (childInfos != null && !childInfos.isEmpty()) {
+            final ArrayNode childrenArrayNode = objectMapper.createArrayNode();
+            for (ChildInfo childInfo : childInfos) {
+                final ObjectNode childNode = objectMapper.createObjectNode();
+                childNode.put("name", childInfo.getName());
+                childNode.put("relationType", childInfo.getRelationType());
+                childNode.put("uuid", childInfo.getUuid());
+                childrenArrayNode.add(childNode);
+            }
+            rootNode.set(ParentChildRelMetadataConstants.CHILDINFOS, childrenArrayNode);
+        }
+        return rootNode;
+    }
+
+    // Return the unSaveOperation if applicable
+    private Optional<Runnable> saveParentChildRelationship(final QualifiedName child, final TableDto tableDto) {
+        if (tableDto.getDefinitionMetadata() != null) {
+            final ObjectNode definitionMetadata = tableDto.getDefinitionMetadata();
+            if (definitionMetadata.has(ParentChildRelMetadataConstants.PARENTNAME)) {
+                // fetch parent name
+                final String parentFullName = definitionMetadata.path(ParentChildRelMetadataConstants.PARENTNAME)
+                    .asText();
+                String parentUUID;
+                String childUUID;
+
+                if (!definitionMetadata.has(ParentChildRelMetadataConstants.PARENTUUID)) {
+                    throw new RuntimeException("root_table_uuid is not specified for parent table=" + parentFullName);
+                }
+
+                if (!definitionMetadata.has(ParentChildRelMetadataConstants.CHILDUUID)) {
+                    throw new RuntimeException("child_table_uuid is not specified for child table=" + child);
+                }
+                parentUUID = definitionMetadata.path(ParentChildRelMetadataConstants.PARENTUUID).asText();
+                childUUID = definitionMetadata.path(ParentChildRelMetadataConstants.CHILDUUID).asText();
+
+                final String[] splits = parentFullName.split("\\.");
+                if (splits.length != 3) {
+                    throw new RuntimeException("Parent table identifier should pass in the following format "
+                        + "{catalog}.{db}.{parentTable}");
+                }
+                final QualifiedName parent = QualifiedName.ofTable(
+                    splits[0],
+                    splits[1],
+                    splits[2]
+                );
+                validate(parent);
+
+                // fetch relationshipType
+                String relationType;
+                if (definitionMetadata.has(ParentChildRelMetadataConstants.RELATIONTYPE)) {
+                    relationType = definitionMetadata.path(ParentChildRelMetadataConstants.RELATIONTYPE).asText();
+                } else {
+                    relationType = "CLONE";
+                }
+                parentChildRelMetadataService.createParentChildRelation(parent, parentUUID,
+                    child, childUUID, relationType);
+
+                // Return a Runnable for deleting the relationship
+                return Optional.of(() -> {
+                    try {
+                        parentChildRelMetadataService.deleteParentChildRelation(parent,
+                            parentUUID, child, childUUID, relationType);
+                    } catch (Exception e) {
+                        log.error("parentChildRelMetadataService: Fail to delete parent child relationship "
+                            + "after failing to create the table={}"
+                            + "with the following parameters: "
+                            + "parent={}, parentUUID={}, child={}, childUUID={}, relationType={}",
+                            child, parent, parentUUID, child, childUUID, relationType, e);
+                    }
+                });
+            }
+        }
+        return Optional.empty();
     }
 
     private void setDefaultAttributes(final TableDto tableDto) {
@@ -267,10 +373,12 @@ public class TableServiceImpl implements TableService {
             }
         }
 
-        // Try to delete the table even if get above fails
+        final Set<ChildInfo> childInfos = parentChildRelMetadataService.getChildren(name);
+        if (childInfos != null && !childInfos.isEmpty()) {
+            throw new RuntimeException("Fail to drop " + name + " because it still has child table");
+        }
         try {
             connectorTableServiceProxy.delete(name);
-
             // If this is a common view, the storage_table if present
             // should also be deleted.
             if (MetacatUtils.isCommonView(tableDto.getMetadata())
@@ -283,9 +391,14 @@ public class TableServiceImpl implements TableService {
                     deleteCommonViewStorageTable(name, qualifiedStorageTableName);
                 }
             }
-
         } catch (NotFoundException ignored) {
             log.debug("NotFoundException ignored for table {}", name);
+        }
+
+        try {
+            parentChildRelMetadataService.drop(name);
+        } catch (Exception e) {
+            log.error("parentChildRelMetadataService: Fail to drop relation for table={}", name, e);
         }
 
         if (canDeleteMetadata(name)) {
@@ -373,11 +486,25 @@ public class TableServiceImpl implements TableService {
         }
 
         if (getTableServiceParameters.isIncludeDefinitionMetadata()) {
-            final Optional<ObjectNode> definitionMetadata =
+            Optional<ObjectNode> definitionMetadata =
                 (getTableServiceParameters.isDisableOnReadMetadataIntercetor())
                     ? userMetadataService.getDefinitionMetadata(name)
                     : userMetadataService.getDefinitionMetadataWithInterceptor(name,
                     GetMetadataInterceptorParameters.builder().hasMetadata(tableInternal).build());
+            // Always get the source of truth for parent child relation from the parentChildRelMetadataService
+            final Set<ParentInfo> parentInfo = parentChildRelMetadataService.getParents(name);
+            final Set<ChildInfo> childInfos = parentChildRelMetadataService.getChildren(name);
+            final ObjectNode parentChildRelObjectNode = createParentChildObjectNode(parentInfo, childInfos);
+            if (definitionMetadata.isPresent()) {
+                if (!parentChildRelObjectNode.isEmpty()) {
+                    definitionMetadata.get().set(ParentChildRelMetadataConstants.PARENTCHILDRELINFO,
+                        parentChildRelObjectNode);
+                }
+            } else {
+                if (!parentChildRelObjectNode.isEmpty()) {
+                    definitionMetadata = Optional.of(parentChildRelObjectNode);
+                }
+            }
             definitionMetadata.ifPresent(table::setDefinitionMetadata);
         }
 
@@ -437,7 +564,24 @@ public class TableServiceImpl implements TableService {
         if (oldTable != null) {
             //Ignore if the operation is not supported, so that we can at least go ahead and save the user metadata
             eventBus.post(new MetacatRenameTablePreEvent(oldName, metacatRequestContext, this, newName));
-            connectorTableServiceProxy.rename(oldName, newName, isMView);
+
+            // Before rename, first rename its parent child relation
+            parentChildRelMetadataService.rename(oldName, newName);
+
+            try {
+                connectorTableServiceProxy.rename(oldName, newName, isMView);
+            } catch (Exception e) {
+                try {
+                    // if rename operation fail, rename back the parent child relation
+                    parentChildRelMetadataService.rename(newName, oldName);
+                } catch (Exception renameException) {
+                    log.error("parentChildRelMetadataService: Fail to rename parent child relation "
+                            + "after table fail to rename from {} to {} "
+                            + "with the following parameters oldName={} to newName={}",
+                        oldName, newName, oldName, newName, renameException);
+                }
+                throw e;
+            }
             userMetadataService.renameDefinitionMetadataKey(oldName, newName);
             tagService.renameTableTags(oldName, newName.getTableName());
 

--- a/metacat-main/src/main/java/com/netflix/metacat/main/services/impl/TableServiceImpl.java
+++ b/metacat-main/src/main/java/com/netflix/metacat/main/services/impl/TableServiceImpl.java
@@ -153,11 +153,11 @@ public class TableServiceImpl implements TableService {
         return dto;
     }
 
-    private ObjectNode createParentChildObjectNode(@Nullable final Set<ParentInfo> parentInfos,
-                                                   @Nullable final Set<ChildInfo> childInfos) {
+    private ObjectNode createParentChildObjectNode(@Nullable final Set<ParentInfo> parentInfos) {
         final ObjectMapper objectMapper = new ObjectMapper();
         final ObjectNode rootNode = objectMapper.createObjectNode();
 
+        // For now, we only populate parent information for a child table.
         if (parentInfos != null && !parentInfos.isEmpty()) {
             final ArrayNode parentArrayNode = objectMapper.createArrayNode();
             for (ParentInfo parentInfo : parentInfos) {
@@ -168,18 +168,6 @@ public class TableServiceImpl implements TableService {
                 parentArrayNode.add(parentNode);
             }
             rootNode.set(ParentChildRelMetadataConstants.PARENTINFOS, parentArrayNode);
-        }
-
-        if (childInfos != null && !childInfos.isEmpty()) {
-            final ArrayNode childrenArrayNode = objectMapper.createArrayNode();
-            for (ChildInfo childInfo : childInfos) {
-                final ObjectNode childNode = objectMapper.createObjectNode();
-                childNode.put("name", childInfo.getName());
-                childNode.put("relationType", childInfo.getRelationType());
-                childNode.put("uuid", childInfo.getUuid());
-                childrenArrayNode.add(childNode);
-            }
-            rootNode.set(ParentChildRelMetadataConstants.CHILDINFOS, childrenArrayNode);
         }
         return rootNode;
     }
@@ -493,8 +481,7 @@ public class TableServiceImpl implements TableService {
                     GetMetadataInterceptorParameters.builder().hasMetadata(tableInternal).build());
             // Always get the source of truth for parent child relation from the parentChildRelMetadataService
             final Set<ParentInfo> parentInfo = parentChildRelMetadataService.getParents(name);
-            final Set<ChildInfo> childInfos = parentChildRelMetadataService.getChildren(name);
-            final ObjectNode parentChildRelObjectNode = createParentChildObjectNode(parentInfo, childInfos);
+            final ObjectNode parentChildRelObjectNode = createParentChildObjectNode(parentInfo);
             if (definitionMetadata.isPresent()) {
                 if (!parentChildRelObjectNode.isEmpty()) {
                     definitionMetadata.get().set(ParentChildRelMetadataConstants.PARENTCHILDRELINFO,

--- a/metacat-main/src/test/groovy/com/netflix/metacat/main/services/impl/TableServiceImplSpec.groovy
+++ b/metacat-main/src/test/groovy/com/netflix/metacat/main/services/impl/TableServiceImplSpec.groovy
@@ -54,8 +54,6 @@ import spock.lang.Specification
 import spock.lang.Unroll
 import com.netflix.metacat.common.server.usermetadata.ParentChildRelMetadataService;
 
-import javax.annotation.meta.When
-
 /**
  * Tests for the TableServiceImpl.
  *
@@ -321,7 +319,7 @@ class TableServiceImplSpec extends Specification {
         service.delete(name)
         then:
         1 * parentChildRelSvc.getParents(name) >> {[new ParentInfo("parent", "clone", "parent_uuid")] as Set}
-        2 * parentChildRelSvc.getChildren(name) >> {[new ChildInfo("child", "clone", "child_uuid")] as Set}
+        1 * parentChildRelSvc.getChildren(name) >> {[new ChildInfo("child", "clone", "child_uuid")] as Set}
         1 * config.getNoTableDeleteOnTags() >> []
         thrown(RuntimeException)
 
@@ -329,7 +327,7 @@ class TableServiceImplSpec extends Specification {
         service.delete(name)
         then:
         1 * parentChildRelSvc.getParents(name)
-        2 * parentChildRelSvc.getChildren(name)
+        1 * parentChildRelSvc.getChildren(name)
         1 * config.getNoTableDeleteOnTags() >> []
         1 * connectorTableServiceProxy.delete(_) >> {throw new RuntimeException("Fail to drop")}
         0 * parentChildRelSvc.drop(_, _)

--- a/metacat-main/src/test/groovy/com/netflix/metacat/main/services/impl/TableServiceImplSpec.groovy
+++ b/metacat-main/src/test/groovy/com/netflix/metacat/main/services/impl/TableServiceImplSpec.groovy
@@ -35,6 +35,8 @@ import com.netflix.metacat.common.server.converter.ConverterUtil
 import com.netflix.metacat.common.server.events.MetacatEventBus
 import com.netflix.metacat.common.server.events.MetacatUpdateTablePostEvent
 import com.netflix.metacat.common.server.events.MetacatUpdateTablePreEvent
+import com.netflix.metacat.common.server.model.ChildInfo
+import com.netflix.metacat.common.server.model.ParentInfo
 import com.netflix.metacat.common.server.properties.Config
 import com.netflix.metacat.common.server.spi.MetacatCatalogConfig
 import com.netflix.metacat.common.server.usermetadata.DefaultAuthorizationService
@@ -50,6 +52,7 @@ import com.netflix.spectator.api.DefaultRegistry
 import com.netflix.spectator.api.NoopRegistry
 import spock.lang.Specification
 import spock.lang.Unroll
+import com.netflix.metacat.common.server.usermetadata.ParentChildRelMetadataService;
 
 import javax.annotation.meta.When
 
@@ -80,6 +83,7 @@ class TableServiceImplSpec extends Specification {
     def connectorTableServiceProxy
     def authorizationService
     def ownerValidationService
+    def parentChildRelSvc
 
     def service
     def setup() {
@@ -93,13 +97,14 @@ class TableServiceImplSpec extends Specification {
         usermetadataService.getDefinitionMetadata(_) >> Optional.empty()
         usermetadataService.getDataMetadata(_) >> Optional.empty()
         usermetadataService.getDefinitionMetadataWithInterceptor(_,_) >> Optional.empty()
-        connectorTableServiceProxy = new ConnectorTableServiceProxy(connectorManager, converterUtil)
+        connectorTableServiceProxy = Spy(new ConnectorTableServiceProxy(connectorManager, converterUtil))
         authorizationService = new DefaultAuthorizationService(config)
         ownerValidationService = Mock(OwnerValidationService)
+        parentChildRelSvc = Mock(ParentChildRelMetadataService)
 
         service = new TableServiceImpl(connectorManager, connectorTableServiceProxy, databaseService, tagService,
             usermetadataService, new MetacatJsonLocator(),
-            eventBus, registry, config, converterUtil, authorizationService, ownerValidationService)
+            eventBus, registry, config, converterUtil, authorizationService, ownerValidationService, parentChildRelSvc)
     }
 
     def testTableGet() {
@@ -270,6 +275,67 @@ class TableServiceImplSpec extends Specification {
         0 * ownerValidationService.enforceOwnerValidation(_, _, _)
     }
 
+    def "Test Create - Clone Table Fail to create table"() {
+        given:
+        def childTableName = QualifiedName.ofTable("clone", "clone", "c")
+        def parentTableName = QualifiedName.ofTable("clone", "clone", "p")
+        def createTableDto = new TableDto(
+            name: childTableName,
+            definitionMetadata: toObjectNode('{\"root_table_name\":\"clone.clone.p\", \"root_table_uuid\":\"p_uuid\", \"child_table_uuid\":\"child_uuid\"}'),
+            serde: new StorageDto(uri: 's3:/clone/clone/c')
+        )
+        when:
+        service.create(childTableName, createTableDto)
+        then:
+        1 * ownerValidationService.extractPotentialOwners(_) >> ["cloneClient"]
+        1 * ownerValidationService.isUserValid(_) >> true
+        1 * ownerValidationService.extractPotentialOwnerGroups(_) >> ["cloneClientGroup"]
+        1 * ownerValidationService.isGroupValid(_) >> true
+
+        1 * parentChildRelSvc.createParentChildRelation(parentTableName, "p_uuid", childTableName, "child_uuid", "CLONE")
+        1 * connectorTableServiceProxy.create(_, _) >> {throw new RuntimeException("Fail to create")}
+        1 * parentChildRelSvc.deleteParentChildRelation(parentTableName, "p_uuid", childTableName, "child_uuid", "CLONE")
+        thrown(RuntimeException)
+    }
+
+    def "Test Rename - Clone Table Fail to update parent child relation"() {
+        given:
+        def oldName = QualifiedName.ofTable("clone", "clone", "oldChild")
+        def newName = QualifiedName.ofTable("clone", "clone", "newChild")
+        when:
+        service.rename(oldName, newName, false)
+
+        then:
+        1 * config.getNoTableRenameOnTags() >> []
+        1 * parentChildRelSvc.rename(oldName, newName)
+        1 * connectorTableServiceProxy.rename(oldName, newName, _) >> {throw new RuntimeException("Fail to rename")}
+        1 * parentChildRelSvc.rename(newName, oldName)
+        thrown(RuntimeException)
+    }
+
+    def "Test Drop - Clone Table Fail to drop parent child relation"() {
+        given:
+        def name = QualifiedName.ofTable("clone", "clone", "child")
+
+        when:
+        service.delete(name)
+        then:
+        1 * parentChildRelSvc.getParents(name) >> {[new ParentInfo("parent", "clone", "parent_uuid")] as Set}
+        2 * parentChildRelSvc.getChildren(name) >> {[new ChildInfo("child", "clone", "child_uuid")] as Set}
+        1 * config.getNoTableDeleteOnTags() >> []
+        thrown(RuntimeException)
+
+        when:
+        service.delete(name)
+        then:
+        1 * parentChildRelSvc.getParents(name)
+        2 * parentChildRelSvc.getChildren(name)
+        1 * config.getNoTableDeleteOnTags() >> []
+        1 * connectorTableServiceProxy.delete(_) >> {throw new RuntimeException("Fail to drop")}
+        0 * parentChildRelSvc.drop(_, _)
+        thrown(RuntimeException)
+    }
+
     def "Will not throw on Successful Table Update with Failed Get"() {
         given:
         def updatedTableDto = new TableDto(name: name, serde: new StorageDto(uri: 's3:/a/b/c'))
@@ -311,7 +377,7 @@ class TableServiceImplSpec extends Specification {
             connectorManager, connectorTableServiceProxy, databaseService, tagService,
             usermetadataService, new MetacatJsonLocator(),
             eventBus, new DefaultRegistry(), config, converterUtil, authorizationService,
-            new DefaultOwnerValidationService(new NoopRegistry()))
+            new DefaultOwnerValidationService(new NoopRegistry()), parentChildRelSvc)
 
         def initialDefinitionMetadataJson = toObjectNode(initialDefinitionMetadata)
         tableDto = new TableDto(

--- a/metacat-metadata-mysql/build.gradle
+++ b/metacat-metadata-mysql/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     api("com.google.guava:guava")
     api("org.apache.tomcat:tomcat-jdbc")
     api("org.slf4j:slf4j-api")
+    api('org.springframework.retry:spring-retry')
     /*******************************
      * Provided Dependencies
      *******************************/

--- a/metacat-metadata-mysql/src/main/java/com/netflix/metacat/metadata/mysql/MySqlParentChildRelMetaDataService.java
+++ b/metacat-metadata-mysql/src/main/java/com/netflix/metacat/metadata/mysql/MySqlParentChildRelMetaDataService.java
@@ -1,0 +1,217 @@
+package com.netflix.metacat.metadata.mysql;
+
+import com.netflix.metacat.common.QualifiedName;
+import com.netflix.metacat.common.server.model.ChildInfo;
+import com.netflix.metacat.common.server.model.ParentInfo;
+import com.netflix.metacat.common.server.usermetadata.ParentChildRelMetadataService;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.sql.PreparedStatement;
+import java.util.Set;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.HashSet;
+
+/**
+ * Parent Child Relationship Metadata Service.
+ * This stores the parent child relationship of two entities as first class citizen in Metacat.
+ */
+@Slf4j
+@SuppressFBWarnings
+@Transactional("metadataTxManager")
+public class MySqlParentChildRelMetaDataService implements ParentChildRelMetadataService {
+    static final String SQL_CREATE_PARENT_CHILD_RELATIONS =
+        "INSERT INTO parent_child_relation (parent, parent_uuid, child, child_uuid, relation_type) "
+            + "VALUES (?, ?, ?, ?, ?)";
+
+    static final String SQL_DELETE_PARENT_CHILD_RELATIONS =
+        "DELETE FROM parent_child_relation "
+            + "WHERE parent = ? AND parent_uuid = ? AND child = ? AND child_uuid = ? AND relation_type = ?";
+
+    static final String SQL_RENAME_PARENT_ENTITY = "UPDATE parent_child_relation "
+        + "SET parent = ? WHERE parent = ?";
+    static final String SQL_RENAME_CHILD_ENTITY = "UPDATE parent_child_relation "
+        + "SET child = ? WHERE child = ?";
+
+    static final String SQL_DROP_CHILD = "DELETE FROM parent_child_relation "
+        + "WHERE child = ? ";
+    static final String SQL_DROP_PARENT = "DELETE FROM parent_child_relation "
+        + "WHERE parent = ? ";
+
+    static final String SQL_GET_PARENTS = "SELECT parent, parent_uuid, relation_type "
+        + "FROM parent_child_relation WHERE child = ?";
+
+    static final String SQL_GET_CHILDREN = "SELECT child, child_uuid, relation_type "
+        + "FROM parent_child_relation WHERE parent = ?";
+
+    private JdbcTemplate jdbcTemplate;
+
+    /**
+     * Constructor.
+     *
+     * @param jdbcTemplate jdbc template
+     */
+    @Autowired
+    public MySqlParentChildRelMetaDataService(final JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    @Override
+    public void createParentChildRelation(final QualifiedName parentName,
+                                          final String parentUUID,
+                                          final QualifiedName childName,
+                                          final String childUUID,
+                                          final String type) {
+        // Validation to prevent having a child have two parents
+        final Set<ParentInfo> childParents = getParents(childName);
+        if (!childParents.isEmpty()) {
+            throw new RuntimeException("Cannot have a child table having more than one parent "
+                + "- Child Table: " + childName
+                + " already have a parent Table=" + childParents.stream().findFirst().get());
+        }
+
+        // Validation to prevent creating a child table as a parent of another child table
+        final Set<ParentInfo> parentParents = getParents(parentName);
+        if (!parentParents.isEmpty()) {
+            throw new RuntimeException("Cannot create a child table as parent "
+                + "- parent table: " + parentName
+                + " already have a parent table = " + parentParents.stream().findFirst().get());
+        }
+
+        // Validation to prevent creating a parent on top of a table that have children
+        final Set<ChildInfo> childChildren = getChildren(childName);
+        if (!childChildren.isEmpty()) {
+            throw new RuntimeException("Cannot create a parent table on top of another parent "
+                + "- child table: " + childName + " already have child");
+        }
+
+        jdbcTemplate.update(connection -> {
+            final PreparedStatement ps = connection.prepareStatement(SQL_CREATE_PARENT_CHILD_RELATIONS);
+            ps.setString(1, parentName.toString());
+            ps.setString(2, parentUUID);
+            ps.setString(3, childName.toString());
+            ps.setString(4, childUUID);
+            ps.setString(5, type);
+            return ps;
+        });
+        log.info("Successfully create parent child relationship with parent={}, parentUUID={}, "
+                + "child={}, childUUID={}, relationType = {}",
+            parentName, parentUUID, childName, childUUID, type
+        );
+    }
+
+    @Override
+    public void deleteParentChildRelation(final QualifiedName parentName,
+                                          final String parentUUID,
+                                          final QualifiedName childName,
+                                          final String childUUID,
+                                          final String type) {
+        log.info("Deleting parent child relationship with parent={}, parentUUID={}, "
+                + "child={}, childUUID={}, relationType = {}",
+            parentName, parentUUID, childName, childUUID, type
+        );
+        jdbcTemplate.update(connection -> {
+            final PreparedStatement ps = connection.prepareStatement(SQL_DELETE_PARENT_CHILD_RELATIONS);
+            ps.setString(1, parentName.toString());
+            ps.setString(2, parentUUID);
+            ps.setString(3, childName.toString());
+            ps.setString(4, childUUID);
+            ps.setString(5, type);
+            return ps;
+        });
+        log.info("Successfully delete parent child relationship with parent={}, parentUUID={}, "
+                + "child={}, childUUID={}, relationType = {}",
+            parentName, parentUUID, childName, childUUID, type
+        );
+    }
+
+    @Override
+    public void rename(final QualifiedName oldName, final QualifiedName newName) {
+        try {
+            renameParent(oldName, newName);
+            renameChild(oldName, newName);
+            log.info("Successfully rename parent child relationship for oldName={}, newName={}",
+                oldName, newName
+            );
+        } catch (RuntimeException e) {
+            log.error("Failed to rename entity", e);
+            throw e;
+        }
+    }
+
+    private void renameParent(final QualifiedName oldName, final QualifiedName newName) {
+        jdbcTemplate.update(connection -> {
+            final PreparedStatement ps = connection.prepareStatement(SQL_RENAME_PARENT_ENTITY);
+            ps.setString(1, newName.toString());
+            ps.setString(2, oldName.toString());
+
+            return ps;
+        });
+    }
+
+    private void renameChild(final QualifiedName oldName, final QualifiedName newName) {
+        jdbcTemplate.update(connection -> {
+            final PreparedStatement ps = connection.prepareStatement(SQL_RENAME_CHILD_ENTITY);
+            ps.setString(1, newName.toString());
+            ps.setString(2, oldName.toString());
+            return ps;
+        });
+    }
+
+    @Override
+    public void drop(final QualifiedName name) {
+        dropParent(name);
+        dropChild(name);
+        log.info("Successfully drop parent child relationship for name={}, uuid={}", name);
+    }
+
+    private void dropParent(final QualifiedName name) {
+        jdbcTemplate.update(connection -> {
+            final PreparedStatement ps = connection.prepareStatement(SQL_DROP_PARENT);
+            ps.setString(1, name.toString());
+            return ps;
+        });
+    }
+
+    private void dropChild(final QualifiedName name) {
+        jdbcTemplate.update(connection -> {
+            final PreparedStatement ps = connection.prepareStatement(SQL_DROP_CHILD);
+            ps.setString(1, name.toString());
+            return ps;
+        });
+    }
+
+    @Override
+    public Set<ParentInfo> getParents(final QualifiedName name) {
+        final List<Object> params = new ArrayList<>();
+        params.add(name.toString());
+        final List<ParentInfo> parents = jdbcTemplate.query(
+            SQL_GET_PARENTS, params.toArray(), (rs, rowNum) -> {
+                final ParentInfo parentInfo = new ParentInfo();
+                parentInfo.setName(rs.getString("parent"));
+                parentInfo.setRelationType(rs.getString("relation_type"));
+                parentInfo.setUuid(rs.getString("parent_uuid"));
+                return parentInfo;
+            });
+        return new HashSet<>(parents);
+    }
+
+    @Override
+    public Set<ChildInfo> getChildren(final QualifiedName name) {
+        final List<Object> params = new ArrayList<>();
+        params.add(name.toString());
+        final List<ChildInfo> children = jdbcTemplate.query(
+            SQL_GET_CHILDREN, params.toArray(), (rs, rowNum) -> {
+                final ChildInfo childInfo = new ChildInfo();
+                childInfo.setName(rs.getString("child"));
+                childInfo.setRelationType(rs.getString("relation_type"));
+                childInfo.setUuid(rs.getString("child_uuid"));
+                return childInfo;
+            });
+        return new HashSet<>(children);
+    }
+}

--- a/metacat-metadata-mysql/src/main/java/com/netflix/metacat/metadata/mysql/MySqlParentChildRelMetaDataService.java
+++ b/metacat-metadata-mysql/src/main/java/com/netflix/metacat/metadata/mysql/MySqlParentChildRelMetaDataService.java
@@ -1,6 +1,8 @@
 package com.netflix.metacat.metadata.mysql;
 
 import com.netflix.metacat.common.QualifiedName;
+import com.netflix.metacat.common.dto.notifications.ChildInfoDto;
+import com.netflix.metacat.common.server.converter.ConverterUtil;
 import com.netflix.metacat.common.server.model.ChildInfo;
 import com.netflix.metacat.common.server.model.ParentInfo;
 import com.netflix.metacat.common.server.usermetadata.ParentChildRelMetadataService;
@@ -15,6 +17,7 @@ import java.util.Set;
 import java.util.List;
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.stream.Collectors;
 
 /**
  * Parent Child Relationship Metadata Service.
@@ -48,16 +51,19 @@ public class MySqlParentChildRelMetaDataService implements ParentChildRelMetadat
     static final String SQL_GET_CHILDREN = "SELECT child, child_uuid, relation_type "
         + "FROM parent_child_relation WHERE parent = ?";
 
-    private JdbcTemplate jdbcTemplate;
+    private final JdbcTemplate jdbcTemplate;
+    private final ConverterUtil converterUtil;
 
     /**
      * Constructor.
      *
      * @param jdbcTemplate jdbc template
+     * @param converterUtil converterUtil
      */
     @Autowired
-    public MySqlParentChildRelMetaDataService(final JdbcTemplate jdbcTemplate) {
+    public MySqlParentChildRelMetaDataService(final JdbcTemplate jdbcTemplate, final ConverterUtil converterUtil) {
         this.jdbcTemplate = jdbcTemplate;
+        this.converterUtil = converterUtil;
     }
 
     @Override
@@ -213,5 +219,11 @@ public class MySqlParentChildRelMetaDataService implements ParentChildRelMetadat
                 return childInfo;
             });
         return new HashSet<>(children);
+    }
+
+    @Override
+    public Set<ChildInfoDto> getChildrenDto(final QualifiedName name) {
+        return getChildren(name).stream()
+            .map(converterUtil::toChildInfoDto).collect(Collectors.toSet());
     }
 }

--- a/metacat-metadata-mysql/src/main/java/com/netflix/metacat/metadata/mysql/MySqlUserMetadataConfig.java
+++ b/metacat-metadata-mysql/src/main/java/com/netflix/metacat/metadata/mysql/MySqlUserMetadataConfig.java
@@ -16,11 +16,12 @@ package com.netflix.metacat.metadata.mysql;
 import com.netflix.metacat.common.json.MetacatJson;
 import com.netflix.metacat.common.server.properties.Config;
 import com.netflix.metacat.common.server.properties.MetacatProperties;
-import com.netflix.metacat.common.server.usermetadata.MetadataInterceptor;
-import com.netflix.metacat.common.server.usermetadata.LookupService;
-import com.netflix.metacat.common.server.usermetadata.MetadataInterceptorImpl;
-import com.netflix.metacat.common.server.usermetadata.TagService;
 import com.netflix.metacat.common.server.usermetadata.UserMetadataService;
+import com.netflix.metacat.common.server.usermetadata.LookupService;
+import com.netflix.metacat.common.server.usermetadata.TagService;
+import com.netflix.metacat.common.server.usermetadata.ParentChildRelMetadataService;
+import com.netflix.metacat.common.server.usermetadata.MetadataInterceptor;
+import com.netflix.metacat.common.server.usermetadata.MetadataInterceptorImpl;
 import com.netflix.metacat.common.server.util.DataSourceManager;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -41,7 +42,6 @@ import javax.sql.DataSource;
 @Configuration
 @ConditionalOnProperty(value = "metacat.mysqlmetadataservice.enabled", havingValue = "true")
 public class MySqlUserMetadataConfig {
-
     /**
      * business Metadata Manager.
      * @return business Metadata Manager
@@ -106,6 +106,19 @@ public class MySqlUserMetadataConfig {
         final UserMetadataService userMetadataService
     ) {
         return new MySqlTagService(config, jdbcTemplate, lookupService, metacatJson, userMetadataService);
+    }
+
+    /**
+     * The parentChildRelMetadataService to use.
+     *
+     * @param jdbcTemplate        JDBC template
+     * @return The parentChildRelMetadataService implementation backed by MySQL
+     */
+    @Bean
+    ParentChildRelMetadataService parentChildRelMetadataService(
+        @Qualifier("metadataJdbcTemplate") final JdbcTemplate jdbcTemplate
+    ) {
+        return new MySqlParentChildRelMetaDataService(jdbcTemplate);
     }
 
     /**

--- a/metacat-metadata-mysql/src/main/java/com/netflix/metacat/metadata/mysql/MySqlUserMetadataConfig.java
+++ b/metacat-metadata-mysql/src/main/java/com/netflix/metacat/metadata/mysql/MySqlUserMetadataConfig.java
@@ -14,6 +14,7 @@
 package com.netflix.metacat.metadata.mysql;
 
 import com.netflix.metacat.common.json.MetacatJson;
+import com.netflix.metacat.common.server.converter.ConverterUtil;
 import com.netflix.metacat.common.server.properties.Config;
 import com.netflix.metacat.common.server.properties.MetacatProperties;
 import com.netflix.metacat.common.server.usermetadata.UserMetadataService;
@@ -116,9 +117,10 @@ public class MySqlUserMetadataConfig {
      */
     @Bean
     ParentChildRelMetadataService parentChildRelMetadataService(
-        @Qualifier("metadataJdbcTemplate") final JdbcTemplate jdbcTemplate
+        @Qualifier("metadataJdbcTemplate") final JdbcTemplate jdbcTemplate,
+        final ConverterUtil converterUtil
     ) {
-        return new MySqlParentChildRelMetaDataService(jdbcTemplate);
+        return new MySqlParentChildRelMetaDataService(jdbcTemplate, converterUtil);
     }
 
     /**


### PR DESCRIPTION
### PR Summary: Introduction of Parent-Child Relationship Metadata in Metacat

This pull request introduces metadata to manage parent-child relationships within Metacat. The key invariants for these relationships are:

- **Child Table**: Once created, a child table’s parent cannot be altered unless the parent itself is renamed.
- **Parent Table**: Modifications to a parent table’s list of children are restricted to:
  - Adding a new clone table.
  - Renaming or dropping an existing child clone table.

The implementation is integrated into the open-source Metacat project, as parent-child relationships will be a fundamental concept, especially for tables like Iceberg.

#### Important Classes:
1. **MySQLParentChildRelMetadataService.java**: 
   - Provides CRUD services to manipulate the parent-child relationship metadata.
   
2. **TableServiceImpl**: 
   - Integrates `MySQLParentChildRelMetadataService` into the table management workflow.

   **Operations**:

   - **Create**:
     - The parent-child relationship is always established before the table is created. If table creation fails, the parent-child relationship is then deleted.
     - This order has two advantages:
       1. Reverting changes to the parent-child relationship is less destructive.
       2. Since both the table name and UUID are stored, it is safe to delete the record if necessary.

   - **Rename**:
     - Similar to the create operation, the parent-child relationship is renamed before the table is renamed. And if table renamed fail, we will try to rename the parent-child relation back.

   - **Drop**:
     - For the drop operation, the table is always dropped first, followed by the parent-child relationship if applicable.
     - If the parent-child relationship cannot be dropped, it will act as a dangling reference.
   
   - **Get**:
     - We will always fetch the parent child relation from `MySQLParentChildRelMetadataService` and then insert it into the definitionMetadata. For now we will only populate the field for child table. For parent to get the list of children, we expose a search endpoint.
   
3. **metacat.sql**:
   - Define the schema of the parent child relation schema