### PR TITLE
Record caller metrics in Atlas

### DIFF
--- a/metacat-common/src/main/java/com/netflix/metacat/common/MetacatRequestContext.java
+++ b/metacat-common/src/main/java/com/netflix/metacat/common/MetacatRequestContext.java
@@ -92,7 +92,7 @@ public class MetacatRequestContext implements Serializable {
      */
     public MetacatRequestContext() {
         this.userName = null;
-        this.clientAppName = null;
+        this.clientAppName = UNKNOWN;
         this.clientId = null;
         this.jobId = null;
         this.dataTypeContext = null;
@@ -198,6 +198,7 @@ public class MetacatRequestContext implements Serializable {
         MetacatRequestContextBuilder() {
             this.bApiUri = UNKNOWN;
             this.bScheme = UNKNOWN;
+            this.bClientAppName = UNKNOWN;
         }
 
         /**

--- a/metacat-main/src/main/java/com/netflix/metacat/main/api/RequestWrapper.java
+++ b/metacat-main/src/main/java/com/netflix/metacat/main/api/RequestWrapper.java
@@ -154,8 +154,14 @@ public final class RequestWrapper {
         if (requestTags != null) {
             tags.putAll(requestTags);
         }
+
         tags.put("request", resourceRequestName);
         tags.put("scheme", MetacatContextManager.getContext().getScheme());
+        String clientAppName =  MetacatContextManager.getContext().getClientAppName();
+        if (clientAppName == null) {
+            clientAppName = "UNKNOWN";
+        }
+        tags.put("caller", clientAppName);
         registry.counter(requestCounterId.withTags(tags)).increment();
 
         try {
@@ -243,6 +249,7 @@ public final class RequestWrapper {
         final long start = registry.clock().wallTime();
         final Map<String, String> tags = Maps.newHashMap();
         tags.put("request", resourceRequestName);
+        tags.put("caller", MetacatContextManager.getContext().getClientAppName());
         registry.counter(requestCounterId.withTags(tags)).increment();
         try {
             MetacatContextManager.getContext().setRequestName(resourceRequestName);


### PR DESCRIPTION
This PR will help with debugging when we get an unusual amount of load through Metacat. With this we will be able to see where the increased load is coming from and lower the amount of time it takes to find the source since currently we can only access that data by querying from a table. Once we have access to more identity information in the future we can switch to a different metric.