### PR TITLE
Refactor Druid HTTP client to support extending a base Druid client

### DIFF
--- a/metacat-connector-druid/src/main/java/com/netflix/metacat/connector/druid/DruidConfigConstants.java
+++ b/metacat-connector-druid/src/main/java/com/netflix/metacat/connector/druid/DruidConfigConstants.java
@@ -19,14 +19,14 @@ package com.netflix.metacat.connector.druid;
 /**
  * Druid Config Constants.
  *
- * @author zhenl
+ * @author zhenl jtuglu
  * @since 1.2.0
  */
 public final class DruidConfigConstants {
     /**
-     * DRUID_COORDINATOR_URI.
+     * DRUID_ROUTER_URI .
      */
-    public static final String DRUID_COORDINATOR_URI = "druid.uri";
+    public static final String DRUID_ROUTER_URI = "druid.uri";
 
     //Http client
     /**

--- a/metacat-connector-druid/src/main/java/com/netflix/metacat/connector/druid/DruidConnectorFactory.java
+++ b/metacat-connector-druid/src/main/java/com/netflix/metacat/connector/druid/DruidConnectorFactory.java
@@ -22,27 +22,30 @@ import com.netflix.metacat.common.server.connectors.ConnectorPartitionService;
 import com.netflix.metacat.common.server.connectors.ConnectorTableService;
 import com.netflix.metacat.common.server.connectors.SpringConnectorFactory;
 import com.netflix.metacat.connector.druid.configs.DruidConnectorConfig;
-import com.netflix.metacat.connector.druid.configs.DruidHttpClientConfig;
+import com.netflix.metacat.connector.druid.configs.BaseDruidHttpClientConfig;
 import com.netflix.metacat.connector.druid.converter.DruidConnectorInfoConverter;
 
 /**
  * Druid Connector Factory.
  *
- * @author zhenl
+ * @author zhenl jtuglu
  * @since 1.2.0
  */
 public class DruidConnectorFactory extends SpringConnectorFactory {
     /**
      * Constructor.
      *
-     * @param connectorContext connector config
+     * @param druidConnectorInfoConverter connector info converter
+     * @param connectorContext            connector context
+     * @param clientConfigClass           config class to register
      */
-    DruidConnectorFactory(
+    public DruidConnectorFactory(
         final DruidConnectorInfoConverter druidConnectorInfoConverter,
-        final ConnectorContext connectorContext
+        final ConnectorContext connectorContext,
+        final Class<? extends BaseDruidHttpClientConfig> clientConfigClass
     ) {
         super(druidConnectorInfoConverter, connectorContext);
-        super.registerClazz(DruidConnectorConfig.class, DruidHttpClientConfig.class);
+        super.registerClazz(DruidConnectorConfig.class, clientConfigClass);
         super.refresh();
     }
 

--- a/metacat-connector-druid/src/main/java/com/netflix/metacat/connector/druid/DruidConnectorPlugin.java
+++ b/metacat-connector-druid/src/main/java/com/netflix/metacat/connector/druid/DruidConnectorPlugin.java
@@ -20,12 +20,13 @@ import com.netflix.metacat.common.server.connectors.ConnectorContext;
 import com.netflix.metacat.common.server.connectors.ConnectorFactory;
 import com.netflix.metacat.common.server.connectors.ConnectorPlugin;
 import com.netflix.metacat.common.server.connectors.ConnectorTypeConverter;
+import com.netflix.metacat.connector.druid.configs.DruidHttpClientConfig;
 import com.netflix.metacat.connector.druid.converter.DruidConnectorInfoConverter;
 
 /**
  * Druid Connector Plugin.
  *
- * @author zhenl
+ * @author zhenl jtuglu
  * @since 1.2.0
  */
 public class DruidConnectorPlugin implements ConnectorPlugin {
@@ -45,7 +46,10 @@ public class DruidConnectorPlugin implements ConnectorPlugin {
     @Override
     public ConnectorFactory create(final ConnectorContext connectorContext) {
         return new DruidConnectorFactory(
-            new DruidConnectorInfoConverter(connectorContext.getCatalogName()), connectorContext);
+            new DruidConnectorInfoConverter(connectorContext.getCatalogName()),
+            connectorContext,
+            DruidHttpClientConfig.class
+        );
     }
 
     /**

--- a/metacat-connector-druid/src/main/java/com/netflix/metacat/connector/druid/client/DruidHttpClientImpl.java
+++ b/metacat-connector-druid/src/main/java/com/netflix/metacat/connector/druid/client/DruidHttpClientImpl.java
@@ -37,13 +37,13 @@ import java.util.stream.IntStream;
 /**
  * DruidHttpClientImpl.
  *
- * @author zhenl
+ * @author zhenl jtuglu
  * @since 1.2.0
  */
 @Slf4j
 public class DruidHttpClientImpl implements MetacatDruidClient {
-    private String druidURI;
-    private final RestTemplate restTemplate;
+    protected String druidURI;
+    protected final RestTemplate restTemplate;
     private final MetacatJsonLocator jsonLocator = new MetacatJsonLocator();
 
     /**
@@ -56,16 +56,16 @@ public class DruidHttpClientImpl implements MetacatDruidClient {
                                final RestTemplate restTemplate) {
         this.restTemplate = restTemplate;
         final Map<String, String> config = connectorContext.getConfiguration();
-        final String coordinatorUri = config.get(DruidConfigConstants.DRUID_COORDINATOR_URI);
-        if (coordinatorUri == null) {
+        final String routerUri = config.get(DruidConfigConstants.DRUID_ROUTER_URI);
+        if (routerUri == null) {
             throw new MetacatException("Druid cluster ending point not provided.");
         }
         try {
-            new URI(coordinatorUri);
+            new URI(routerUri);
         } catch (URISyntaxException exception) {
             throw new MetacatException("Druid ending point invalid");
         }
-        this.druidURI = coordinatorUri;
+        this.druidURI = routerUri;
         log.info("druid server uri={}", this.druidURI);
     }
 

--- a/metacat-connector-druid/src/main/java/com/netflix/metacat/connector/druid/client/DruidHttpClientUtil.java
+++ b/metacat-connector-druid/src/main/java/com/netflix/metacat/connector/druid/client/DruidHttpClientUtil.java
@@ -30,7 +30,7 @@ public final class DruidHttpClientUtil {
      * get Latest Segment.
      *
      * @param input segments strings
-     * @return lastest segment id
+     * @return latest segment id
      */
     public static String getLatestSegment(final String input) {
         final String[] segments = input.substring(1, input.length() - 1).split(",");

--- a/metacat-connector-druid/src/main/java/com/netflix/metacat/connector/druid/configs/BaseDruidHttpClientConfig.java
+++ b/metacat-connector-druid/src/main/java/com/netflix/metacat/connector/druid/configs/BaseDruidHttpClientConfig.java
@@ -1,0 +1,77 @@
+package com.netflix.metacat.connector.druid.configs;
+
+import com.netflix.metacat.common.server.connectors.ConnectorContext;
+import com.netflix.metacat.common.server.connectors.util.TimeUtil;
+import com.netflix.metacat.connector.druid.DruidConfigConstants;
+import com.netflix.metacat.connector.druid.MetacatDruidClient;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * BaseDruidHttpClientConfig.
+ *
+ * @author zhenl jtuglu
+ * @since 1.2.0
+ */
+public abstract class BaseDruidHttpClientConfig {
+    /**
+     * Druid client instance.
+     *
+     * @param connectorContext connector context
+     * @param restTemplate     rest template
+     * @return MetacatDruidClient
+     */
+    @Bean
+    public abstract MetacatDruidClient createMetacatDruidClient(
+        final ConnectorContext connectorContext,
+        final RestTemplate restTemplate
+    );
+
+    /**
+     * Rest template.
+     *
+     * @param connectorContext connector context
+     * @return RestTemplate
+     */
+    @Bean
+    public RestTemplate restTemplate(final ConnectorContext connectorContext) {
+        return new RestTemplate(new HttpComponentsClientHttpRequestFactory(httpClient(connectorContext)));
+    }
+
+    /**
+     * Http client.
+     *
+     * @param connectorContext connector context
+     * @return HttpClient
+     */
+    @Bean
+    public HttpClient httpClient(final ConnectorContext connectorContext) {
+        final int timeout = (int) TimeUtil.toTime(
+            connectorContext.getConfiguration().getOrDefault(DruidConfigConstants.HTTP_TIMEOUT, "5s"),
+            TimeUnit.SECONDS,
+            TimeUnit.MILLISECONDS
+        );
+        final int poolSize = Integer.parseInt(connectorContext.getConfiguration()
+            .getOrDefault(DruidConfigConstants.POOL_SIZE, "10"));
+        final RequestConfig config = RequestConfig.custom()
+            .setConnectTimeout(timeout)
+            .setConnectionRequestTimeout(timeout)
+            .setSocketTimeout(timeout)
+            .setMaxRedirects(3)
+            .build();
+        final PoolingHttpClientConnectionManager connectionManager = new PoolingHttpClientConnectionManager();
+        connectionManager.setMaxTotal(poolSize);
+        return HttpClientBuilder
+            .create()
+            .setDefaultRequestConfig(config)
+            .setConnectionManager(connectionManager)
+            .build();
+    }
+}

--- a/metacat-connector-druid/src/main/java/com/netflix/metacat/connector/druid/configs/DruidHttpClientConfig.java
+++ b/metacat-connector-druid/src/main/java/com/netflix/metacat/connector/druid/configs/DruidHttpClientConfig.java
@@ -17,83 +17,30 @@
 package com.netflix.metacat.connector.druid.configs;
 
 import com.netflix.metacat.common.server.connectors.ConnectorContext;
-import com.netflix.metacat.common.server.connectors.util.TimeUtil;
-import com.netflix.metacat.connector.druid.DruidConfigConstants;
 import com.netflix.metacat.connector.druid.MetacatDruidClient;
 import com.netflix.metacat.connector.druid.client.DruidHttpClientImpl;
-import org.apache.http.client.HttpClient;
-import org.apache.http.client.config.RequestConfig;
-import org.apache.http.impl.client.HttpClientBuilder;
-import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
-
-import java.net.UnknownHostException;
-import java.util.concurrent.TimeUnit;
 
 /**
  * DruidHttpClientConfig.
  *
- * @author zhenl
+ * @author zhenl jtuglu
  * @since 1.2.0
  */
 @Configuration
-public class DruidHttpClientConfig {
+public class DruidHttpClientConfig extends BaseDruidHttpClientConfig {
     /**
      * Druid client instance.
      *
      * @param connectorContext connector context
      * @param restTemplate     rest template
      * @return MetacatDruidClient
-     * @throws UnknownHostException exception for unknownhost
      */
-    @Bean
+    @Override
     public MetacatDruidClient createMetacatDruidClient(
         final ConnectorContext connectorContext,
-        final RestTemplate restTemplate) throws UnknownHostException {
+        final RestTemplate restTemplate) {
         return new DruidHttpClientImpl(connectorContext, restTemplate);
-    }
-
-    /**
-     * Rest template.
-     *
-     * @param connectorContext connector context
-     * @return RestTemplate
-     */
-    @Bean
-    public RestTemplate restTemplate(final ConnectorContext connectorContext) {
-        return new RestTemplate(new HttpComponentsClientHttpRequestFactory(httpClient(connectorContext)));
-    }
-
-    /**
-     * Http client.
-     *
-     * @param connectorContext connector context
-     * @return HttpClient
-     */
-    @Bean
-    public HttpClient httpClient(final ConnectorContext connectorContext) {
-        final int timeout = (int) TimeUtil.toTime(
-            connectorContext.getConfiguration().getOrDefault(DruidConfigConstants.HTTP_TIMEOUT, "5s"),
-            TimeUnit.SECONDS,
-            TimeUnit.MILLISECONDS
-        );
-        final int poolsize = Integer.parseInt(connectorContext.getConfiguration()
-            .getOrDefault(DruidConfigConstants.POOL_SIZE, "10"));
-        final RequestConfig config = RequestConfig.custom()
-            .setConnectTimeout(timeout)
-            .setConnectionRequestTimeout(timeout)
-            .setSocketTimeout(timeout)
-            .setMaxRedirects(3)
-            .build();
-        final PoolingHttpClientConnectionManager connectionManager = new PoolingHttpClientConnectionManager();
-        connectionManager.setMaxTotal(poolsize);
-        return HttpClientBuilder
-            .create()
-            .setDefaultRequestConfig(config)
-            .setConnectionManager(connectionManager)
-            .build();
     }
 }

--- a/metacat-connector-druid/src/test/groovy/com/netflix/metacat/connector/druid/DruidHttpClientUtilSpec.groovy
+++ b/metacat-connector-druid/src/test/groovy/com/netflix/metacat/connector/druid/DruidHttpClientUtilSpec.groovy
@@ -5,11 +5,11 @@ import spock.lang.Specification
 
 /**
  * DruidHttpClientUtilSpec.
- * @author zhenl
+ * @author zhenl jtuglu
  * @since 1.2.0
  */
-class DruidHttpClientUtilSpec extends Specification{
-    
+class DruidHttpClientUtilSpec extends Specification {
+
     def "Test for getLatestDataByName"() {
 
         when:


### PR DESCRIPTION
# Overview
This allows for extensibility of Druid Connector client (through inheritance). Implementing a TLS-supported (or whatever signing mechanism you have) client is now much easier as users can apply the necessary overrides of the `RestTemplate` after `Base` ctor returns.

# Changes
- Change Coordinator URI to Router URI, as this is how Druid clusters are accessed now.
- Create `BaseDruidHttpClientConfig` which is an abstract class that specifies the Bean(s) to implement for any `MetcatDruidClient`.
- Modify `DruidConnectorFactory` to take in any class which extends the `BaseDruidHttpClientConfig` class. 

# Notes:
- Idea here is that to extend the default Druid connector, you can create your own `*Plugin.java` file, and pass the custom `MetacatDruidClient` client implementation class type into the `DruidConnectorFactory` ctor.
- Having an abstract class instead of a `BaseDruidHttpClientConfig` with default impls is regrettable, but I was getting duplicate Bean name warnings when instantiating multiple instances of the interface.
