### PR TITLE
Fixing debug port format for metacat test cluster

### DIFF
--- a/metacat-functional-tests/metacat-test-cluster/docker-compose.yml
+++ b/metacat-functional-tests/metacat-test-cluster/docker-compose.yml
@@ -43,7 +43,7 @@ services:
             JAVA_OPTS: '-ea
                 -Xms256m
                 -Xmx768m
-                -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8000
+                -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:8000
                 -noverify
                 -Dnetflix.environment=test
                 -Dlogging.level.org.springframework.web=INFO


### PR DESCRIPTION
After migration to JDK17, we need to update the port specification for debugging. 

Tested by trying remote JVM debugger before/after.