### PR TITLE
Configurable long timeout for metadata queries

### DIFF
--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/Config.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/Config.java
@@ -588,6 +588,13 @@ public interface Config {
     int getMetadataQueryTimeout();
 
     /**
+     * Long metadata query timeout in seconds, for longer running queries.
+     *
+     * @return Long metadata query timeout in seconds
+     */
+    int getLongMetadataQueryTimeout();
+
+    /**
      * Whether to check the existence of the iceberg metadata location before updating the table.
      *
      * @return Whether to check the existence of the iceberg metadata location before updating the table

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/Config.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/Config.java
@@ -588,9 +588,9 @@ public interface Config {
     int getMetadataQueryTimeout();
 
     /**
-     * Long metadata query timeout in seconds, for longer running queries.
+     * Metadata query timeout in seconds, for longer running queries.
      *
-     * @return Long metadata query timeout in seconds
+     * @return Metadata query timeout in seconds for longer running queries
      */
     int getLongMetadataQueryTimeout();
 

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/DefaultConfigImpl.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/DefaultConfigImpl.java
@@ -665,6 +665,11 @@ public class DefaultConfigImpl implements Config {
     }
 
     @Override
+    public int getLongMetadataQueryTimeout() {
+        return this.metacatProperties.getUsermetadata().getLongQueryTimeoutInSeconds();
+    }
+
+    @Override
     public boolean isIcebergPreviousMetadataLocationCheckEnabled() {
         return this.metacatProperties.getHive().getIceberg().isIcebergPreviousMetadataLocationCheckEnabled();
     }

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/UserMetadata.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/UserMetadata.java
@@ -31,6 +31,7 @@ public class UserMetadata {
     @NonNull
     private Config config = new Config();
     private int queryTimeoutInSeconds = 60;
+    private int longQueryTimeoutInSeconds = 120;
 
     /**
      * config related properties.

--- a/metacat-metadata-mysql/src/main/java/com/netflix/metacat/metadata/mysql/MySqlServiceUtil.java
+++ b/metacat-metadata-mysql/src/main/java/com/netflix/metacat/metadata/mysql/MySqlServiceUtil.java
@@ -19,6 +19,7 @@ import com.netflix.metacat.common.server.util.DataSourceManager;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 
+import javax.sql.DataSource;
 import java.io.InputStream;
 import java.net.URL;
 import java.nio.file.FileSystems;
@@ -80,6 +81,19 @@ public final class MySqlServiceUtil {
             throw new Exception(String.format("Unable to read from user metadata config file %s", configLocation), e);
         }
         dataSourceManager.load(UserMetadataService.NAME_DATASOURCE, connectionProperties);
+    }
+
+    /**
+     * Create a JDBC template with a query timeout.
+     *
+     * @param dataSource data source
+     * @param timeoutSec query timeout, in sec
+     * @return the JDBC template
+     */
+    public static JdbcTemplate createJdbcTemplate(final DataSource dataSource, final int timeoutSec) {
+        final JdbcTemplate result = new JdbcTemplate(dataSource);
+        result.setQueryTimeout(timeoutSec);
+        return result;
     }
 }
 

--- a/metacat-metadata-mysql/src/main/java/com/netflix/metacat/metadata/mysql/MySqlTagService.java
+++ b/metacat-metadata-mysql/src/main/java/com/netflix/metacat/metadata/mysql/MySqlTagService.java
@@ -105,24 +105,23 @@ public class MySqlTagService implements TagService {
     /**
      * Constructor.
      *
-     * @param config                  config
-     * @param jdbcTemplate            JDBC template
-     * @param jdbcTemplateLongTimeout JDBC template for longer running queries
-     * @param lookupService           lookup service
-     * @param metacatJson             json util
-     * @param userMetadataService     user metadata service
+     * @param config              config
+     * @param jdbcTemplate        JDBC template
+     * @param lookupService       lookup service
+     * @param metacatJson         json util
+     * @param userMetadataService user metadata service
      */
     public MySqlTagService(
         final Config config,
         final JdbcTemplate jdbcTemplate,
-        final JdbcTemplate jdbcTemplateLongTimeout,
         final LookupService lookupService,
         final MetacatJson metacatJson,
         final UserMetadataService userMetadataService
     ) {
         this.config = Preconditions.checkNotNull(config, "config is required");
         this.jdbcTemplate = jdbcTemplate;
-        this.jdbcTemplateLongTimeout = jdbcTemplateLongTimeout;
+        this.jdbcTemplateLongTimeout = MySqlServiceUtil.createJdbcTemplate(
+            jdbcTemplate.getDataSource(), config.getLongMetadataQueryTimeout());
         this.lookupService = Preconditions.checkNotNull(lookupService, "lookupService is required");
         this.metacatJson = Preconditions.checkNotNull(metacatJson, "metacatJson is required");
         this.userMetadataService = Preconditions.checkNotNull(userMetadataService, "userMetadataService is required");

--- a/metacat-metadata-mysql/src/main/java/com/netflix/metacat/metadata/mysql/MySqlTagService.java
+++ b/metacat-metadata-mysql/src/main/java/com/netflix/metacat/metadata/mysql/MySqlTagService.java
@@ -105,11 +105,12 @@ public class MySqlTagService implements TagService {
     /**
      * Constructor.
      *
-     * @param config              config
-     * @param jdbcTemplate        JDBC template
-     * @param lookupService       lookup service
-     * @param metacatJson         json util
-     * @param userMetadataService user metadata service
+     * @param config                  config
+     * @param jdbcTemplate            JDBC template
+     * @param jdbcTemplateLongTimeout JDBC template for longer running queries
+     * @param lookupService           lookup service
+     * @param metacatJson             json util
+     * @param userMetadataService     user metadata service
      */
     public MySqlTagService(
         final Config config,

--- a/metacat-metadata-mysql/src/main/java/com/netflix/metacat/metadata/mysql/MySqlUserMetadataConfig.java
+++ b/metacat-metadata-mysql/src/main/java/com/netflix/metacat/metadata/mysql/MySqlUserMetadataConfig.java
@@ -92,11 +92,12 @@ public class MySqlUserMetadataConfig {
     /**
      * The tag service to use.
      *
-     * @param jdbcTemplate        JDBC template
-     * @param config              System config to use
-     * @param metacatJson         Json Utilities to use
-     * @param lookupService       Look up service implementation to use
-     * @param userMetadataService User metadata service implementation to use
+     * @param jdbcTemplate            JDBC template
+     * @param jdbcTemplateLongTimeout JDBC template for longer running queries
+     * @param config                  System config to use
+     * @param metacatJson             Json Utilities to use
+     * @param lookupService           Look up service implementation to use
+     * @param userMetadataService     User metadata service implementation to use
      * @return The tag service implementation backed by MySQL
      */
     @Bean
@@ -108,7 +109,8 @@ public class MySqlUserMetadataConfig {
         final LookupService lookupService,
         final UserMetadataService userMetadataService
     ) {
-        return new MySqlTagService(config, jdbcTemplate, jdbcTemplateLongTimeout, lookupService, metacatJson, userMetadataService);
+        return new MySqlTagService(
+            config, jdbcTemplate, jdbcTemplateLongTimeout, lookupService, metacatJson, userMetadataService);
     }
 
     /**

--- a/metacat-metadata-mysql/src/main/java/com/netflix/metacat/metadata/mysql/MySqlUserMetadataConfig.java
+++ b/metacat-metadata-mysql/src/main/java/com/netflix/metacat/metadata/mysql/MySqlUserMetadataConfig.java
@@ -29,7 +29,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Primary;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 
@@ -92,25 +91,22 @@ public class MySqlUserMetadataConfig {
     /**
      * The tag service to use.
      *
-     * @param jdbcTemplate            JDBC template
-     * @param jdbcTemplateLongTimeout JDBC template for longer running queries
-     * @param config                  System config to use
-     * @param metacatJson             Json Utilities to use
-     * @param lookupService           Look up service implementation to use
-     * @param userMetadataService     User metadata service implementation to use
+     * @param jdbcTemplate        JDBC template
+     * @param config              System config to use
+     * @param metacatJson         Json Utilities to use
+     * @param lookupService       Look up service implementation to use
+     * @param userMetadataService User metadata service implementation to use
      * @return The tag service implementation backed by MySQL
      */
     @Bean
     public TagService tagService(
         @Qualifier("metadataJdbcTemplate") final JdbcTemplate jdbcTemplate,
-        @Qualifier("metadataJdbcTemplateLongTimeout") final JdbcTemplate jdbcTemplateLongTimeout,
         final Config config,
         final MetacatJson metacatJson,
         final LookupService lookupService,
         final UserMetadataService userMetadataService
     ) {
-        return new MySqlTagService(
-            config, jdbcTemplate, jdbcTemplateLongTimeout, lookupService, metacatJson, userMetadataService);
+        return new MySqlTagService(config, jdbcTemplate, lookupService, metacatJson, userMetadataService);
     }
 
     /**
@@ -163,28 +159,10 @@ public class MySqlUserMetadataConfig {
      * @return metadata JDBC template
      */
     @Bean
-    @Primary
     public JdbcTemplate metadataJdbcTemplate(
         @Qualifier("metadataDataSource") final DataSource mySqlDataSource,
         final Config config) {
-        final JdbcTemplate result = new JdbcTemplate(mySqlDataSource);
-        result.setQueryTimeout(config.getMetadataQueryTimeout());
-        return result;
-    }
-
-    /**
-     * mySql metadata JDBC template for longer running queries.
-     *
-     * @param mySqlDataSource metadata data source
-     * @param config System config to use
-     * @return metadata JDBC template
-     */
-    @Bean
-    public JdbcTemplate metadataJdbcTemplateLongTimeout(
-        @Qualifier("metadataDataSource") final DataSource mySqlDataSource,
-        final Config config) {
-        final JdbcTemplate result = new JdbcTemplate(mySqlDataSource);
-        result.setQueryTimeout(config.getLongMetadataQueryTimeout());
-        return result;
+        return MySqlServiceUtil.createJdbcTemplate(
+            mySqlDataSource, config.getMetadataQueryTimeout());
     }
 }


### PR DESCRIPTION
This PR allows the long query timeout to be configurable, rather than having it hard-coded for the tag list query.