### PR TITLE
Yingjianw/additional safety rollout

### DIFF
--- a/metacat-client/src/main/java/com/netflix/metacat/client/api/ParentChildRelV1.java
+++ b/metacat-client/src/main/java/com/netflix/metacat/client/api/ParentChildRelV1.java
@@ -7,7 +7,8 @@ import javax.ws.rs.GET;
 import javax.ws.rs.PathParam;
 
 import javax.ws.rs.core.MediaType;
-import com.netflix.metacat.common.dto.notifications.ChildInfoDto;
+import com.netflix.metacat.common.dto.ChildInfoDto;
+import com.netflix.metacat.common.dto.ParentInfoDto;
 
 import java.util.Set;
 
@@ -33,6 +34,26 @@ public interface ParentChildRelV1 {
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     Set<ChildInfoDto> getChildren(
+        @PathParam("catalog-name")
+        String catalogName,
+        @PathParam("database-name")
+        String databaseName,
+        @PathParam("table-name")
+        String tableName
+    );
+
+    /**
+     * Return the list of parent.
+     * @param catalogName catalogName
+     * @param databaseName databaseName
+     * @param tableName tableName
+     * @return list of parent info dtos
+     */
+    @GET
+    @Path("parents/catalog/{catalog-name}/database/{database-name}/table/{table-name}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    Set<ParentInfoDto> getParents(
         @PathParam("catalog-name")
         String catalogName,
         @PathParam("database-name")

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/converter/ConverterUtil.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/converter/ConverterUtil.java
@@ -33,7 +33,8 @@ import com.netflix.metacat.common.dto.PartitionsSaveResponseDto;
 import com.netflix.metacat.common.dto.Sort;
 import com.netflix.metacat.common.dto.StorageDto;
 import com.netflix.metacat.common.dto.TableDto;
-import com.netflix.metacat.common.dto.notifications.ChildInfoDto;
+import com.netflix.metacat.common.dto.ChildInfoDto;
+import com.netflix.metacat.common.dto.ParentInfoDto;
 import com.netflix.metacat.common.server.connectors.ConnectorRequestContext;
 import com.netflix.metacat.common.server.connectors.model.AuditInfo;
 import com.netflix.metacat.common.server.connectors.model.CatalogInfo;
@@ -48,6 +49,7 @@ import com.netflix.metacat.common.server.connectors.model.PartitionsSaveResponse
 import com.netflix.metacat.common.server.connectors.model.StorageInfo;
 import com.netflix.metacat.common.server.connectors.model.TableInfo;
 import com.netflix.metacat.common.server.model.ChildInfo;
+import com.netflix.metacat.common.server.model.ParentInfo;
 import lombok.NonNull;
 import org.dozer.CustomConverter;
 import org.dozer.DozerBeanMapper;
@@ -286,5 +288,15 @@ public class ConverterUtil {
      */
     public ChildInfoDto toChildInfoDto(final ChildInfo childInfo) {
         return mapper.map(childInfo, ChildInfoDto.class);
+    }
+
+    /**
+     * Convert ParentInfo to ParentInfoDto.
+     *
+     * @param parentInfo parentInfo
+     * @return parentInfo dto
+     */
+    public ParentInfoDto toParentInfoDto(final ParentInfo parentInfo) {
+        return mapper.map(parentInfo, ParentInfoDto.class);
     }
 }

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/Config.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/Config.java
@@ -635,5 +635,12 @@ public interface Config {
      * @return True if it should be.
      */
     boolean isParentChildDropEnabled();
+
+    /**
+     * Get the parentChildRelationshipProperties config.
+     *
+     * @return parentChildRelationshipProperties
+     */
+    ParentChildRelationshipProperties getParentChildRelationshipProperties();
 }
 

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/Config.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/Config.java
@@ -607,5 +607,33 @@ public interface Config {
      * @return True if it should be.
      */
     boolean shouldFetchOnlyMetadataLocationEnabled();
+
+    /**
+     * Whether we allow parent child relationship to be created.
+     *
+     * @return True if it should be.
+     */
+    boolean isParentChildCreateEnabled();
+
+    /**
+     * Whether we allow renaming parent child relationship.
+     *
+     * @return True if it should be.
+     */
+    boolean isParentChildRenameEnabled();
+
+    /**
+     * Whether we allow getting parent child relationship in the getTable call.
+     *
+     * @return True if it should be.
+     */
+    boolean isParentChildGetEnabled();
+
+    /**
+     * Whether we allow dropping tables that are either parent or child.
+     *
+     * @return True if it should be.
+     */
+    boolean isParentChildDropEnabled();
 }
 

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/DefaultConfigImpl.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/DefaultConfigImpl.java
@@ -681,21 +681,26 @@ public class DefaultConfigImpl implements Config {
 
     @Override
     public boolean isParentChildCreateEnabled() {
-        return this.metacatProperties.getParentChildRelationshipProperties().isParentChildCreateEnabled();
+        return this.metacatProperties.getParentChildRelationshipProperties().isCreateEnabled();
     }
 
     @Override
     public boolean isParentChildRenameEnabled() {
-        return this.metacatProperties.getParentChildRelationshipProperties().isParentChildRenameEnabled();
+        return this.metacatProperties.getParentChildRelationshipProperties().isRenameEnabled();
     }
 
     @Override
     public boolean isParentChildGetEnabled() {
-        return this.metacatProperties.getParentChildRelationshipProperties().isParentChildGetEnabled();
+        return this.metacatProperties.getParentChildRelationshipProperties().isGetEnabled();
     }
 
     @Override
     public boolean isParentChildDropEnabled() {
-        return this.metacatProperties.getParentChildRelationshipProperties().isParentChildDropEnabled();
+        return this.metacatProperties.getParentChildRelationshipProperties().isDropEnabled();
+    }
+
+    @Override
+    public ParentChildRelationshipProperties getParentChildRelationshipProperties() {
+        return this.metacatProperties.getParentChildRelationshipProperties();
     }
 }

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/DefaultConfigImpl.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/DefaultConfigImpl.java
@@ -678,4 +678,24 @@ public class DefaultConfigImpl implements Config {
     public boolean shouldFetchOnlyMetadataLocationEnabled() {
         return this.metacatProperties.getHive().getIceberg().isShouldFetchOnlyMetadataLocationEnabled();
     }
+
+    @Override
+    public boolean isParentChildCreateEnabled() {
+        return this.metacatProperties.getParentChildRelationshipProperties().isParentChildCreateEnabled();
+    }
+
+    @Override
+    public boolean isParentChildRenameEnabled() {
+        return this.metacatProperties.getParentChildRelationshipProperties().isParentChildRenameEnabled();
+    }
+
+    @Override
+    public boolean isParentChildGetEnabled() {
+        return this.metacatProperties.getParentChildRelationshipProperties().isParentChildGetEnabled();
+    }
+
+    @Override
+    public boolean isParentChildDropEnabled() {
+        return this.metacatProperties.getParentChildRelationshipProperties().isParentChildDropEnabled();
+    }
 }

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/MetacatProperties.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/MetacatProperties.java
@@ -18,6 +18,7 @@
 package com.netflix.metacat.common.server.properties;
 
 import lombok.NonNull;
+import org.springframework.core.env.Environment;
 
 /**
  * Entry point to entire property tree of Metacat namespace.
@@ -27,6 +28,8 @@ import lombok.NonNull;
  */
 @lombok.Data
 public class MetacatProperties {
+    @NonNull
+    private Environment env;
     @NonNull
     private Data data = new Data();
     @NonNull
@@ -68,6 +71,15 @@ public class MetacatProperties {
     @NonNull
     private RateLimiterProperties rateLimiterProperties = new RateLimiterProperties();
     @NonNull
-    private ParentChildRelationshipProperties parentChildRelationshipProperties
-        = new ParentChildRelationshipProperties();
+    private ParentChildRelationshipProperties parentChildRelationshipProperties;
+
+    /**
+     * Constructor for MetacatProperties.
+     *
+     * @param env Spring Environment
+     */
+    public MetacatProperties(final Environment env) {
+        this.env = env;
+        this.parentChildRelationshipProperties = new ParentChildRelationshipProperties(env);
+    }
 }

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/MetacatProperties.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/MetacatProperties.java
@@ -67,4 +67,7 @@ public class MetacatProperties {
     private AliasServiceProperties aliasServiceProperties = new AliasServiceProperties();
     @NonNull
     private RateLimiterProperties rateLimiterProperties = new RateLimiterProperties();
+    @NonNull
+    private ParentChildRelationshipProperties parentChildRelationshipProperties
+        = new ParentChildRelationshipProperties();
 }

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/ParentChildRelationshipProperties.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/ParentChildRelationshipProperties.java
@@ -1,6 +1,14 @@
 package com.netflix.metacat.common.server.properties;
 
 import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.env.Environment;
+
+import javax.annotation.Nullable;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Parent Child Relationship service properties.
@@ -8,9 +16,104 @@ import lombok.Data;
  * @author yingjianw
  */
 @Data
+@Slf4j
 public class ParentChildRelationshipProperties {
-    private boolean parentChildCreateEnabled = true;
-    private boolean parentChildGetEnabled = true;
-    private boolean parentChildRenameEnabled = true;
-    private boolean parentChildDropEnabled = true;
+    private boolean createEnabled = true;
+    private boolean getEnabled = true;
+    private boolean renameEnabled = true;
+    private boolean dropEnabled = true;
+    private int maxAllow = 5;
+    private Map<String, Map<String, Integer>> maxAllowPerTablePerRelType = new HashMap<>();
+    private Map<String, Map<String, Integer>> maxAllowPerDBPerRelType = new HashMap<>();
+    private Map<String, Integer> defaultMaxAllowPerRelType = new HashMap<>();
+    private String maxAllowPerTablePerRelPropertyName =
+        "metacat.parentChildRelationshipProperties.maxAllowPerTablePerRelConfig";
+    private String maxAllowPerDBPerRelPropertyName =
+        "metacat.parentChildRelationshipProperties.maxAllowPerDBPerRelConfig";
+    private String defaultMaxAllowPerRelPropertyName =
+        "metacat.parentChildRelationshipProperties.defaultMaxAllowPerRelConfig";
+
+    /**
+     * Constructor.
+     *
+     * @param env Spring environment
+     */
+    public ParentChildRelationshipProperties(@Nullable final Environment env) {
+        if (env != null) {
+            setMaxAllowPerTablePerRelType(
+                env.getProperty(maxAllowPerTablePerRelPropertyName, String.class, "")
+            );
+            setMaxAllowPerDBPerRelType(
+                env.getProperty(maxAllowPerDBPerRelPropertyName, String.class, "")
+            );
+            setDefaultMaxAllowPerRelType(
+                env.getProperty(defaultMaxAllowPerRelPropertyName, String.class, "")
+            );
+        }
+    }
+
+    /**
+     * setMaxAllowPerTablePerRelType based on String config.
+     *
+     * @param  configStr configString
+     */
+    public void setMaxAllowPerTablePerRelType(@Nullable final String configStr) {
+        if (configStr == null || configStr.isEmpty()) {
+            return;
+        }
+        try {
+            this.maxAllowPerTablePerRelType = parseNestedConfigString(configStr);
+        } catch (Exception e) {
+            log.error("Fail to apply configStr = {} for maxAllowPerTablePerRelType", configStr, e);
+        }
+    }
+
+    /**
+     * setMaxAllowPerDBPerRelType based on String config.
+     *
+     * @param  configStr configString
+     */
+    public void setMaxAllowPerDBPerRelType(@Nullable final String configStr) {
+        if (configStr == null || configStr.isEmpty()) {
+            return;
+        }
+        try {
+            this.maxAllowPerDBPerRelType = parseNestedConfigString(configStr);
+        } catch (Exception e) {
+            log.error("Fail to apply configStr = {} for maxCloneAllowPerDBPerRelType", configStr);
+        }
+    }
+    /**
+     * setMaxCloneAllowPerDBPerRelType based on String config.
+     *
+     * @param  configStr configString
+     */
+    public void setDefaultMaxAllowPerRelType(@Nullable final String configStr) {
+        if (configStr == null || configStr.isEmpty()) {
+            return;
+        }
+        try {
+            this.defaultMaxAllowPerRelType =
+                Arrays.stream(configStr.split(";"))
+                    .map(entry -> entry.split(","))
+                    .collect(Collectors.toMap(
+                        parts -> parts[0],
+                        parts -> Integer.parseInt(parts[1])
+                    ));
+        } catch (Exception e) {
+            log.error("Fail to apply configStr = {} for defaultMaxAllowPerRelType", configStr);
+        }
+    }
+
+    private Map<String, Map<String, Integer>> parseNestedConfigString(final String configStr) {
+        return Arrays.stream(configStr.split(";"))
+            .map(entry -> entry.split(","))
+            .collect(Collectors.groupingBy(
+                parts -> parts[0],
+                Collectors.toMap(
+                    parts -> parts[1],
+                    parts -> Integer.parseInt(parts[2])
+                )
+            ));
+    }
 }

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/ParentChildRelationshipProperties.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/ParentChildRelationshipProperties.java
@@ -18,20 +18,20 @@ import java.util.stream.Collectors;
 @Data
 @Slf4j
 public class ParentChildRelationshipProperties {
-    private boolean createEnabled = true;
-    private boolean getEnabled = true;
-    private boolean renameEnabled = true;
-    private boolean dropEnabled = true;
+    private static final String MAX_ALLOW_PER_TABLE_PER_REL_PROPERTY_NAME =
+        "metacat.parentChildRelationshipProperties.maxAllowPerTablePerRelConfig";
+    private static final String MAX_ALLOW_PER_DB_PER_REL_PROPERTY_NAME =
+        "metacat.parentChildRelationshipProperties.maxAllowPerDBPerRelConfig";
+    private static final String DEFAULT_MAX_ALLOW_PER_REL_PROPERTY_NAME =
+        "metacat.parentChildRelationshipProperties.defaultMaxAllowPerRelConfig";
+    private boolean createEnabled;
+    private boolean getEnabled;
+    private boolean renameEnabled;
+    private boolean dropEnabled;
     private int maxAllow = 5;
     private Map<String, Map<String, Integer>> maxAllowPerTablePerRelType = new HashMap<>();
     private Map<String, Map<String, Integer>> maxAllowPerDBPerRelType = new HashMap<>();
     private Map<String, Integer> defaultMaxAllowPerRelType = new HashMap<>();
-    private String maxAllowPerTablePerRelPropertyName =
-        "metacat.parentChildRelationshipProperties.maxAllowPerTablePerRelConfig";
-    private String maxAllowPerDBPerRelPropertyName =
-        "metacat.parentChildRelationshipProperties.maxAllowPerDBPerRelConfig";
-    private String defaultMaxAllowPerRelPropertyName =
-        "metacat.parentChildRelationshipProperties.defaultMaxAllowPerRelConfig";
 
     /**
      * Constructor.
@@ -41,13 +41,13 @@ public class ParentChildRelationshipProperties {
     public ParentChildRelationshipProperties(@Nullable final Environment env) {
         if (env != null) {
             setMaxAllowPerTablePerRelType(
-                env.getProperty(maxAllowPerTablePerRelPropertyName, String.class, "")
+                env.getProperty(MAX_ALLOW_PER_TABLE_PER_REL_PROPERTY_NAME, String.class, "")
             );
             setMaxAllowPerDBPerRelType(
-                env.getProperty(maxAllowPerDBPerRelPropertyName, String.class, "")
+                env.getProperty(MAX_ALLOW_PER_DB_PER_REL_PROPERTY_NAME, String.class, "")
             );
             setDefaultMaxAllowPerRelType(
-                env.getProperty(defaultMaxAllowPerRelPropertyName, String.class, "")
+                env.getProperty(DEFAULT_MAX_ALLOW_PER_REL_PROPERTY_NAME, String.class, "")
             );
         }
     }

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/ParentChildRelationshipProperties.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/ParentChildRelationshipProperties.java
@@ -1,0 +1,16 @@
+package com.netflix.metacat.common.server.properties;
+
+import lombok.Data;
+
+/**
+ * Parent Child Relationship service properties.
+ *
+ * @author yingjianw
+ */
+@Data
+public class ParentChildRelationshipProperties {
+    private boolean parentChildCreateEnabled = true;
+    private boolean parentChildGetEnabled = true;
+    private boolean parentChildRenameEnabled = true;
+    private boolean parentChildDropEnabled = true;
+}

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/usermetadata/ParentChildRelMetadataService.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/usermetadata/ParentChildRelMetadataService.java
@@ -103,4 +103,18 @@ public interface ParentChildRelMetadataService {
     Set<ChildInfoDto> getChildrenDto(
         QualifiedName name
     );
+
+    /**
+     * return whether the table is a parent.
+     * @param tableName tableName
+     * @return true if it exists
+     */
+    boolean isParentTable(final QualifiedName tableName);
+
+    /**
+     * return whether the table is a child.
+     * @param tableName tableName
+     * @return true if it exists
+     */
+    boolean isChildTable(final QualifiedName tableName);
 }

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/usermetadata/ParentChildRelMetadataService.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/usermetadata/ParentChildRelMetadataService.java
@@ -1,6 +1,7 @@
 package com.netflix.metacat.common.server.usermetadata;
 import com.netflix.metacat.common.QualifiedName;
-import com.netflix.metacat.common.dto.notifications.ChildInfoDto;
+import com.netflix.metacat.common.dto.ChildInfoDto;
+import com.netflix.metacat.common.dto.ParentInfoDto;
 import com.netflix.metacat.common.server.model.ChildInfo;
 import com.netflix.metacat.common.server.model.ParentInfo;
 
@@ -98,11 +99,18 @@ public interface ParentChildRelMetadataService {
     /**
      * get the set of children dto for the input name.
      * @param name name
-     * @return a set of ChildInfo
+     * @return a set of ChildInfo dto
      */
     Set<ChildInfoDto> getChildrenDto(
         QualifiedName name
     );
+
+    /**
+     * get the set of parent dto for the input name.
+     * @param name name
+     * @return a set of parentInfo dto
+     */
+    Set<ParentInfoDto> getParentsDto(QualifiedName name);
 
     /**
      * return whether the table is a parent.

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/usermetadata/ParentChildRelMetadataService.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/usermetadata/ParentChildRelMetadataService.java
@@ -4,6 +4,7 @@ import com.netflix.metacat.common.dto.ChildInfoDto;
 import com.netflix.metacat.common.dto.ParentInfoDto;
 import com.netflix.metacat.common.server.model.ChildInfo;
 import com.netflix.metacat.common.server.model.ParentInfo;
+import com.netflix.metacat.common.server.properties.ParentChildRelationshipProperties;
 
 import java.util.Set;
 
@@ -25,13 +26,15 @@ public interface ParentChildRelMetadataService {
      * @param childName     the name of the child entity
      * @param childUUID     the uuid of the child
      * @param relationType  the type of the relationship
+     * @param prop          properties config
      */
     void createParentChildRelation(
         QualifiedName parentName,
         String parentUUID,
         QualifiedName childName,
         String childUUID,
-        String relationType
+        String relationType,
+        ParentChildRelationshipProperties prop
     );
 
     /**

--- a/metacat-common/src/main/java/com/netflix/metacat/common/dto/ChildInfoDto.java
+++ b/metacat-common/src/main/java/com/netflix/metacat/common/dto/ChildInfoDto.java
@@ -1,0 +1,30 @@
+package com.netflix.metacat.common.dto;
+
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+/**
+ * ChildInfo dto information.
+ */
+@SuppressWarnings("unused")
+@Data
+@EqualsAndHashCode(callSuper = false)
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ChildInfoDto extends BaseDto {
+    private static final long serialVersionUID = 9121109874202088789L;
+    /* Name of the child */
+    @ApiModelProperty(value = "name of the child")
+    private String name;
+    /* Type of the relation */
+    @ApiModelProperty(value = "type of the relation")
+    private String relationType;
+    /* uuid of the table */
+    @ApiModelProperty(value = "uuid of the table")
+    private String uuid;
+}

--- a/metacat-common/src/main/java/com/netflix/metacat/common/dto/ParentInfoDto.java
+++ b/metacat-common/src/main/java/com/netflix/metacat/common/dto/ParentInfoDto.java
@@ -1,6 +1,5 @@
-package com.netflix.metacat.common.dto.notifications;
+package com.netflix.metacat.common.dto;
 
-import com.netflix.metacat.common.dto.BaseDto;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -9,7 +8,7 @@ import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
 /**
- * ChildInfo information.
+ * ParentInfo dto information.
  */
 @SuppressWarnings("unused")
 @Data
@@ -17,9 +16,9 @@ import lombok.NoArgsConstructor;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class ChildInfoDto extends BaseDto {
-    private static final long serialVersionUID = 9121109874202088789L;
-    /* Name of the child */
+public class ParentInfoDto extends BaseDto {
+    private static final long serialVersionUID = 8121239864203088788L;
+    /* Name of the parent */
     @ApiModelProperty(value = "name of the child")
     private String name;
     /* Type of the relation */

--- a/metacat-connector-polaris/src/test/java/com/netflix/metacat/connector/polaris/PolarisConnectorDatabaseServiceTest.java
+++ b/metacat-connector-polaris/src/test/java/com/netflix/metacat/connector/polaris/PolarisConnectorDatabaseServiceTest.java
@@ -65,7 +65,7 @@ public class PolarisConnectorDatabaseServiceTest {
     @BeforeEach
     public void init() {
         connectorContext = new ConnectorContext(CATALOG_NAME, CATALOG_NAME, "polaris",
-            new DefaultConfigImpl(new MetacatProperties()), new NoopRegistry(), null,  Maps.newHashMap());
+            new DefaultConfigImpl(new MetacatProperties(null)), new NoopRegistry(), null,  Maps.newHashMap());
         polarisDBService = new PolarisConnectorDatabaseService(polarisStoreService, connectorContext);
     }
 

--- a/metacat-connector-polaris/src/test/java/com/netflix/metacat/connector/polaris/PolarisConnectorTableServiceTest.java
+++ b/metacat-connector-polaris/src/test/java/com/netflix/metacat/connector/polaris/PolarisConnectorTableServiceTest.java
@@ -33,6 +33,7 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.env.Environment;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -75,6 +76,9 @@ public class PolarisConnectorTableServiceTest {
     @Shared
     private PolarisConnectorTableService polarisTableService;
 
+    @Shared
+    private Environment env = Mockito.mock(Environment.class);
+
     /**
      * Initialization.
      */
@@ -83,7 +87,7 @@ public class PolarisConnectorTableServiceTest {
         final String location = "file://temp";
         polarisStoreService.createDatabase(DB_NAME, location, "metacat_user");
         connectorContext = new ConnectorContext(CATALOG_NAME, CATALOG_NAME, "polaris",
-            new DefaultConfigImpl(new MetacatProperties()), new NoopRegistry(), null,  Maps.newHashMap());
+            new DefaultConfigImpl(new MetacatProperties(null)), new NoopRegistry(), null,  Maps.newHashMap());
         polarisDBService = new PolarisConnectorDatabaseService(polarisStoreService, connectorContext);
         polarisTableService = new PolarisConnectorTableService(
             polarisStoreService,

--- a/metacat-functional-tests/metacat-test-cluster/docker-compose.yml
+++ b/metacat-functional-tests/metacat-test-cluster/docker-compose.yml
@@ -73,7 +73,11 @@ services:
                 -Dmetacat.table.delete.noDeleteOnTags=do_not_drop,iceberg_migration_do_not_modify
                 -Dmetacat.table.rename.noRenameOnTags=do_not_rename,iceberg_migration_do_not_modify
                 -Dmetacat.table.update.noUpdateOnTags=iceberg_migration_do_not_modify
-                -Dmetacat.event.updateIcebergTablePostEventEnabled=true'
+                -Dmetacat.event.updateIcebergTablePostEventEnabled=true
+                -Dmetacat.parentChildRelationshipProperties.createEnabled=true
+                -Dmetacat.parentChildRelationshipProperties.getEnabled=true
+                -Dmetacat.parentChildRelationshipProperties.renameEnabled=true
+                -Dmetacat.parentChildRelationshipProperties.dropEnabled=true'
         labels:
           - "com.netflix.metacat.oss.test"
           - "com.netflix.metacat.oss.test.war"

--- a/metacat-functional-tests/src/functionalTest/groovy/com/netflix/metacat/MetacatSmokeSpec.groovy
+++ b/metacat-functional-tests/src/functionalTest/groovy/com/netflix/metacat/MetacatSmokeSpec.groovy
@@ -24,7 +24,6 @@ import com.netflix.metacat.client.api.PartitionV1
 import com.netflix.metacat.client.api.TagV1
 import com.netflix.metacat.common.QualifiedName
 import com.netflix.metacat.common.dto.*
-import com.netflix.metacat.common.dto.notifications.ChildInfoDto
 import com.netflix.metacat.common.exception.MetacatAlreadyExistsException
 import com.netflix.metacat.common.exception.MetacatBadRequestException
 import com.netflix.metacat.common.exception.MetacatNotFoundException
@@ -2050,6 +2049,7 @@ class MetacatSmokeSpec extends Specification {
         // Test Parent 1 parentChildInfo
         assert parent1Table.definitionMetadata.get("parentChildRelationInfo").get("isParent").booleanValue()
         assert parentChildRelV1.getChildren(catalogName, databaseName, parent1) == [new ChildInfoDto("embedded-fast-hive-metastore/iceberg_db/child11", "CLONE", "c11_uuid")] as Set
+        assert parentChildRelV1.getParents(catalogName, databaseName, parent1).isEmpty()
 
         // Test Child11 parentChildInfo
         assert !child11Table.definitionMetadata.get("parentChildRelationInfo").has("isParent")
@@ -2057,6 +2057,7 @@ class MetacatSmokeSpec extends Specification {
         JSONAssert.assertEquals(child11Table.definitionMetadata.get("parentChildRelationInfo").toString(),
             '{"parentInfos":[{"name":"embedded-fast-hive-metastore/iceberg_db/parent1","relationType":"CLONE", "uuid":"p1_uuid"}]}',
             false)
+        assert parentChildRelV1.getParents(catalogName, databaseName, child11) == [new ParentInfoDto("embedded-fast-hive-metastore/iceberg_db/parent1", "CLONE", "p1_uuid")] as Set
         assert parentChildRelV1.getChildren(catalogName, databaseName, child11).isEmpty()
 
         /*
@@ -2078,6 +2079,7 @@ class MetacatSmokeSpec extends Specification {
         assert parentChildRelV1.getChildren(catalogName, databaseName, parent1) == [
             new ChildInfoDto("embedded-fast-hive-metastore/iceberg_db/child11", "CLONE", "c11_uuid"),
         ] as Set
+        assert parentChildRelV1.getParents(catalogName, databaseName, parent1).isEmpty()
         // Test Child11 parentChildInfo
         assert !child11Table.definitionMetadata.get("parentChildRelationInfo").has("isParent")
         assert child11Table.definitionMetadata.get("random_key").asText() == "random_value"
@@ -2085,6 +2087,7 @@ class MetacatSmokeSpec extends Specification {
             '{"parentInfos":[{"name":"embedded-fast-hive-metastore/iceberg_db/parent1","relationType":"CLONE", "uuid":"p1_uuid"}]}',
             false)
         assert parentChildRelV1.getChildren(catalogName, databaseName, child11).isEmpty()
+        assert parentChildRelV1.getParents(catalogName, databaseName, child11) == [new ParentInfoDto("embedded-fast-hive-metastore/iceberg_db/parent1", "CLONE", "p1_uuid")] as Set
 
         /*
         Step 3: create another table with the same child1 name but different uuid under the same parent should fail
@@ -2146,6 +2149,7 @@ class MetacatSmokeSpec extends Specification {
         // Test Parent 1 parentChildInfo
         assert parent1Table.definitionMetadata.get("parentChildRelationInfo").get("isParent").booleanValue()
         assert parentChildRelV1.getChildren(catalogName, databaseName, parent1) == [new ChildInfoDto("embedded-fast-hive-metastore/iceberg_db/child11", "CLONE", "c11_uuid")] as Set
+        assert parentChildRelV1.getParents(catalogName, databaseName, parent1).isEmpty()
 
         // Test Child11 parentChildInfo
         assert !child11Table.definitionMetadata.get("parentChildRelationInfo").has("isParent")
@@ -2154,6 +2158,7 @@ class MetacatSmokeSpec extends Specification {
             '{"parentInfos":[{"name":"embedded-fast-hive-metastore/iceberg_db/parent1","relationType":"CLONE", "uuid":"p1_uuid"}]}',
             false)
         assert parentChildRelV1.getChildren(catalogName, databaseName, child11).isEmpty()
+        assert parentChildRelV1.getParents(catalogName, databaseName, child11) == [new ParentInfoDto("embedded-fast-hive-metastore/iceberg_db/parent1", "CLONE", "p1_uuid")] as Set
 
 
         /*
@@ -2174,6 +2179,7 @@ class MetacatSmokeSpec extends Specification {
             new ChildInfoDto("embedded-fast-hive-metastore/iceberg_db/child11", "CLONE", "c11_uuid"),
             new ChildInfoDto("embedded-fast-hive-metastore/iceberg_db/child12", "CLONE", "c12_uuid")
         ] as Set
+        assert parentChildRelV1.getParents(catalogName, databaseName, parent1).isEmpty()
 
         // Test Child12 parentChildInfo
         assert !child12Table.definitionMetadata.get("parentChildRelationInfo").has("isParent")
@@ -2181,6 +2187,7 @@ class MetacatSmokeSpec extends Specification {
             '{"parentInfos":[{"name":"embedded-fast-hive-metastore/iceberg_db/parent1","relationType":"CLONE","uuid":"p1_uuid"}]}',
             false)
         assert parentChildRelV1.getChildren(catalogName, databaseName, child12).isEmpty()
+        assert parentChildRelV1.getParents(catalogName, databaseName, child12) == [new ParentInfoDto("embedded-fast-hive-metastore/iceberg_db/parent1", "CLONE", "p1_uuid")] as Set
 
         /*
         Step 8: create a parent table on top of another parent table should fail
@@ -2229,12 +2236,14 @@ class MetacatSmokeSpec extends Specification {
         assert parentChildRelV1.getChildren(catalogName, databaseName, parent2) == [
             new ChildInfoDto("embedded-fast-hive-metastore/iceberg_db/child21", "CLONE", "c21_uuid")
         ] as Set
+        assert parentChildRelV1.getParents(catalogName, databaseName, parent2).isEmpty()
 
         // Test Child21 parentChildInfo
         JSONAssert.assertEquals(child21Table.definitionMetadata.get("parentChildRelationInfo").toString(),
             '{"parentInfos":[{"name":"embedded-fast-hive-metastore/iceberg_db/parent2","relationType":"CLONE","uuid":"p2_uuid"}]}',
             false)
         assert parentChildRelV1.getChildren(catalogName, databaseName, child21).isEmpty()
+        assert parentChildRelV1.getParents(catalogName, databaseName, child21) == [new ParentInfoDto("embedded-fast-hive-metastore/iceberg_db/parent2", "CLONE", "p2_uuid")] as Set
 
         /*
         Step 11: Create a table newParent1 without any parent child rel info
@@ -2261,6 +2270,7 @@ class MetacatSmokeSpec extends Specification {
             new ChildInfoDto("embedded-fast-hive-metastore/iceberg_db/child11", "CLONE", "c11_uuid"),
             new ChildInfoDto("embedded-fast-hive-metastore/iceberg_db/child12", "CLONE", "c12_uuid")
         ] as Set
+        assert parentChildRelV1.getParents(catalogName, databaseName, parent1).isEmpty()
         // Test Child11 parentChildInfo
         assert !child11Table.definitionMetadata.get("parentChildRelationInfo").has("isParent")
         assert child11Table.definitionMetadata.get("random_key").asText() == "random_value"
@@ -2268,12 +2278,14 @@ class MetacatSmokeSpec extends Specification {
             '{"parentInfos":[{"name":"embedded-fast-hive-metastore/iceberg_db/parent1","relationType":"CLONE", "uuid":"p1_uuid"}]}',
             false)
         assert parentChildRelV1.getChildren(catalogName, databaseName, child11).isEmpty()
+        assert parentChildRelV1.getParents(catalogName, databaseName, child11) == [new ParentInfoDto("embedded-fast-hive-metastore/iceberg_db/parent1", "CLONE", "p1_uuid")] as Set
         // Test Child12 parentChildInfo
         assert !child12Table.definitionMetadata.get("parentChildRelationInfo").has("isParent")
         JSONAssert.assertEquals(child12Table.definitionMetadata.get("parentChildRelationInfo").toString(),
             '{"parentInfos":[{"name":"embedded-fast-hive-metastore/iceberg_db/parent1","relationType":"CLONE","uuid":"p1_uuid"}]}',
             false)
         assert parentChildRelV1.getChildren(catalogName, databaseName, child12).isEmpty()
+        assert parentChildRelV1.getParents(catalogName, databaseName, child12) == [new ParentInfoDto("embedded-fast-hive-metastore/iceberg_db/parent1", "CLONE", "p1_uuid")] as Set
 
         /*
          Step 12: Attempt to rename parent1 to parent2 which has parent child relationship and should fail
@@ -2298,6 +2310,7 @@ class MetacatSmokeSpec extends Specification {
             new ChildInfoDto("embedded-fast-hive-metastore/iceberg_db/child11", "CLONE", "c11_uuid"),
             new ChildInfoDto("embedded-fast-hive-metastore/iceberg_db/child12", "CLONE", "c12_uuid")
         ] as Set
+        assert parentChildRelV1.getParents(catalogName, databaseName, parent1).isEmpty()
         // Test Child11 parentChildInfo
         assert !child11Table.definitionMetadata.get("parentChildRelationInfo").has("isParent")
         assert child11Table.definitionMetadata.get("random_key").asText() == "random_value"
@@ -2305,6 +2318,7 @@ class MetacatSmokeSpec extends Specification {
             '{"parentInfos":[{"name":"embedded-fast-hive-metastore/iceberg_db/parent1","relationType":"CLONE", "uuid":"p1_uuid"}]}',
             false)
         assert parentChildRelV1.getChildren(catalogName, databaseName, child11).isEmpty()
+        assert parentChildRelV1.getParents(catalogName, databaseName, child11) == [new ParentInfoDto("embedded-fast-hive-metastore/iceberg_db/parent1", "CLONE", "p1_uuid")] as Set
         // Test Child12 parentChildInfo
         assert !child12Table.definitionMetadata.get("parentChildRelationInfo").has("isParent")
         JSONAssert.assertEquals(child12Table.definitionMetadata.get("parentChildRelationInfo").toString(),
@@ -2321,6 +2335,7 @@ class MetacatSmokeSpec extends Specification {
             '{"parentInfos":[{"name":"embedded-fast-hive-metastore/iceberg_db/parent2","relationType":"CLONE","uuid":"p2_uuid"}]}',
             false)
         assert parentChildRelV1.getChildren(catalogName, databaseName, child21).isEmpty()
+        assert parentChildRelV1.getParents(catalogName, databaseName, child12) == [new ParentInfoDto("embedded-fast-hive-metastore/iceberg_db/parent1", "CLONE", "p1_uuid")] as Set
 
 
         /*
@@ -2341,12 +2356,14 @@ class MetacatSmokeSpec extends Specification {
                 new ChildInfoDto("embedded-fast-hive-metastore/iceberg_db/child11", "CLONE", "c11_uuid"),
                 new ChildInfoDto("embedded-fast-hive-metastore/iceberg_db/child12", "CLONE", "c12_uuid")
             ] as Set
+        assert parentChildRelV1.getParents(catalogName, databaseName, renameParent1).isEmpty()
         // Test Child11 parentChildInfo
         assert !child11Table.definitionMetadata.get("parentChildRelationInfo").has("isParent")
         JSONAssert.assertEquals(child11Table.definitionMetadata.get("parentChildRelationInfo").toString(),
             '{"parentInfos":[{"name":"embedded-fast-hive-metastore/iceberg_db/rename_parent1","relationType":"CLONE","uuid":"p1_uuid"}]}',
             false)
         assert parentChildRelV1.getChildren(catalogName, databaseName, child11).isEmpty()
+        assert parentChildRelV1.getParents(catalogName, databaseName, child11) == [new ParentInfoDto("embedded-fast-hive-metastore/iceberg_db/rename_parent1", "CLONE", "p1_uuid")] as Set
 
         // Test Child12 parentChildInfo
         assert !child12Table.definitionMetadata.get("parentChildRelationInfo").has("isParent")
@@ -2354,6 +2371,7 @@ class MetacatSmokeSpec extends Specification {
             '{"parentInfos":[{"name":"embedded-fast-hive-metastore/iceberg_db/rename_parent1","relationType":"CLONE","uuid":"p1_uuid"}]}',
             false)
         assert parentChildRelV1.getChildren(catalogName, databaseName, child12).isEmpty()
+        assert parentChildRelV1.getParents(catalogName, databaseName, child12) == [new ParentInfoDto("embedded-fast-hive-metastore/iceberg_db/rename_parent1", "CLONE", "p1_uuid")] as Set
 
         //get the parent oldName should fail as it no longer exists
         when:
@@ -2387,12 +2405,14 @@ class MetacatSmokeSpec extends Specification {
                 new ChildInfoDto("embedded-fast-hive-metastore/iceberg_db/child11", "CLONE", "c11_uuid"),
                 new ChildInfoDto("embedded-fast-hive-metastore/iceberg_db/child12", "CLONE", "c12_uuid")
             ] as Set
+        assert parentChildRelV1.getParents(catalogName, databaseName, renameParent1).isEmpty()
         // Test Child11 parentChildInfo
         assert !child11Table.definitionMetadata.get("parentChildRelationInfo").has("isParent")
         JSONAssert.assertEquals(child11Table.definitionMetadata.get("parentChildRelationInfo").toString(),
             '{"parentInfos":[{"name":"embedded-fast-hive-metastore/iceberg_db/rename_parent1","relationType":"CLONE","uuid":"p1_uuid"}]}',
             false)
         assert parentChildRelV1.getChildren(catalogName, databaseName, child11).isEmpty()
+        assert parentChildRelV1.getParents(catalogName, databaseName, child11) == [new ParentInfoDto("embedded-fast-hive-metastore/iceberg_db/rename_parent1", "CLONE", "p1_uuid")] as Set
 
         // Test Child12 parentChildInfo
         assert !child12Table.definitionMetadata.get("parentChildRelationInfo").has("isParent")
@@ -2400,6 +2420,7 @@ class MetacatSmokeSpec extends Specification {
             '{"parentInfos":[{"name":"embedded-fast-hive-metastore/iceberg_db/rename_parent1","relationType":"CLONE","uuid":"p1_uuid"}]}',
             false)
         assert parentChildRelV1.getChildren(catalogName, databaseName, child12).isEmpty()
+        assert parentChildRelV1.getParents(catalogName, databaseName, child12) == [new ParentInfoDto("embedded-fast-hive-metastore/iceberg_db/rename_parent1", "CLONE", "p1_uuid")] as Set
 
         /*
         Step 15: Create a table renameChild11 with parent childInfo and then try to rename child11 to renameChild11, which should fail
@@ -2430,24 +2451,28 @@ class MetacatSmokeSpec extends Specification {
                 new ChildInfoDto("embedded-fast-hive-metastore/iceberg_db/child12", "CLONE", "c12_uuid"),
                 new ChildInfoDto("embedded-fast-hive-metastore/iceberg_db/rename_child11", "CLONE", "random_uuid")
             ] as Set
+        assert parentChildRelV1.getParents(catalogName, databaseName, renameParent1).isEmpty()
         // Test Child11 parentChildInfo
         assert !child11Table.definitionMetadata.get("parentChildRelationInfo").has("isParent")
         JSONAssert.assertEquals(child11Table.definitionMetadata.get("parentChildRelationInfo").toString(),
             '{"parentInfos":[{"name":"embedded-fast-hive-metastore/iceberg_db/rename_parent1","relationType":"CLONE","uuid":"p1_uuid"}]}',
             false)
         assert parentChildRelV1.getChildren(catalogName, databaseName, child11).isEmpty()
+        assert parentChildRelV1.getParents(catalogName, databaseName, child11) == [new ParentInfoDto("embedded-fast-hive-metastore/iceberg_db/rename_parent1", "CLONE", "p1_uuid")] as Set
         // Test Child12 parentChildInfo
         assert !child12Table.definitionMetadata.get("parentChildRelationInfo").has("isParent")
         JSONAssert.assertEquals(child12Table.definitionMetadata.get("parentChildRelationInfo").toString(),
             '{"parentInfos":[{"name":"embedded-fast-hive-metastore/iceberg_db/rename_parent1","relationType":"CLONE","uuid":"p1_uuid"}]}',
             false)
         assert parentChildRelV1.getChildren(catalogName, databaseName, child12).isEmpty()
+        assert parentChildRelV1.getParents(catalogName, databaseName, child12) == [new ParentInfoDto("embedded-fast-hive-metastore/iceberg_db/rename_parent1", "CLONE", "p1_uuid")] as Set
         // Test renameChild11Table parentChildInfo
         assert !renameChild11Table.definitionMetadata.get("parentChildRelationInfo").has("isParent")
         JSONAssert.assertEquals(renameChild11Table.definitionMetadata.get("parentChildRelationInfo").toString(),
             '{"parentInfos":[{"name":"embedded-fast-hive-metastore/iceberg_db/rename_parent1","relationType":"CLONE","uuid":"p1_uuid"}]}',
             false)
         assert parentChildRelV1.getChildren(catalogName, databaseName, renameChild11).isEmpty()
+        assert parentChildRelV1.getParents(catalogName, databaseName, renameChild11) == [new ParentInfoDto("embedded-fast-hive-metastore/iceberg_db/rename_parent1", "CLONE", "p1_uuid")] as Set
 
 
         /*
@@ -2466,6 +2491,7 @@ class MetacatSmokeSpec extends Specification {
             new ChildInfoDto("embedded-fast-hive-metastore/iceberg_db/rename_child11", "CLONE", "c11_uuid"),
             new ChildInfoDto("embedded-fast-hive-metastore/iceberg_db/child12", "CLONE", "c12_uuid")
         ] as Set
+        assert parentChildRelV1.getParents(catalogName, databaseName, renameParent1).isEmpty()
         // Test Child11 parentChildInfo with newName
         assert !child11Table.definitionMetadata.get("parentChildRelationInfo").has("isParent")
         assert child11Table.definitionMetadata.get("random_key").asText() == "random_value"
@@ -2473,6 +2499,7 @@ class MetacatSmokeSpec extends Specification {
             '{"parentInfos":[{"name":"embedded-fast-hive-metastore/iceberg_db/rename_parent1","relationType":"CLONE","uuid":"p1_uuid"}]}',
             false)
         assert parentChildRelV1.getChildren(catalogName, databaseName, renameChild11).isEmpty()
+        assert parentChildRelV1.getParents(catalogName, databaseName, renameChild11) == [new ParentInfoDto("embedded-fast-hive-metastore/iceberg_db/rename_parent1", "CLONE", "p1_uuid")] as Set
 
         //get the child oldName should fail as it no longer exists
         when:
@@ -2504,6 +2531,7 @@ class MetacatSmokeSpec extends Specification {
         assert parentChildRelV1.getChildren(catalogName, databaseName, renameParent1) == [
             new ChildInfoDto("embedded-fast-hive-metastore/iceberg_db/child12", "CLONE", "c12_uuid")
         ] as Set
+        assert parentChildRelV1.getParents(catalogName, databaseName, renameParent1).isEmpty()
 
         /*
         Step 19: Create renameChild11 and should expect random_key should appear at it is reattached
@@ -2518,13 +2546,14 @@ class MetacatSmokeSpec extends Specification {
         then:
         assert !child11Table.definitionMetadata.has("parentChildRelationInfo")
         assert child11Table.definitionMetadata.get("random_key").asText() == "random_value"
-        assert parentChildRelV1.getChildren(catalogName, databaseName, child11).isEmpty()
-
+        assert parentChildRelV1.getChildren(catalogName, databaseName, renameChild11).isEmpty()
+        assert parentChildRelV1.getParents(catalogName, databaseName, renameChild11).isEmpty()
         // Test parent1 Table still only have child12
         assert parent1Table.definitionMetadata.get("parentChildRelationInfo").get("isParent").booleanValue()
         assert parentChildRelV1.getChildren(catalogName, databaseName, renameParent1) == [
             new ChildInfoDto("embedded-fast-hive-metastore/iceberg_db/child12", "CLONE", "c12_uuid")
         ] as Set
+        assert parentChildRelV1.getParents(catalogName, databaseName, renameParent1).isEmpty()
 
         /*
         Step 20: Drop child12 should succeed
@@ -2535,6 +2564,7 @@ class MetacatSmokeSpec extends Specification {
         then:
         assert !parent1Table.definitionMetadata.has("parentChildRelationInfo")
         assert parentChildRelV1.getChildren(catalogName, databaseName, renameParent1).isEmpty()
+        assert parentChildRelV1.getParents(catalogName, databaseName, renameParent1).isEmpty()
 
         /*
         Step 21: Drop renameParent1 should succeed as there is no more child under it
@@ -2545,6 +2575,9 @@ class MetacatSmokeSpec extends Specification {
         child21Table = api.getTable(catalogName, databaseName, child21, true, true, false)
 
         then:
+        //Since renameParent1 table is dropped
+        assert parentChildRelV1.getChildren(catalogName, databaseName, renameParent1).isEmpty()
+        assert parentChildRelV1.getParents(catalogName, databaseName, renameParent1).isEmpty()
         // Since all the operations above are on the first connected relationship, the second connected relationship
         // should remain the same
         // Test Parent 2 parentChildInfo
@@ -2552,6 +2585,7 @@ class MetacatSmokeSpec extends Specification {
         assert parentChildRelV1.getChildren(catalogName, databaseName, parent2) == [
             new ChildInfoDto("embedded-fast-hive-metastore/iceberg_db/child21", "CLONE", "c21_uuid")
         ] as Set
+        assert parentChildRelV1.getParents(catalogName, databaseName, parent2).isEmpty()
 
         // Test Child21 parentChildInfo
         assert !child21Table.definitionMetadata.get("parentChildRelationInfo").has("isParent")
@@ -2559,6 +2593,7 @@ class MetacatSmokeSpec extends Specification {
             '{"parentInfos":[{"name":"embedded-fast-hive-metastore/iceberg_db/parent2","relationType":"CLONE","uuid":"p2_uuid"}]}',
             false)
         assert parentChildRelV1.getChildren(catalogName, databaseName, child21).isEmpty()
+        assert parentChildRelV1.getParents(catalogName, databaseName, child21) == [new ParentInfoDto("embedded-fast-hive-metastore/iceberg_db/parent2", "CLONE", "p2_uuid")] as Set
 
         /*
         Step 22: update parent2 with random parentChildRelationInfo to test immutability
@@ -2575,13 +2610,14 @@ class MetacatSmokeSpec extends Specification {
         assert parentChildRelV1.getChildren(catalogName, databaseName, parent2) == [
             new ChildInfoDto("embedded-fast-hive-metastore/iceberg_db/child21", "CLONE", "c21_uuid")
         ] as Set
-
+        assert parentChildRelV1.getParents(catalogName, databaseName, parent2).isEmpty()
         // Test Child21 parentChildInfo
         assert !child21Table.definitionMetadata.get("parentChildRelationInfo").has("isParent")
         JSONAssert.assertEquals(child21Table.definitionMetadata.get("parentChildRelationInfo").toString(),
             '{"parentInfos":[{"name":"embedded-fast-hive-metastore/iceberg_db/parent2","relationType":"CLONE","uuid":"p2_uuid"}]}',
             false)
         assert parentChildRelV1.getChildren(catalogName, databaseName, child21).isEmpty()
+        assert parentChildRelV1.getParents(catalogName, databaseName, child21) == [new ParentInfoDto("embedded-fast-hive-metastore/iceberg_db/parent2", "CLONE", "p2_uuid")] as Set
 
         /*
         Step 23: update child21 with random parentChildRelationInfo to test immutability
@@ -2599,6 +2635,7 @@ class MetacatSmokeSpec extends Specification {
         assert parentChildRelV1.getChildren(catalogName, databaseName, parent2) == [
             new ChildInfoDto("embedded-fast-hive-metastore/iceberg_db/child21", "CLONE", "c21_uuid")
         ] as Set
+        assert parentChildRelV1.getParents(catalogName, databaseName, parent2).isEmpty()
 
         // Test Child21 parentChildInfo
         assert !child21Table.definitionMetadata.get("parentChildRelationInfo").has("isParent")
@@ -2606,5 +2643,6 @@ class MetacatSmokeSpec extends Specification {
             '{"parentInfos":[{"name":"embedded-fast-hive-metastore/iceberg_db/parent2","relationType":"CLONE","uuid":"p2_uuid"}]}',
             false)
         assert parentChildRelV1.getChildren(catalogName, databaseName, child21).isEmpty()
+        assert parentChildRelV1.getParents(catalogName, databaseName, child21) == [new ParentInfoDto("embedded-fast-hive-metastore/iceberg_db/parent2", "CLONE", "p2_uuid")] as Set
     }
 }

--- a/metacat-functional-tests/src/functionalTest/groovy/com/netflix/metacat/ParentChildRelMetadataServiceSpec.groovy
+++ b/metacat-functional-tests/src/functionalTest/groovy/com/netflix/metacat/ParentChildRelMetadataServiceSpec.groovy
@@ -67,10 +67,14 @@ class ParentChildRelMetadataServiceSpec extends Specification{
         // Test Parent
         assert service.getParents(parent).isEmpty()
         assert service.getChildren(parent) == parent_children_expected
+        assert !service.isChildTable(parent)
+        assert service.isParentTable(parent)
 
         // Test Child
         assert service.getParents(child) == child_parent_expected
         assert service.getParents(child) == child_parent_expected
+        assert service.isChildTable(child)
+        assert !service.isParentTable(child)
 
         when:
         service.deleteParentChildRelation(parent, parentUUID, child, childUUID, type)
@@ -79,10 +83,14 @@ class ParentChildRelMetadataServiceSpec extends Specification{
         // Test Parent
         assert service.getParents(parent).isEmpty()
         assert service.getChildren(parent).isEmpty()
+        assert !service.isChildTable(parent)
+        assert !service.isParentTable(parent)
 
         // Test Child
         assert service.getParents(child).isEmpty()
         assert service.getParents(child).isEmpty()
+        assert !service.isChildTable(parent)
+        assert !service.isParentTable(parent)
 
     }
 
@@ -109,14 +117,19 @@ class ParentChildRelMetadataServiceSpec extends Specification{
         // Test Parent
         assert service.getParents(parent).isEmpty()
         assert parent_children_expected == service.getChildren(parent)
+        assert !service.isChildTable(parent)
+        assert service.isParentTable(parent)
 
         // Test Children
-        // Test Child 1
         assert child_parent_expected == service.getParents(child1)
         assert service.getChildren(child1).isEmpty()
+        assert service.isChildTable(child1)
+        assert !service.isParentTable(child1)
 
         assert child_parent_expected == service.getParents(child2)
         assert service.getChildren(child2).isEmpty()
+        assert service.isChildTable(child2)
+        assert !service.isParentTable(child2)
     }
 
     def "Test Create - oneChildMultiParentException"() {
@@ -141,6 +154,8 @@ class ParentChildRelMetadataServiceSpec extends Specification{
         def child_parent_expected = [new ParentInfo(parent1.toString(), type, parent1UUID)] as Set
         assert child_parent_expected == service.getParents(child)
         assert service.getChildren(child).isEmpty()
+        assert service.isChildTable(child)
+        assert !service.isParentTable(child)
     }
 
     def "Test Create - oneChildAsParentOfAnotherException"() {
@@ -165,6 +180,8 @@ class ParentChildRelMetadataServiceSpec extends Specification{
         def child_parent_expected = [new ParentInfo(parent.toString(), type, parentUUID)] as Set
         assert service.getParents(child) == child_parent_expected
         assert service.getChildren(child).isEmpty()
+        assert service.isChildTable(child)
+        assert !service.isParentTable(child)
     }
 
     def "Test Create - oneParentAsChildOfAnother"() {
@@ -203,16 +220,22 @@ class ParentChildRelMetadataServiceSpec extends Specification{
         // Test Old Parent Name
         assert service.getParents(parent).isEmpty()
         assert service.getChildren(parent).isEmpty()
+        assert !service.isChildTable(parent)
+        assert !service.isParentTable(parent)
 
         // Test New Parent Name
         assert service.getParents(newParent).isEmpty()
         def newParent_children_expected = [new ChildInfo(child.toString(), type, childUUID)] as Set
         assert service.getChildren(newParent) == newParent_children_expected
+        assert !service.isChildTable(newParent)
+        assert service.isParentTable(newParent)
 
         // Test Child
         def child_parent_expected = [new ParentInfo(newParent.toString(), type, parentUUID)] as Set
         assert child_parent_expected == service.getParents(child)
         assert service.getChildren(child).isEmpty()
+        assert service.isChildTable(child)
+        assert !service.isParentTable(child)
 
         // rename back
         when:
@@ -223,14 +246,20 @@ class ParentChildRelMetadataServiceSpec extends Specification{
         // Test new Parent Name
         assert service.getParents(newParent).isEmpty()
         assert service.getChildren(newParent).isEmpty()
+        assert !service.isChildTable(newParent)
+        assert !service.isParentTable(newParent)
 
         // Test old Parent Name
         assert service.getParents(parent).isEmpty()
         assert service.getChildren(parent) == newParent_children_expected
+        assert !service.isChildTable(parent)
+        assert service.isParentTable(parent)
 
         // Test Child
         assert child_parent_expected == service.getParents(child)
         assert service.getChildren(child).isEmpty()
+        assert service.isChildTable(child)
+        assert !service.isParentTable(child)
     }
 
     def "Test Rename Parent - Multi Child"() {
@@ -251,10 +280,31 @@ class ParentChildRelMetadataServiceSpec extends Specification{
         service.rename(parent, newParent)
 
         then:
+        // Test Old Parent Name
+        assert service.getParents(parent).isEmpty()
+        assert service.getChildren(parent).isEmpty()
+        assert !service.isChildTable(parent)
+        assert !service.isParentTable(parent)
+
+        // Test New Parent Name
+        assert service.getParents(newParent).isEmpty()
+        def newParent_children_expected = [
+            new ChildInfo(child1.toString(), type, child1UUID),
+            new ChildInfo(child2.toString(), type, child2UUID),
+        ] as Set
+        assert service.getChildren(newParent) == newParent_children_expected
+        assert !service.isChildTable(newParent)
+        assert service.isParentTable(newParent)
+
+        then:
         // Test Child1
         assert service.getParents(child1) == child_parent_expected
+        assert service.isChildTable(child1)
+        assert !service.isParentTable(child1)
         //Test Child2
         assert service.getParents(child2) == child_parent_expected
+        assert service.isChildTable(child1)
+        assert !service.isParentTable(child1)
     }
 
     def "Test Rename Child"() {
@@ -274,15 +324,21 @@ class ParentChildRelMetadataServiceSpec extends Specification{
         assert service.getParents(parent).isEmpty()
         def parent_children_expected  = [new ChildInfo(newChild.toString(), type, childUUID)] as Set
         assert parent_children_expected == service.getChildren(parent)
+        assert !service.isChildTable(parent)
+        assert service.isParentTable(parent)
 
-        // Test Child
+        // Test old Child
         assert service.getParents(child).isEmpty()
         assert service.getChildren(child).isEmpty()
+        assert !service.isChildTable(child)
+        assert !service.isParentTable(child)
 
         // Test New Child
         def child_parent_expected = [new ParentInfo(parent.toString(), type, parentUUID)] as Set
         assert child_parent_expected == service.getParents(newChild)
         assert service.getChildren(child).isEmpty()
+        assert service.isChildTable(newChild)
+        assert !service.isParentTable(newChild)
 
         // rename back
         when:
@@ -293,14 +349,20 @@ class ParentChildRelMetadataServiceSpec extends Specification{
         // Test Parent
         assert service.getParents(parent).isEmpty()
         assert parent_children_expected == service.getChildren(parent)
+        assert !service.isChildTable(parent)
+        assert service.isParentTable(parent)
 
         // Test New Child
         assert service.getParents(newChild).isEmpty()
         assert service.getChildren(newChild).isEmpty()
+        assert !service.isChildTable(newChild)
+        assert !service.isParentTable(newChild)
 
         // Test Child
         assert child_parent_expected == service.getParents(child)
         assert service.getChildren(child).isEmpty()
+        assert service.isChildTable(child)
+        assert !service.isParentTable(child)
     }
 
 
@@ -319,10 +381,14 @@ class ParentChildRelMetadataServiceSpec extends Specification{
         // Test Parent
         assert service.getParents(parent).isEmpty()
         assert service.getChildren(parent).isEmpty()
+        assert !service.isChildTable(parent)
+        assert !service.isParentTable(parent)
 
         // Test Child
         assert service.getParents(child).isEmpty()
         assert service.getChildren(child).isEmpty()
+        assert !service.isChildTable(child)
+        assert !service.isParentTable(child)
     }
 
     def "Test Rename and Drop Child"() {
@@ -343,13 +409,76 @@ class ParentChildRelMetadataServiceSpec extends Specification{
         // Test Parent
         assert service.getParents(parent).isEmpty()
         assert service.getChildren(parent).isEmpty()
+        assert !service.isChildTable(parent)
+        assert !service.isParentTable(parent)
 
         // Test Child
         assert service.getParents(child).isEmpty()
         assert service.getChildren(child).isEmpty()
+        assert !service.isChildTable(child)
+        assert !service.isParentTable(child)
 
         // Test newChild
         assert service.getParents(newChild).isEmpty()
         assert service.getChildren(newChild).isEmpty()
+        assert !service.isChildTable(newChild)
+        assert !service.isParentTable(newChild)
+    }
+
+    def "rename to an existing tableName in parent child relationship service"() {
+        setup:
+        def parent1 = QualifiedName.ofTable(catalog, database, "p1")
+        def parent1UUID = "p_uuid1"
+        def parent2 = QualifiedName.ofTable(catalog, database, "p2")
+        def parent2UUID = "p_uuid2"
+        def child1 = QualifiedName.ofTable(catalog, database, "c1")
+        def child1UUID = "c1_uuid"
+        def child2 = QualifiedName.ofTable(catalog, database, "c2")
+        def child2UUID = "c2_uuid"
+        def type = "clone";
+        service.createParentChildRelation(parent1, parent1UUID, child1, child1UUID, type)
+        service.createParentChildRelation(parent2, parent2UUID, child2, child2UUID, type)
+        def child1Parent = [new ParentInfo(parent1.toString(), type, parent1UUID)] as Set
+        def parent1Children = [new ChildInfo(child1.toString(), type, child1UUID)] as Set
+        def child2Parent = [new ParentInfo(parent2.toString(), type, parent2UUID)] as Set
+        def parent2Children = [new ChildInfo(child2.toString(), type, child2UUID)] as Set
+
+        // rename to an existing parent
+        when:
+        service.rename(parent1, parent2)
+        then:
+        def e = thrown(Exception)
+        assert e.message.contains("is already a parent table")
+
+        // rename to an existing child
+        when:
+        service.rename(child2, child1)
+        then:
+        e = thrown(Exception)
+        assert e.message.contains("is already a child table")
+
+        //Test p1
+        assert service.getParents(parent1).isEmpty()
+        assert service.getChildren(parent1) == parent1Children
+        assert !service.isChildTable(parent1)
+        assert service.isParentTable(parent1)
+
+        //Test c1
+        assert service.getParents(child1) == child1Parent
+        assert service.getChildren(child1).isEmpty()
+        assert service.isChildTable(child1)
+        assert !service.isParentTable(child1)
+
+        //Test p2
+        assert service.getParents(parent2).isEmpty()
+        assert service.getChildren(parent2) == parent2Children
+        assert !service.isChildTable(parent2)
+        assert service.isParentTable(parent2)
+
+        //Test c2
+        assert service.getParents(child2) == child2Parent
+        assert service.getChildren(child2).isEmpty()
+        assert service.isChildTable(child2)
+        assert !service.isParentTable(child2)
     }
 }

--- a/metacat-main/src/main/java/com/netflix/metacat/main/api/v1/ParentChildRelController.java
+++ b/metacat-main/src/main/java/com/netflix/metacat/main/api/v1/ParentChildRelController.java
@@ -1,7 +1,8 @@
 package com.netflix.metacat.main.api.v1;
 
 import com.netflix.metacat.common.QualifiedName;
-import com.netflix.metacat.common.dto.notifications.ChildInfoDto;
+import com.netflix.metacat.common.dto.ChildInfoDto;
+import com.netflix.metacat.common.dto.ParentInfoDto;
 import com.netflix.metacat.common.server.usermetadata.ParentChildRelMetadataService;
 import com.netflix.metacat.main.api.RequestWrapper;
 import io.swagger.annotations.Api;
@@ -68,6 +69,37 @@ public class ParentChildRelController {
         return this.requestWrapper.processRequest(
             "ParentChildRelV1Resource.getChildren",
             () -> this.parentChildRelMetadataService.getChildrenDto(
+                QualifiedName.ofTable(catalogName, databaseName, tableName)
+            )
+        );
+    }
+
+    /**
+     * Return the list of children for a given table.
+     * @param catalogName catalogName
+     * @param databaseName databaseName
+     * @param tableName tableName
+     * @return list of childInfoDto
+     */
+    @RequestMapping(method = RequestMethod.GET,
+        path = "/parents/catalog/{catalog-name}/database/{database-name}/table/{table-name}")
+    @ResponseStatus(HttpStatus.OK)
+    @ApiOperation(
+        position = 1,
+        value = "Returns the parents",
+        notes = "Returns the parents"
+    )
+    public Set<ParentInfoDto> getParents(
+        @ApiParam(value = "The name of the catalog", required = true)
+        @PathVariable("catalog-name") final String catalogName,
+        @ApiParam(value = "The name of the database", required = true)
+        @PathVariable("database-name") final String databaseName,
+        @ApiParam(value = "The name of the table", required = true)
+        @PathVariable("table-name") final String tableName
+    ) {
+        return this.requestWrapper.processRequest(
+            "ParentChildRelV1Resource.getParents",
+            () -> this.parentChildRelMetadataService.getParentsDto(
                 QualifiedName.ofTable(catalogName, databaseName, tableName)
             )
         );

--- a/metacat-main/src/main/java/com/netflix/metacat/main/configs/PropertiesConfig.java
+++ b/metacat-main/src/main/java/com/netflix/metacat/main/configs/PropertiesConfig.java
@@ -23,6 +23,7 @@ import com.netflix.metacat.common.server.properties.MetacatProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
 
 /**
  * Configuration for binding Metacat properties.
@@ -36,12 +37,13 @@ public class PropertiesConfig {
     /**
      * Static properties bindings.
      *
+     * @param env Spring environment
      * @return The metacat properties.
      */
     @Bean
     @ConfigurationProperties("metacat")
-    public MetacatProperties metacatProperties() {
-        return new MetacatProperties();
+    public MetacatProperties metacatProperties(final Environment env) {
+        return new MetacatProperties(env);
     }
 
     /**

--- a/metacat-main/src/main/java/com/netflix/metacat/main/services/impl/TableServiceImpl.java
+++ b/metacat-main/src/main/java/com/netflix/metacat/main/services/impl/TableServiceImpl.java
@@ -195,26 +195,26 @@ public class TableServiceImpl implements TableService {
 
                 String parentName;
                 if (!parentChildRelInfo.has(ParentChildRelMetadataConstants.PARENT_NAME)) {
-                    throw new RuntimeException("parent name is not specified");
+                    throw new IllegalArgumentException("parent name is not specified");
                 }
                 parentName = parentChildRelInfo.path(ParentChildRelMetadataConstants.PARENT_NAME)
                     .asText();
                 final QualifiedName parent = QualifiedName.fromString(parentName);
                 validate(parent);
                 if (!exists(parent)) {
-                    throw new RuntimeException("Parent Table:" + parent + " does not exist");
+                    throw new IllegalArgumentException("Parent Table:" + parent + " does not exist");
                 }
 
                 // fetch parent and child uuid
                 String parentUUID;
                 String childUUID;
                 if (!parentChildRelInfo.has(ParentChildRelMetadataConstants.PARENT_UUID)) {
-                    throw new RuntimeException("parent_table_uuid is not specified for parent table="
+                    throw new IllegalArgumentException("parent_table_uuid is not specified for parent table="
                             + parentName);
                 }
 
                 if (!parentChildRelInfo.has(ParentChildRelMetadataConstants.CHILD_UUID)) {
-                    throw new RuntimeException("child_table_uuid is not specified for child table=" + child);
+                    throw new IllegalArgumentException("child_table_uuid is not specified for child table=" + child);
                 }
                 parentUUID = parentChildRelInfo.path(ParentChildRelMetadataConstants.PARENT_UUID).asText();
                 childUUID = parentChildRelInfo.path(ParentChildRelMetadataConstants.CHILD_UUID).asText();
@@ -229,7 +229,7 @@ public class TableServiceImpl implements TableService {
 
                 // Create parent child relationship
                 parentChildRelMetadataService.createParentChildRelation(parent, parentUUID,
-                    child, childUUID, relationType);
+                    child, childUUID, relationType, config.getParentChildRelationshipProperties());
 
                 // Return a Runnable for deleting the relationship
                 return Optional.of(() -> {

--- a/metacat-main/src/test/groovy/com/netflix/metacat/main/services/impl/TableServiceImplSpec.groovy
+++ b/metacat-main/src/test/groovy/com/netflix/metacat/main/services/impl/TableServiceImplSpec.groovy
@@ -274,7 +274,7 @@ class TableServiceImplSpec extends Specification {
         0 * ownerValidationService.enforceOwnerValidation(_, _, _)
     }
 
-    def "Test Create - Clone Table Fail to create table"() {
+    def "Mock Parent Child Relationship Create"() {
         given:
         def childTableName = QualifiedName.ofTable("clone", "clone", "c")
         def parentTableName = QualifiedName.ofTable("clone", "clone", "p")
@@ -292,9 +292,11 @@ class TableServiceImplSpec extends Specification {
             definitionMetadata: outerNode,
             serde: new StorageDto(uri: 's3:/clone/clone/c')
         )
+        // mock case where create Table Fail and revert function is triggerred
         when:
         service.create(childTableName, createTableDto)
         then:
+        1 * config.isParentChildCreateEnabled() >> true
         1 * ownerValidationService.extractPotentialOwners(_) >> ["cloneClient"]
         1 * ownerValidationService.isUserValid(_) >> true
         1 * ownerValidationService.extractPotentialOwnerGroups(_) >> ["cloneClientGroup"]
@@ -304,44 +306,231 @@ class TableServiceImplSpec extends Specification {
         1 * connectorTableServiceProxy.create(_, _) >> {throw new RuntimeException("Fail to create")}
         1 * parentChildRelSvc.deleteParentChildRelation(parentTableName, "p_uuid", childTableName, "child_uuid", "CLONE")
         thrown(RuntimeException)
+
+        // mock case where parent child relationship creation is disabled
+        when:
+        service.create(childTableName, createTableDto)
+
+        then:
+        1 * config.isParentChildCreateEnabled() >> false
+        1 * ownerValidationService.extractPotentialOwners(_) >> ["cloneClient"]
+        1 * ownerValidationService.isUserValid(_) >> true
+        1 * ownerValidationService.extractPotentialOwnerGroups(_) >> ["cloneClientGroup"]
+        1 * ownerValidationService.isGroupValid(_) >> true
+
+        0 * parentChildRelSvc.createParentChildRelation(parentTableName, "p_uuid", childTableName, "child_uuid", "CLONE")
+        0 * connectorTableServiceProxy.create(_, _)
+        def e = thrown(RuntimeException)
+        assert e.message.contains("is currently disabled")
+
+        // mock successful case
+        when:
+        service.create(childTableName, createTableDto)
+        then:
+        1 * config.isParentChildCreateEnabled() >> true
+        1 * ownerValidationService.extractPotentialOwners(_) >> ["cloneClient"]
+        1 * ownerValidationService.isUserValid(_) >> true
+        1 * ownerValidationService.extractPotentialOwnerGroups(_) >> ["cloneClientGroup"]
+        1 * ownerValidationService.isGroupValid(_) >> true
+
+        1 * parentChildRelSvc.createParentChildRelation(parentTableName, "p_uuid", childTableName, "child_uuid", "CLONE")
+        1 * connectorTableServiceProxy.create(_, _)
+        0 * parentChildRelSvc.deleteParentChildRelation(parentTableName, "p_uuid", childTableName, "child_uuid", "CLONE")
+        noExceptionThrown()
     }
 
-    def "Test Rename - Clone Table Fail to update parent child relation"() {
+    def "Mock Parent Child Relationship Rename"() {
         given:
         def oldName = QualifiedName.ofTable("clone", "clone", "oldChild")
         def newName = QualifiedName.ofTable("clone", "clone", "newChild")
+        // mock when rename fail and revert happen
         when:
         service.rename(oldName, newName, false)
 
         then:
+        1 * config.isParentChildRenameEnabled() >> true
         1 * config.getNoTableRenameOnTags() >> []
         1 * parentChildRelSvc.rename(oldName, newName)
         1 * connectorTableServiceProxy.rename(oldName, newName, _) >> {throw new RuntimeException("Fail to rename")}
         1 * parentChildRelSvc.rename(newName, oldName)
         thrown(RuntimeException)
+
+        // mock when rename parent child relation is disabled and the table is a child table
+        when:
+        service.rename(oldName, newName, false)
+        then:
+        1 * config.getNoTableRenameOnTags() >> []
+        1 * config.isParentChildRenameEnabled() >> false
+        1 * parentChildRelSvc.isChildTable(oldName) >> true
+        0 * parentChildRelSvc.isParentTable(oldName)
+        0 * parentChildRelSvc.rename(oldName, newName)
+        0 * connectorTableServiceProxy.rename(oldName, newName, _)
+        def e = thrown(RuntimeException)
+        assert e.message.contains("is currently disabled")
+
+        // mock when rename parent child relation is disabled and the table is a parent table
+        when:
+        service.rename(oldName, newName, false)
+        then:
+        1 * config.getNoTableRenameOnTags() >> []
+        1 * config.isParentChildRenameEnabled() >> false
+        1 * parentChildRelSvc.isChildTable(oldName) >> false
+        1 * parentChildRelSvc.isParentTable(oldName) >> true
+        0 * parentChildRelSvc.rename(oldName, newName)
+        0 * connectorTableServiceProxy.rename(oldName, newName, _)
+        e = thrown(RuntimeException)
+        assert e.message.contains("is currently disabled")
+
+        // mock when rename parent child relation is disabled but the table is not a parent nor child table
+        when:
+        service.rename(oldName, newName, false)
+        then:
+        1 * config.getNoTableRenameOnTags() >> []
+        1 * config.isParentChildRenameEnabled() >> false
+        1 * parentChildRelSvc.isChildTable(oldName) >> false
+        1 * parentChildRelSvc.isParentTable(oldName) >> false
+        1 * parentChildRelSvc.rename(oldName, newName)
+        1 * connectorTableServiceProxy.rename(oldName, newName, _)
+        noExceptionThrown()
+
+        // mock normal success case
+        when:
+        service.rename(oldName, newName, false)
+        then:
+        1 * config.getNoTableRenameOnTags() >> []
+        1 * config.isParentChildRenameEnabled() >> true
+        0 * parentChildRelSvc.isChildTable(oldName)
+        0 * parentChildRelSvc.isParentTable(oldName)
+        1 * parentChildRelSvc.rename(oldName, newName)
+        1 * connectorTableServiceProxy.rename(oldName, newName, _)
+        noExceptionThrown()
     }
 
-    def "Test Drop - Clone Table Fail to drop parent child relation"() {
+    def "Mock Parent Child Relationship Drop"() {
         given:
         def name = QualifiedName.ofTable("clone", "clone", "child")
 
+        // drop a parent table that has child
         when:
         service.delete(name)
         then:
-        1 * parentChildRelSvc.getParents(name) >> {[new ParentInfo("parent", "clone", "parent_uuid")] as Set}
+        1 * config.isParentChildGetEnabled() >> true
+        1 * config.isParentChildDropEnabled() >> true
+        1 * parentChildRelSvc.getParents(name) >> {[] as Set}
         2 * parentChildRelSvc.getChildren(name) >> {[new ChildInfo("child", "clone", "child_uuid")] as Set}
         1 * config.getNoTableDeleteOnTags() >> []
-        thrown(RuntimeException)
+        def e = thrown(RuntimeException)
+        assert e.message.contains("because it still has")
 
+        // mock failure to drop the table, should not trigger deletion in parentChildRelSvc
         when:
         service.delete(name)
         then:
+        1 * config.isParentChildGetEnabled() >> true
+        1 * config.isParentChildDropEnabled() >> true
         1 * parentChildRelSvc.getParents(name)
         2 * parentChildRelSvc.getChildren(name)
         1 * config.getNoTableDeleteOnTags() >> []
         1 * connectorTableServiceProxy.delete(_) >> {throw new RuntimeException("Fail to drop")}
-        0 * parentChildRelSvc.drop(_, _)
+        0 * parentChildRelSvc.drop(_)
         thrown(RuntimeException)
+
+        // mock drop is not enabled and it is a child table
+        when:
+        service.delete(name)
+        then:
+        1 * config.isParentChildGetEnabled() >> true
+        1 * config.isParentChildDropEnabled() >> false
+        1 * parentChildRelSvc.isChildTable(name) >> true
+        0 * parentChildRelSvc.isParentTable(name)
+        1 * parentChildRelSvc.getParents(name)
+        1 * parentChildRelSvc.getChildren(name)
+        1 * config.getNoTableDeleteOnTags() >> []
+        0 * connectorTableServiceProxy.delete(_)
+        0 * parentChildRelSvc.drop(_)
+        e = thrown(RuntimeException)
+        assert e.message.contains("is currently disabled")
+
+        // mock drop is not enabled and it is a parent table
+        when:
+        service.delete(name)
+        then:
+        1 * config.isParentChildGetEnabled() >> true
+        1 * config.isParentChildDropEnabled() >> false
+        1 * parentChildRelSvc.isChildTable(name) >> false
+        1 * parentChildRelSvc.isParentTable(name) >> true
+        1 * parentChildRelSvc.getParents(name)
+        1 * parentChildRelSvc.getChildren(name)
+        1 * config.getNoTableDeleteOnTags() >> []
+        0 * connectorTableServiceProxy.delete(_)
+        0 * parentChildRelSvc.drop(_)
+        e = thrown(RuntimeException)
+        assert e.message.contains("is currently disabled")
+
+        // mock drop is not enabled and it is not a parent nor child table
+        // and it doesn't have any children
+        when:
+        service.delete(name)
+        then:
+        1 * config.isParentChildGetEnabled() >> true
+        1 * config.isParentChildDropEnabled() >> false
+        1 * parentChildRelSvc.isChildTable(name) >> false
+        1 * parentChildRelSvc.isParentTable(name) >> false
+        1 * parentChildRelSvc.getParents(name) >> {[] as Set}
+        2 * parentChildRelSvc.getChildren(name) >> {[] as Set}
+        1 * config.getNoTableDeleteOnTags() >> []
+        1 * connectorTableServiceProxy.delete(_)
+        1 * parentChildRelSvc.drop(_)
+        1 * config.canDeleteTableDefinitionMetadata() >> true
+        noExceptionThrown()
+
+        // mock normal successful case
+        when:
+        service.delete(name)
+        then:
+        1 * config.isParentChildGetEnabled() >> true
+        1 * config.isParentChildDropEnabled() >> true
+        0 * parentChildRelSvc.isChildTable(name)
+        0 * parentChildRelSvc.isParentTable(name)
+        1 * parentChildRelSvc.getParents(name) >> {[] as Set}
+        2 * parentChildRelSvc.getChildren(name) >> {[] as Set}
+        1 * config.getNoTableDeleteOnTags() >> []
+        1 * connectorTableServiceProxy.delete(_)
+        1 * parentChildRelSvc.drop(_)
+        1 * config.canDeleteTableDefinitionMetadata() >> true
+        noExceptionThrown()
+    }
+
+    def "Mock Parent Child Relationship Get"() {
+        when:
+        service.get(name,GetTableServiceParameters.builder().
+            disableOnReadMetadataIntercetor(false)
+            .includeDataMetadata(true)
+            .includeDefinitionMetadata(true)
+            .build())
+        then:
+        1 * connectorManager.getCatalogConfig(_) >> catalogConfig
+        1 * usermetadataService.getDefinitionMetadataWithInterceptor(_,_) >> Optional.empty()
+        1 * usermetadataService.getDataMetadata(_) >> Optional.empty()
+        0 * usermetadataService.getDefinitionMetadata(_) >> Optional.empty()
+        1 * config.isParentChildGetEnabled() >> false
+        0 * parentChildRelSvc.getParents(name)
+        0 * parentChildRelSvc.isParentTable(name)
+
+        when:
+        service.get(name,GetTableServiceParameters.builder().
+            disableOnReadMetadataIntercetor(false)
+            .includeDataMetadata(true)
+            .includeDefinitionMetadata(true)
+            .build())
+        then:
+        1 * connectorManager.getCatalogConfig(_) >> catalogConfig
+        1 * usermetadataService.getDefinitionMetadataWithInterceptor(_,_) >> Optional.empty()
+        1 * usermetadataService.getDataMetadata(_) >> Optional.empty()
+        0 * usermetadataService.getDefinitionMetadata(_) >> Optional.empty()
+        1 * config.isParentChildGetEnabled() >> true
+        1 * parentChildRelSvc.getParents(name)
+        1 * parentChildRelSvc.isParentTable(name)
     }
 
     def "Will not throw on Successful Table Update with Failed Get"() {

--- a/metacat-metadata-mysql/src/main/java/com/netflix/metacat/metadata/mysql/MySqlParentChildRelMetaDataService.java
+++ b/metacat-metadata-mysql/src/main/java/com/netflix/metacat/metadata/mysql/MySqlParentChildRelMetaDataService.java
@@ -6,6 +6,7 @@ import com.netflix.metacat.common.dto.ParentInfoDto;
 import com.netflix.metacat.common.server.converter.ConverterUtil;
 import com.netflix.metacat.common.server.model.ChildInfo;
 import com.netflix.metacat.common.server.model.ParentInfo;
+import com.netflix.metacat.common.server.properties.ParentChildRelationshipProperties;
 import com.netflix.metacat.common.server.usermetadata.ParentChildRelMetadataService;
 import com.netflix.metacat.common.server.usermetadata.ParentChildRelServiceException;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -18,11 +19,12 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.sql.PreparedStatement;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Map;
 import java.util.Set;
-import java.util.StringJoiner;
+import java.util.List;
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.StringJoiner;
 import java.util.stream.Collectors;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -68,6 +70,9 @@ public class MySqlParentChildRelMetaDataService implements ParentChildRelMetadat
     static final String SQL_GET_CHILDREN_UUIDS = "SELECT DISTINCT child_uuid FROM parent_child_relation "
         + "where child = ?";
 
+    static final String SQL_GET_CHILDREN_SIZE_PER_REL = "SELECT COUNT(*) FROM parent_child_relation "
+        + "where parent = ? and relation_type = ?";
+
     private final JdbcTemplate jdbcTemplate;
     private final ConverterUtil converterUtil;
 
@@ -83,12 +88,77 @@ public class MySqlParentChildRelMetaDataService implements ParentChildRelMetadat
         this.converterUtil = converterUtil;
     }
 
-    @Override
-    public void createParentChildRelation(final QualifiedName parentName,
-                                          final String parentUUID,
-                                          final QualifiedName childName,
-                                          final String childUUID,
-                                          final String type) {
+    private Integer getMaxAllowedFromNestedMap(
+        final QualifiedName parent,
+        final String relationType,
+        final Map<String, Map<String, Integer>> maxAllowPerResourcePerRelType,
+        final boolean isTable) {
+        Integer maxCloneAllow = null;
+        final Map<String, Integer> maxAllowPerResource = maxAllowPerResourcePerRelType.get(relationType);
+        if (maxAllowPerResource != null) {
+            if (isTable) {
+                maxCloneAllow = maxAllowPerResource.get(parent.toString());
+            } else {
+                maxCloneAllow = maxAllowPerResource.get(parent.getDatabaseName());
+            }
+        }
+        return maxCloneAllow;
+    }
+
+    private void validateMaxAllow(final QualifiedName parentName,
+                                  final String type,
+                                  final ParentChildRelationshipProperties props) {
+        // Validate max clone allow
+        // First check if the parent table have configured max allowed on the table config
+        Integer maxAllow = getMaxAllowedFromNestedMap(
+            parentName,
+            type,
+            props.getMaxAllowPerTablePerRelType(),
+            true
+        );
+
+        // Then check if the parent have configured max allowed on the db config
+        if (maxAllow == null) {
+            maxAllow = getMaxAllowedFromNestedMap(
+                parentName,
+                type,
+                props.getMaxAllowPerDBPerRelType(),
+                false
+            );
+        }
+
+        // If not specified in maxAllowPerDBPerRelType,check the default max Allow based on relationType
+        if (maxAllow == null) {
+            final Integer count = props.getDefaultMaxAllowPerRelType().get(type);
+            if (count != null) {
+                maxAllow = count;
+            }
+        }
+
+        // Finally fallback to the default value for all types
+        if (maxAllow == null) {
+            maxAllow = props.getMaxAllow();
+        }
+
+        // if maxAllow < 0, this means we can create as many child table under the parent
+        if (maxAllow < 0) {
+            return;
+        }
+
+        if (getChildrenCountPerType(parentName, type) >= maxAllow) {
+            final String errorMsg = String.format(
+                "Parent table: %s is not allow to have more than %s child table",
+                parentName, maxAllow);
+            throw new ParentChildRelServiceException(errorMsg);
+        }
+    }
+
+    private void validateCreate(final QualifiedName parentName,
+                                final String parentUUID,
+                                final QualifiedName childName,
+                                final String childUUID,
+                                final String type,
+                                final ParentChildRelationshipProperties props) {
         // Validation to prevent having a child have two parents
         final Set<ParentInfo> childParents = getParents(childName);
         if (!childParents.isEmpty()) {
@@ -120,6 +190,18 @@ public class MySqlParentChildRelMetaDataService implements ParentChildRelMetadat
         final Set<String> existingChildUuids = getExistingUUIDS(childName.toString());
         validateUUIDs(childName.toString(), existingChildUuids, childUUID, "Child");
 
+        // Validation to control how many children tables can be created per type
+        validateMaxAllow(parentName, type, props);
+    }
+
+    @Override
+    public void createParentChildRelation(final QualifiedName parentName,
+                                          final String parentUUID,
+                                          final QualifiedName childName,
+                                          final String childUUID,
+                                          final String type,
+                                          final ParentChildRelationshipProperties props) {
+        validateCreate(parentName, parentUUID, childName, childUUID, type, props);
         try {
             jdbcTemplate.update(connection -> {
                 final PreparedStatement ps = connection.prepareStatement(SQL_CREATE_PARENT_CHILD_RELATIONS);
@@ -370,4 +452,10 @@ public class MySqlParentChildRelMetaDataService implements ParentChildRelMetadat
         }
     }
 
+    private int getChildrenCountPerType(final QualifiedName parent, final String type) {
+        final List<Object> params = new ArrayList<>();
+        params.add(parent.toString());
+        params.add(type);
+        return jdbcTemplate.queryForObject(SQL_GET_CHILDREN_SIZE_PER_REL, params.toArray(), Integer.class);
+    }
 }

--- a/metacat-metadata-mysql/src/main/java/com/netflix/metacat/metadata/mysql/MySqlParentChildRelMetaDataService.java
+++ b/metacat-metadata-mysql/src/main/java/com/netflix/metacat/metadata/mysql/MySqlParentChildRelMetaDataService.java
@@ -147,8 +147,8 @@ public class MySqlParentChildRelMetaDataService implements ParentChildRelMetadat
 
         if (getChildrenCountPerType(parentName, type) >= maxAllow) {
             final String errorMsg = String.format(
-                "Parent table: %s is not allow to have more than %s child table",
-                parentName, maxAllow);
+                "Parent table: %s is not allow to have more than %s child table for %s relation type",
+                parentName, maxAllow, type);
             throw new ParentChildRelServiceException(errorMsg);
         }
     }

--- a/metacat-metadata-mysql/src/main/java/com/netflix/metacat/metadata/mysql/MySqlParentChildRelMetaDataService.java
+++ b/metacat-metadata-mysql/src/main/java/com/netflix/metacat/metadata/mysql/MySqlParentChildRelMetaDataService.java
@@ -1,7 +1,8 @@
 package com.netflix.metacat.metadata.mysql;
 
 import com.netflix.metacat.common.QualifiedName;
-import com.netflix.metacat.common.dto.notifications.ChildInfoDto;
+import com.netflix.metacat.common.dto.ChildInfoDto;
+import com.netflix.metacat.common.dto.ParentInfoDto;
 import com.netflix.metacat.common.server.converter.ConverterUtil;
 import com.netflix.metacat.common.server.model.ChildInfo;
 import com.netflix.metacat.common.server.model.ParentInfo;
@@ -291,6 +292,12 @@ public class MySqlParentChildRelMetaDataService implements ParentChildRelMetadat
     public Set<ChildInfoDto> getChildrenDto(final QualifiedName name) {
         return getChildren(name).stream()
             .map(converterUtil::toChildInfoDto).collect(Collectors.toSet());
+    }
+
+    @Override
+    public Set<ParentInfoDto> getParentsDto(final QualifiedName name) {
+        return getParents(name).stream()
+            .map(converterUtil::toParentInfoDto).collect(Collectors.toSet());
     }
 
     @Override

--- a/metacat-metadata-mysql/src/main/java/com/netflix/metacat/metadata/mysql/MySqlParentChildRelMetaDataService.java
+++ b/metacat-metadata-mysql/src/main/java/com/netflix/metacat/metadata/mysql/MySqlParentChildRelMetaDataService.java
@@ -61,8 +61,8 @@ public class MySqlParentChildRelMetaDataService implements ParentChildRelMetadat
     static final String SQL_GET_CHILDREN = "SELECT child, child_uuid, relation_type "
         + "FROM parent_child_relation WHERE parent = ?";
 
-    static final String SQL_IS_PARENT_TABLE = "SELECT 1 FROM parent_child_relation WHERE parent = ?";
-    static final String SQL_IS_CHILD_TABLE = "SELECT 1 FROM parent_child_relation WHERE child = ?";
+    static final String SQL_IS_PARENT_TABLE = "SELECT 1 FROM parent_child_relation WHERE parent = ? LIMIT 1";
+    static final String SQL_IS_CHILD_TABLE = "SELECT 1 FROM parent_child_relation WHERE child = ? LIMIT 1";
 
     static final String SQL_GET_PARENT_UUIDS = "SELECT DISTINCT parent_uuid FROM parent_child_relation "
         + "where parent = ?";


### PR DESCRIPTION
**First commit:**
1. Add a flag to controll the rollout in case there are any performance degradation or bug for each api call (create, rename, drop, get) that can touch the parent child relation service. This flag can also be used in the long run if we see performance degradation as we have more parent child relationship created and we can quickly block certain actions. 
2. Add a validation to make sure the parent name specified in the request actually exists in metacat
3. One bug fix on the rename side even though we are going to rewrite to use two phase commit idea in this pr https://github.com/Netflix/metacat/pull/600, which already handled this case. I have also added this case in our e2e test

More specifically the bug is:
- Supposed that we have childName = 'c' and parentName = 'p', and let's ignore uuid and clone type for example.
- Then we insert a new parent child relationship childName = 'nc' and parentName = 'p'
- So for now we have two records:
- 1. 'c' | 'p'
- 2. 'nc' | 'p'
- Then we rename 'c' to 'nc' because we always rename in parent child relationship first, and after the rename, the db will look something like
- 1. 'nc' | 'p'
- 2. 'nc' | 'p'
-  But it will fail later in the tableProxy as table 'nc' already and then if we revert back it will make all 2 records as 'c' | 'p'

**Second commit**
1. Add a validation during createTable to prevent creating a new record having the same name in the existing mysql db but uuid is different from that of the exiting one.

**Third commit**
1. Add a search endpoint for getParentsApi in case we need to block the get api and we can still have way to debug

**Forth commit**
1. Move out other parent child config out to keep all validation logic in the same place and also the config is general enough and doesn't need to be netflix specific

**Fifth commit**
Make all the flags to false by default