### PR TITLE
Adding support for table parameters in Polaris

### DIFF
--- a/metacat-connector-polaris/src/functionalTest/java/com/netflix/metacat/connector/polaris/PolarisConnectorTableServiceFunctionalTest.java
+++ b/metacat-connector-polaris/src/functionalTest/java/com/netflix/metacat/connector/polaris/PolarisConnectorTableServiceFunctionalTest.java
@@ -53,7 +53,8 @@ public class PolarisConnectorTableServiceFunctionalTest extends PolarisConnector
         final QualifiedName name3 = QualifiedName.ofTable(CATALOG_NAME, DB_NAME, "table3");
         final TableInfo tableInfo3 = TableInfo.builder()
             .name(name3)
-            .metadata(ImmutableMap.of("table_type", "ICEBERG", "metadata_location", "loc3"))
+            .metadata(ImmutableMap.of("table_type", "ICEBERG", "metadata_location", "loc3",
+                "other_param", "param_value"))
             .build();
         getPolarisTableService().create(getRequestContext(), tableInfo3);
 

--- a/metacat-connector-polaris/src/functionalTest/resources/schema.sql
+++ b/metacat-connector-polaris/src/functionalTest/resources/schema.sql
@@ -19,6 +19,7 @@ create table TBLS (
   tbl_name varchar(255) not null,
   previous_metadata_location varchar(8192),
   metadata_location varchar(8192),
+  params TEXT,
   constraint uniq_name unique(db_name, tbl_name),
   created_by STRING(255),
   created_date TIMESTAMP not null,

--- a/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/store/PolarisStoreConnector.java
+++ b/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/store/PolarisStoreConnector.java
@@ -12,7 +12,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import javax.annotation.Nullable;
 import java.time.Instant;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -115,6 +117,24 @@ public class PolarisStoreConnector implements PolarisStoreService {
                                           final String tableName,
                                           final String metadataLocation,
                                           final String createdBy) {
+        return createTable(dbName, tableName, metadataLocation, new HashMap<>(), createdBy);
+    }
+
+    /**
+     * Creates entry for new table (with parameters).
+     * @param dbName database name
+     * @param tableName table name
+     * @param metadataLocation metadata location of the table.
+     * @param params table parameters
+     * @param createdBy user creating this table.
+     * @return entity corresponding to created table entry
+     */
+    @Override
+    public PolarisTableEntity createTable(final String dbName,
+                                          final String tableName,
+                                          final String metadataLocation,
+                                          final Map<String, String> params,
+                                          final String createdBy) {
         final AuditEntity auditEntity = AuditEntity.builder()
                 .createdBy(createdBy)
                 .lastModifiedBy(createdBy)
@@ -124,6 +144,7 @@ public class PolarisStoreConnector implements PolarisStoreService {
                 .dbName(dbName)
                 .tblName(tableName)
                 .metadataLocation(metadataLocation)
+                .params(params)
                 .build();
         return tblRepo.save(e);
     }
@@ -221,6 +242,31 @@ public class PolarisStoreConnector implements PolarisStoreService {
         final int updatedRowCount =
                 tblRepo.updateMetadataLocation(databaseName, tableName,
                         expectedLocation, newLocation, lastModifiedBy, Instant.now());
+        return updatedRowCount > 0;
+    }
+
+    /**
+     * Do an atomic compare-and-swap to update the table's metdata location and params.
+     * @param databaseName database name of the table
+     * @param tableName table name
+     * @param expectedLocation expected current metadata-location of the table
+     * @param newLocation new metadata location of the table
+     * @param expectedParams expected current parameters of the table
+     * @param newParams new parameters of the table (should only include changed values)
+     * @param lastModifiedBy user updating the location
+     * @return true, if the location update was successful. false, otherwise
+     */
+    public boolean updateTableMetadataLocationAndParams(
+        final String databaseName, final String tableName,
+        final String expectedLocation, final String newLocation,
+        final Map<String, String> expectedParams, final Map<String, String> newParams,
+        final String lastModifiedBy) {
+        final Map<String, String> mergedParams = expectedParams == null
+            ? new HashMap<>() : new HashMap<>(expectedParams);
+        mergedParams.putAll(newParams);
+        final int updatedRowCount =
+            tblRepo.updateMetadataLocationAndParams(databaseName, tableName,
+                expectedLocation, newLocation, expectedParams, mergedParams, lastModifiedBy, Instant.now());
         return updatedRowCount > 0;
     }
 }

--- a/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/store/PolarisStoreService.java
+++ b/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/store/PolarisStoreService.java
@@ -5,6 +5,7 @@ import com.netflix.metacat.connector.polaris.store.entities.PolarisDatabaseEntit
 import com.netflix.metacat.connector.polaris.store.entities.PolarisTableEntity;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -77,6 +78,18 @@ public interface PolarisStoreService {
     PolarisTableEntity createTable(String dbName, String tableName, String metadataLocation, String createdBy);
 
     /**
+     * Creates entry for new table (with parameters).
+     * @param dbName database name
+     * @param tableName table name
+     * @param metadataLocation metadata location of the table.
+     * @param params table parameters
+     * @param createdBy user creating this table.
+     * @return entity corresponding to created table entry
+     */
+    PolarisTableEntity createTable(String dbName, String tableName,
+                                   String metadataLocation, Map<String, String> params, String createdBy);
+
+    /**
      * Fetches table entry.
      * @param dbName database name
      * @param tableName table name
@@ -137,4 +150,22 @@ public interface PolarisStoreService {
         String databaseName, String tableName,
         String expectedLocation, String newLocation,
         String lastModifiedBy);
+
+    /**
+     * Do an atomic compare-and-swap to update the table's metdata location and params.
+     * @param databaseName database name of the table
+     * @param tableName table name
+     * @param expectedLocation expected current metadata-location of the table
+     * @param newLocation new metadata location of the table
+     * @param expectedParams expected current parameters of the table
+     * @param newParams new parameters of the table (should only include changed values)
+     * @param lastModifiedBy user updating the location
+     * @return true, if the location update was successful. false, otherwise
+     */
+    boolean updateTableMetadataLocationAndParams(
+        final String databaseName, final String tableName,
+        final String expectedLocation, final String newLocation,
+        final Map<String, String> expectedParams, final Map<String, String> newParams,
+        final String lastModifiedBy
+    );
 }

--- a/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/store/entities/PolarisTableEntity.java
+++ b/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/store/entities/PolarisTableEntity.java
@@ -1,5 +1,6 @@
 package com.netflix.metacat.connector.polaris.store.entities;
 
+import jakarta.persistence.Convert;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -19,6 +20,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.persistence.Version;
+import java.util.Map;
 
 
 /**
@@ -65,6 +67,11 @@ public class PolarisTableEntity {
 
     @Embedded
     private AuditEntity audit;
+
+    @Setter
+    @Convert(converter = StringParamsConverter.class)
+    @Column(name = "params", nullable = true, updatable = true)
+    private Map<String, String> params;
 
     /**
      * Constructor for Polaris Table Entity.

--- a/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/store/entities/StringParamsConverter.java
+++ b/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/store/entities/StringParamsConverter.java
@@ -1,0 +1,44 @@
+package com.netflix.metacat.connector.polaris.store.entities;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * Converter to represent String Map as a JSON-formatted String in the database.
+ */
+@Converter
+public class StringParamsConverter implements AttributeConverter<Map<String, String>, String> {
+    @Override
+    public String convertToDatabaseColumn(final Map<String, String> attribute) {
+
+        if (attribute == null || attribute.isEmpty()) {
+            return null;
+        }
+        final TreeMap<String, String> map = new TreeMap<>(attribute);
+        try {
+            return new ObjectMapper().writeValueAsString(map);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Error converting params Map to String", e);
+        }
+    }
+
+    @Override
+    public Map<String, String> convertToEntityAttribute(final String dbData) {
+        if (dbData == null || dbData.isEmpty()) {
+            return new HashMap<>();
+        }
+
+        try {
+            return new ObjectMapper().readValue(dbData, new TypeReference<Map<String, String>>() { });
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Error converting params String to Map", e);
+        }
+    }
+}

--- a/metacat-connector-polaris/src/test/java/com/netflix/metacat/connector/polaris/store/PolarisStoreConnectorTest.java
+++ b/metacat-connector-polaris/src/test/java/com/netflix/metacat/connector/polaris/store/PolarisStoreConnectorTest.java
@@ -27,6 +27,8 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Random;
 
@@ -44,6 +46,12 @@ public class PolarisStoreConnectorTest {
     private static final String DB_NAME_FOO = "foo";
     private static final String TBL_NAME_BAR = "bar";
     private static final String DEFAULT_METACAT_USER = "metacat_user";
+    private static final Map<String, String> TBL_PARAMS = new HashMap<String, String>() {
+        {
+            put("metadata-key-1", "metadata-value-1");
+            put("metadata-key-2", "metadata-value-2");
+        }
+    };
     private static Random random = new Random(System.currentTimeMillis());
 
     @Autowired
@@ -54,6 +62,8 @@ public class PolarisStoreConnectorTest {
 
     @Autowired
     private PolarisStoreConnector polarisConnector;
+    @Autowired
+    private PolarisStoreService polarisStoreService;
 
     @MockBean
     private DateTimeProvider dateTimeProvider;
@@ -98,8 +108,14 @@ public class PolarisStoreConnectorTest {
     }
 
     public PolarisTableEntity createTable(final String dbName, final String tblName) {
-        final PolarisTableEntity entity = polarisConnector.createTable(dbName, tblName,
-                "loc", PolarisUtils.DEFAULT_METACAT_USER);
+        return createTable(dbName, tblName, new HashMap<>());
+    }
+
+    public PolarisTableEntity createTable(
+        final String dbName, final String tblName, final Map<String, String> tblParams
+    ) {
+        final PolarisTableEntity entity = polarisStoreService.createTable(dbName, tblName,
+            "loc", tblParams, PolarisUtils.DEFAULT_METACAT_USER);
 
         Assert.assertTrue(polarisConnector.tableExistsById(entity.getTblId()));
         Assert.assertTrue(polarisConnector.tableExists(dbName, tblName));
@@ -109,6 +125,7 @@ public class PolarisStoreConnectorTest {
 
         Assert.assertEquals(dbName, entity.getDbName());
         Assert.assertEquals(tblName, entity.getTblName());
+        Assert.assertEquals(tblParams, entity.getParams());
 
         final Optional<PolarisTableEntity> fetchedEntity = polarisConnector.getTable(dbName, tblName);
         Assert.assertTrue(fetchedEntity.isPresent());
@@ -151,10 +168,25 @@ public class PolarisStoreConnectorTest {
     }
 
     /**
+     * Test table creation if database exists.
+     * Verify table deletion
+     */
+    @Test
+    public void testTableCreationAndDeletionWithParams() {
+        final String dbName = generateDatabaseName();
+        final String tblName = generateTableName();
+        final PolarisDatabaseEntity dbEntity = createDB(dbName);
+        final PolarisTableEntity tblEntity = createTable(dbName, tblName, TBL_PARAMS);
+
+        polarisConnector.deleteTable(dbName, tblName);
+        Assert.assertFalse(polarisConnector.tableExistsById(tblEntity.getTblId()));
+    }
+
+    /**
      * Test to verify that table name can be updated.
      */
     @Test
-    public void testTableUpdate() {
+    public void testTableUpdate() throws InterruptedException {
         // Create Table Entity in DB
         final String dbName = generateDatabaseName();
         final String tblName = generateTableName();
@@ -248,6 +280,110 @@ public class PolarisStoreConnectorTest {
         // At this point, savedEntity is stale, and any updates to savedEntity should not be allowed
         // to persist.
         savedEntity.setMetadataLocation(location2);
+        Assertions.assertThrows(OptimisticLockingFailureException.class, () -> {
+            polarisConnector.saveTable(savedEntity);
+        });
+    }
+
+    /**
+     * Test to verify that compare-and-swap update of the metadata location and params works as expected.
+     */
+    @Test
+    public void updateMetadataLocationAndParams() {
+        final String dbName = generateDatabaseName();
+        createDB(dbName);
+
+        final String tblName = generateTableName();
+        final String metadataLocation = "s3/s3n://dataoven-prod/hive/dataoven_prod/warehouse/foo";
+        final PolarisTableEntity e = new PolarisTableEntity(dbName, tblName, "metacatuser");
+        e.setMetadataLocation(metadataLocation);
+        final PolarisTableEntity savedEntity = polarisConnector.saveTable(e);
+
+        final String newLocation = "s3/s3n://dataoven-prod/hive/dataoven_prod/warehouse/bar";
+
+        // update should fail since the expected location is not going to match.
+        boolean updatedSuccess = polarisConnector.updateTableMetadataLocationAndParams(
+            dbName, tblName, "unexpected_location",
+            newLocation, null, new HashMap<>(), PolarisUtils.DEFAULT_METACAT_USER);
+        Assert.assertFalse(updatedSuccess);
+
+        // there should be no table params since update failed
+        final PolarisTableEntity failedUpdateEntity = polarisConnector.
+            getTable(dbName, tblName).orElseThrow(() -> new RuntimeException("Expected to find saved entity"));
+        Assert.assertTrue(failedUpdateEntity.getParams().isEmpty());
+
+        HashMap<String, String> params = new HashMap<>();
+
+        for (int i = 0; i < 10; i++) {
+            params.put("key-" + i, "value-" + i);
+        }
+        // successful update should happen.
+        updatedSuccess = polarisConnector.updateTableMetadataLocationAndParams(dbName, tblName, metadataLocation,
+            newLocation, null, params, "new_user");
+        Assert.assertTrue(updatedSuccess);
+        final PolarisTableEntity updatedEntity = polarisConnector.
+            getTable(dbName, tblName).orElseThrow(() -> new RuntimeException("Expected to find saved entity"));
+        Assert.assertEquals(updatedEntity.getPreviousMetadataLocation(), metadataLocation);
+        Assert.assertEquals(updatedEntity.getParams(), params);
+
+        final Map<String, String> updatedParams = new HashMap<>(params);
+        for (int i = 9; i >= 0; i--) {
+            updatedParams.put("key-" + i, "value-" + i + "-updated");
+        }
+        // successful update should happen.
+        updatedSuccess = polarisConnector.updateTableMetadataLocationAndParams(dbName, tblName, newLocation,
+            newLocation, params, updatedParams, "new_user");
+        Assert.assertTrue(updatedSuccess);
+        final PolarisTableEntity updatedEntity2 = polarisConnector.
+            getTable(dbName, tblName).orElseThrow(() -> new RuntimeException("Expected to find saved entity"));
+        Assert.assertEquals(updatedEntity2.getMetadataLocation(), newLocation);
+        Assert.assertEquals(updatedEntity2.getParams(), updatedParams);
+
+        // after the successful update, the same call should fail, since the current params have changed.
+        updatedSuccess = polarisConnector.updateTableMetadataLocationAndParams(dbName, tblName, newLocation,
+            newLocation, params, new HashMap<>(), PolarisUtils.DEFAULT_METACAT_USER);
+        Assert.assertFalse(updatedSuccess);
+
+        // after the successful update, the same call should fail, since the current metadata has changed.
+        updatedSuccess = polarisConnector.updateTableMetadataLocationAndParams(dbName, tblName, metadataLocation,
+            newLocation, updatedParams, new HashMap<>(), PolarisUtils.DEFAULT_METACAT_USER);
+        Assert.assertFalse(updatedSuccess);
+    }
+
+    /**
+     * Test updateLocationAndParams(...) while save(...) is called in interleaved fashion.
+     */
+    @Test
+    public void updateMetadataLocationWithParamsAndInterleavedSave() {
+        final String dbName = generateDatabaseName();
+        createDB(dbName);
+
+        final String tblName = generateTableName();
+        final String location0 = "s3/s3n://dataoven-prod/hive/dataoven_prod/warehouse/location0";
+        final PolarisTableEntity e = new PolarisTableEntity(dbName, tblName, "metacatuser");
+        e.setMetadataLocation(location0);
+        final PolarisTableEntity savedEntity = polarisConnector.saveTable(e);
+
+        final String location1 = "s3/s3n://dataoven-prod/hive/dataoven_prod/warehouse/location1";
+
+        // update the metadata location.
+        final boolean updatedSuccess =
+            polarisConnector.updateTableMetadataLocationAndParams(
+                dbName, tblName, location0, location1, null, TBL_PARAMS, "new_user");
+        Assert.assertTrue(updatedSuccess);
+
+        // confirm updated params
+        final PolarisTableEntity updatedEntity = polarisConnector.getTable(dbName, tblName)
+            .orElseThrow(() -> new RuntimeException("Expected to find saved entity"));
+        Assert.assertEquals(TBL_PARAMS, updatedEntity.getParams());
+        Assert.assertEquals(location1, updatedEntity.getMetadataLocation());
+
+        // At this point, savedEntity is stale, and any updates to savedEntity should not be allowed
+        // to persist.
+        Map<String, String> newParams = new HashMap<String, String>() {
+            { put("metadata-key-1", "metadata-value-1-updated"); }
+        };
+        savedEntity.setParams(newParams);
         Assertions.assertThrows(OptimisticLockingFailureException.class, () -> {
             polarisConnector.saveTable(savedEntity);
         });

--- a/metacat-connector-polaris/src/test/java/com/netflix/metacat/connector/polaris/store/entities/StringParamsConverterTest.java
+++ b/metacat-connector-polaris/src/test/java/com/netflix/metacat/connector/polaris/store/entities/StringParamsConverterTest.java
@@ -1,0 +1,61 @@
+package com.netflix.metacat.connector.polaris.store.entities;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+class StringParamsConverterTest {
+    private static final Map<String, String> VALID_MAP_PARAM = new HashMap<>() { {
+        put("keyA", "value1");
+        put("keyB", "value2");
+        put("keyC", "value3");
+    } };
+    private static final String VALID_STRING_PARAM = "{\"keyA\":\"value1\",\"keyB\":\"value2\",\"keyC\":\"value3\"}";
+    private static final String NESTED_STRING_PARAM = "{\"keyA\":{\"keyB\":\"value2\"},\"keyC\":\"value3\"}";
+
+    private final StringParamsConverter converter = new StringParamsConverter();
+
+    @Test
+    void validMapToStringConversion() {
+        String converted = converter.convertToDatabaseColumn(VALID_MAP_PARAM);
+        Assertions.assertEquals(
+            VALID_STRING_PARAM,
+            converted
+        );
+    }
+
+    @Test
+    void validStringToMapConversion() {
+        Map<String, String> converted = converter.convertToEntityAttribute(VALID_STRING_PARAM);
+        Assertions.assertEquals(
+            VALID_MAP_PARAM,
+            converted
+        );
+    }
+
+    @Test
+    void invalidStringToMapConversion() {
+        Assertions.assertThrowsExactly(
+            RuntimeException.class,
+            () -> converter.convertToEntityAttribute(VALID_STRING_PARAM.substring(10)),
+            "Error converting params String to Map"
+        );
+
+        Assertions.assertThrowsExactly(
+            RuntimeException.class,
+            () -> converter.convertToEntityAttribute(NESTED_STRING_PARAM),
+            "Error converting params String to Map"
+        );
+    }
+
+    @Test
+    void nullEmptyConversionBehavior() {
+        Assertions.assertNull(converter.convertToDatabaseColumn(null));
+        Assertions.assertNull(converter.convertToDatabaseColumn(new HashMap<>()));
+
+        Assertions.assertEquals(new HashMap<>(), converter.convertToEntityAttribute(null));
+        Assertions.assertEquals(new HashMap<>(), converter.convertToEntityAttribute(""));
+    }
+}

--- a/metacat-connector-polaris/src/test/java/com/netflix/metacat/connector/polaris/store/entities/package-info.java
+++ b/metacat-connector-polaris/src/test/java/com/netflix/metacat/connector/polaris/store/entities/package-info.java
@@ -1,0 +1,22 @@
+/*
+ *
+ *  Copyright 2021 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+/**
+ * Polaris connector test classes.
+ */
+package com.netflix.metacat.connector.polaris.store.entities;

--- a/metacat-connector-polaris/src/test/resources/h2db/schema.sql
+++ b/metacat-connector-polaris/src/test/resources/h2db/schema.sql
@@ -1,5 +1,6 @@
 drop table if exists TBLS;
 drop table if exists DBS;
+drop table if exists TBL_PARAMS;
 
 create table DBS (
   version bigint not null,
@@ -19,12 +20,19 @@ create table TBLS (
   tbl_name varchar(255) not null,
   previous_metadata_location varchar(1024),
   metadata_location varchar(1024),
+  params TEXT,
   constraint uniq_name unique(db_name, tbl_name),
   created_by varchar(255),
   created_date TIMESTAMP not null,
   last_updated_by varchar(255),
   last_updated_date TIMESTAMP not null,
   foreign key (db_name) references DBS(name) ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+create table TBL_PARAMS (
+  polaris_table_entity_id varchar(255) not null,
+  param_key varchar(255) not null,
+  param_value varchar(255) not null
 );
 
 CREATE INDEX DB_NAME_IDX ON TBLS(db_name);

--- a/metacat-functional-tests/metacat-test-cluster/datastores/crdb/sql/schema.sql
+++ b/metacat-functional-tests/metacat-test-cluster/datastores/crdb/sql/schema.sql
@@ -19,6 +19,7 @@ create table TBLS (
     tbl_name varchar(255) not null,
     previous_metadata_location varchar(8192),
     metadata_location varchar(8192),
+    params text,
     created_by STRING(255),
     created_date TIMESTAMP not null,
     last_updated_by STRING(255),


### PR DESCRIPTION
* Update the PolarisTableEntity to include a params field
* Add AttributeConverter for storing params in JSON-formatted string
* Update PolarisTableMapper to include and filter params when mapping to/from TableInfo
* Add support in PolarisConnectorTableService + PolarisTableRepository + PolarisStore to atomically update params
* Update test schemas to enable testing table params