### PR TITLE
Move to Java 17

### DIFF
--- a/.github/workflows/nebula-branch.yml
+++ b/.github/workflows/nebula-branch.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # test against JDK 8
-        java: [ 8 ]
+        # test against JDK 17
+        java: [ 17 ]
     name: CI with Java ${{ matrix.java }}
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/nebula-pr-functional-tests.yml
+++ b/.github/workflows/nebula-pr-functional-tests.yml
@@ -7,8 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # test against JDK 8
-        java: [ 8 ]
+        # test against JDK 17
+        java: [ 17 ]
     name: Functional tests with Java ${{ matrix.java }}
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/nebula-publish.yml
+++ b/.github/workflows/nebula-publish.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - name: Setup jdk 8
+      - name: Setup jdk 17
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 17
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:

--- a/.github/workflows/nebula-pull-request.yml
+++ b/.github/workflows/nebula-pull-request.yml
@@ -7,8 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # test against JDK 8
-        java: [ 8 ]
+        # test against JDK 17
+        java: [ 17 ]
     name: CI with Java ${{ matrix.java }}
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/nebula-snapshot.yml
+++ b/.github/workflows/nebula-snapshot.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v1
         with:
-          java-version: 8
+          java-version: 17
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:

--- a/build.gradle
+++ b/build.gradle
@@ -81,8 +81,8 @@ allprojects {
 
 idea {
     project {
-        jdkName = "8"
-        languageLevel = "8"
+        jdkName = "17"
+        languageLevel = "17"
         vcs = "Git"
     }
 }
@@ -98,8 +98,8 @@ configure(javaProjects) {
 
     group = "com.netflix.${githubProjectName}"
 
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
 
     dependencyManagement {
         imports {

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,7 +21,7 @@
 # Used in documentation and for including the Gradle plugin
 spring_boot_version=2.7.11
 spring_cloud_version=Hoxton.SR8
-google_guice_version=4.1.0
+google_guice_version=5.1.0
 spock_version=2.1-groovy-3.0
 
 ## Override Spring Boot versions

--- a/metacat-common/src/main/java/com/netflix/metacat/common/type/RowType.java
+++ b/metacat-common/src/main/java/com/netflix/metacat/common/type/RowType.java
@@ -24,9 +24,9 @@ import com.google.common.collect.Lists;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.List;
 

--- a/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/client/thrift/HiveMetastoreClientFactory.java
+++ b/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/client/thrift/HiveMetastoreClientFactory.java
@@ -52,7 +52,7 @@ public class HiveMetastoreClientFactory {
     }
 
     private static Socket createSocksSocket(final HostAndPort proxy) {
-        final SocketAddress address = InetSocketAddress.createUnresolved(proxy.getHostText(), proxy.getPort());
+        final SocketAddress address = InetSocketAddress.createUnresolved(proxy.getHost(), proxy.getPort());
         return new Socket(new Proxy(Proxy.Type.SOCKS, address));
     }
 

--- a/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/configs/PolarisPersistenceConfig.java
+++ b/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/configs/PolarisPersistenceConfig.java
@@ -79,6 +79,11 @@ public class PolarisPersistenceConfig {
     return new PolarisStoreConnector(repo, tblRepo);
   }
 
+  /**
+   * Set timestamp precision for JPA auditing.
+   *
+   * @return The date time provider
+   */
   @Bean
   public DateTimeProvider dateTimeProvider() {
     return () -> Optional.of(Instant.now().truncatedTo(ChronoUnit.MICROS));

--- a/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/configs/PolarisPersistenceConfig.java
+++ b/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/configs/PolarisPersistenceConfig.java
@@ -17,15 +17,11 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
-import org.springframework.data.auditing.DateTimeProvider;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 import javax.sql.DataSource;
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
-import java.util.Optional;
 
 /**
  * The Polaris Store Persistence config.
@@ -77,15 +73,5 @@ public class PolarisPersistenceConfig {
   public PolarisStoreService polarisStoreService(
       final PolarisDatabaseRepository repo, final PolarisTableRepository tblRepo) {
     return new PolarisStoreConnector(repo, tblRepo);
-  }
-
-  /**
-   * Set timestamp precision for JPA auditing.
-   *
-   * @return The date time provider
-   */
-  @Bean
-  public DateTimeProvider dateTimeProvider() {
-    return () -> Optional.of(Instant.now().truncatedTo(ChronoUnit.MICROS));
   }
 }

--- a/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/configs/PolarisPersistenceConfig.java
+++ b/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/configs/PolarisPersistenceConfig.java
@@ -17,11 +17,15 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
+import org.springframework.data.auditing.DateTimeProvider;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 import javax.sql.DataSource;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Optional;
 
 /**
  * The Polaris Store Persistence config.
@@ -73,5 +77,10 @@ public class PolarisPersistenceConfig {
   public PolarisStoreService polarisStoreService(
       final PolarisDatabaseRepository repo, final PolarisTableRepository tblRepo) {
     return new PolarisStoreConnector(repo, tblRepo);
+  }
+
+  @Bean
+  public DateTimeProvider dateTimeProvider() {
+    return () -> Optional.of(Instant.now().truncatedTo(ChronoUnit.MICROS));
   }
 }

--- a/metacat-connector-s3/build.gradle
+++ b/metacat-connector-s3/build.gradle
@@ -27,7 +27,6 @@ dependencies {
     api("com.google.guava:guava")
     api("com.google.inject:guice")
     api("com.google.inject.extensions:guice-persist")
-    api("com.google.inject.extensions:guice-multibindings")
     api("com.google.inject.extensions:guice-servlet")
     api("joda-time:joda-time:2.10.10")
     api("org.hibernate:hibernate-entitymanager")


### PR DESCRIPTION
Guice had to be updated to 5.1.0. Also, `Instant` precision in Java 17 can be nanos, which was causing a test assertion failure (because the DB is using micro precision), so there is a workaround for that.