### PR TITLE
Adding explicit cacheNames for all @Cacheable and @CacheEvict declarations

### DIFF
--- a/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/commonview/CommonViewHandler.java
+++ b/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/commonview/CommonViewHandler.java
@@ -97,7 +97,7 @@ public class CommonViewHandler {
      * @param tableInfo         table info
      * @param tableMetadataLocation the common view table metadata location.
      */
-    @CacheEvict(key = "'iceberg.view.' + #tableMetadataLocation", beforeInvocation = true)
+    @CacheEvict(cacheNames = "metacat", key = "'iceberg.view.' + #tableMetadataLocation", beforeInvocation = true)
     public void handleUpdate(final ConnectorRequestContext requestContext,
                              final DirectSqlTable directSqlTable,
                              final TableInfo tableInfo,

--- a/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/iceberg/IcebergTableOpsProxy.java
+++ b/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/iceberg/IcebergTableOpsProxy.java
@@ -15,7 +15,11 @@ public class IcebergTableOpsProxy {
      * @param useCache true, if table can be retrieved from cache
      * @return TableMetadata
      */
-    @Cacheable(cacheNames = "metacat", key = "'iceberg.' + #icebergTableOps.currentMetadataLocation()", condition = "#useCache")
+    @Cacheable(
+        cacheNames = "metacat",
+        key = "'iceberg.' + #icebergTableOps.currentMetadataLocation()",
+        condition = "#useCache"
+    )
     public TableMetadata getMetadata(final IcebergTableOps icebergTableOps, final boolean useCache) {
         return icebergTableOps.refresh();
     }

--- a/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/iceberg/IcebergTableOpsProxy.java
+++ b/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/iceberg/IcebergTableOpsProxy.java
@@ -15,7 +15,7 @@ public class IcebergTableOpsProxy {
      * @param useCache true, if table can be retrieved from cache
      * @return TableMetadata
      */
-    @Cacheable(key = "'iceberg.' + #icebergTableOps.currentMetadataLocation()", condition = "#useCache")
+    @Cacheable(cacheNames = "metacat", key = "'iceberg.' + #icebergTableOps.currentMetadataLocation()", condition = "#useCache")
     public TableMetadata getMetadata(final IcebergTableOps icebergTableOps, final boolean useCache) {
         return icebergTableOps.refresh();
     }

--- a/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/sql/HiveConnectorFastTableServiceProxy.java
+++ b/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/sql/HiveConnectorFastTableServiceProxy.java
@@ -61,7 +61,7 @@ public class HiveConnectorFastTableServiceProxy {
      * @param useCache true, if table can be retrieved from cache
      * @return TableInfo
      */
-    @Cacheable(key = "'iceberg.table.' + #includeInfoDetails + '.' + #tableMetadataLocation", condition = "#useCache")
+    @Cacheable(cacheNames = "metacat", key = "'iceberg.table.' + #includeInfoDetails + '.' + #tableMetadataLocation", condition = "#useCache")
     public TableInfo getIcebergTable(final QualifiedName tableName,
                                      final String tableMetadataLocation,
                                      final TableInfo info,
@@ -83,7 +83,7 @@ public class HiveConnectorFastTableServiceProxy {
      * @param useCache true, if table can be retrieved from cache
      * @return TableInfo
      */
-    @Cacheable(key = "'iceberg.view.' + #tableMetadataLocation", condition = "#useCache")
+    @Cacheable(cacheNames = "metacat", key = "'iceberg.view.' + #tableMetadataLocation", condition = "#useCache")
     public TableInfo getCommonViewTableInfo(final QualifiedName name,
                                      final String tableMetadataLocation,
                                      final TableInfo info,

--- a/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/sql/HiveConnectorFastTableServiceProxy.java
+++ b/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/sql/HiveConnectorFastTableServiceProxy.java
@@ -61,7 +61,11 @@ public class HiveConnectorFastTableServiceProxy {
      * @param useCache true, if table can be retrieved from cache
      * @return TableInfo
      */
-    @Cacheable(cacheNames = "metacat", key = "'iceberg.table.' + #includeInfoDetails + '.' + #tableMetadataLocation", condition = "#useCache")
+    @Cacheable(
+        cacheNames = "metacat",
+        key = "'iceberg.table.' + #includeInfoDetails + '.' + #tableMetadataLocation",
+        condition = "#useCache"
+    )
     public TableInfo getIcebergTable(final QualifiedName tableName,
                                      final String tableMetadataLocation,
                                      final TableInfo info,

--- a/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/PolarisConnectorTableService.java
+++ b/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/PolarisConnectorTableService.java
@@ -365,7 +365,7 @@ public class PolarisConnectorTableService implements ConnectorTableService {
      * @param useCache              true, if table can be retrieved from cache
      * @return TableInfo
      */
-    @Cacheable(key = "'iceberg.table.' + #includeInfoDetails + '.' + #tableMetadataLocation", condition = "#useCache")
+    @Cacheable(cacheNames = "metacat", key = "'iceberg.table.' + #includeInfoDetails + '.' + #tableMetadataLocation", condition = "#useCache")
     public TableInfo getIcebergTable(final QualifiedName tableName,
                                      final String tableMetadataLocation,
                                      final TableInfo info,

--- a/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/PolarisConnectorTableService.java
+++ b/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/PolarisConnectorTableService.java
@@ -30,6 +30,7 @@ import com.netflix.metacat.connector.polaris.store.entities.PolarisTableEntity;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.cache.annotation.CacheConfig;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.dao.DataIntegrityViolationException;
 
@@ -45,6 +46,7 @@ import java.util.stream.Collectors;
  * table service for polaris connector.
  */
 @Slf4j
+@CacheConfig(cacheNames = "metacat")
 public class PolarisConnectorTableService implements ConnectorTableService {
     protected final PolarisStoreService polarisStoreService;
     protected final PolarisConnectorDatabaseService polarisConnectorDatabaseService;
@@ -365,7 +367,11 @@ public class PolarisConnectorTableService implements ConnectorTableService {
      * @param useCache              true, if table can be retrieved from cache
      * @return TableInfo
      */
-    @Cacheable(cacheNames = "metacat", key = "'iceberg.table.' + #includeInfoDetails + '.' + #tableMetadataLocation", condition = "#useCache")
+    @Cacheable(
+        cacheNames = "metacat",
+        key = "'iceberg.table.' + #includeInfoDetails + '.' + #tableMetadataLocation",
+        condition = "#useCache"
+    )
     public TableInfo getIcebergTable(final QualifiedName tableName,
                                      final String tableMetadataLocation,
                                      final TableInfo info,

--- a/metacat-main/src/main/java/com/netflix/metacat/main/services/impl/ConnectorTableServiceProxy.java
+++ b/metacat-main/src/main/java/com/netflix/metacat/main/services/impl/ConnectorTableServiceProxy.java
@@ -163,8 +163,16 @@ public class ConnectorTableServiceProxy {
      */
     @Caching(evict = {
             @CacheEvict(cacheNames = "metacat", key = "'table.' + #oldName", beforeInvocation = true),
-            @CacheEvict(cacheNames = "metacat", key = "'table.includeInfoDetails.' + #oldName", beforeInvocation = true),
-            @CacheEvict(cacheNames = "metacat", key = "'table.metadataLocationOnly.' + #oldName", beforeInvocation = true)
+            @CacheEvict(
+                cacheNames = "metacat",
+                key = "'table.includeInfoDetails.' + #oldName",
+                beforeInvocation = true
+            ),
+            @CacheEvict(
+                cacheNames = "metacat",
+                key = "'table.metadataLocationOnly.' + #oldName",
+                beforeInvocation = true
+            )
     })
     public void rename(
         final QualifiedName oldName,

--- a/metacat-main/src/main/java/com/netflix/metacat/main/services/impl/ConnectorTableServiceProxy.java
+++ b/metacat-main/src/main/java/com/netflix/metacat/main/services/impl/ConnectorTableServiceProxy.java
@@ -79,9 +79,9 @@ public class ConnectorTableServiceProxy {
      * @param name table name
      */
     @Caching(evict = {
-            @CacheEvict(key = "'table.' + #name", beforeInvocation = true),
-            @CacheEvict(key = "'table.includeInfoDetails.' + #name", beforeInvocation = true),
-            @CacheEvict(key = "'table.metadataLocationOnly.' + #name", beforeInvocation = true)
+            @CacheEvict(cacheNames = "metacat", key = "'table.' + #name", beforeInvocation = true),
+            @CacheEvict(cacheNames = "metacat", key = "'table.includeInfoDetails.' + #name", beforeInvocation = true),
+            @CacheEvict(cacheNames = "metacat", key = "'table.metadataLocationOnly.' + #name", beforeInvocation = true)
     })
     public void delete(final QualifiedName name) {
         final MetacatRequestContext metacatRequestContext = MetacatContextManager.getContext();
@@ -100,7 +100,7 @@ public class ConnectorTableServiceProxy {
      * @param useCache true, if the location can be retrieved from the cache
      * @return The table info object with the metadata location.
      */
-    @Cacheable(key = "'table.metadataLocationOnly.' + #name", condition = "#useCache")
+    @Cacheable(cacheNames = "metacat", key = "'table.metadataLocationOnly.' + #name", condition = "#useCache")
     public TableInfo getWithMetadataLocationOnly(final QualifiedName name,
                                                  final GetTableServiceParameters getTableServiceParameters,
                                                  final boolean useCache) {
@@ -115,7 +115,7 @@ public class ConnectorTableServiceProxy {
      * @param useCache true, if the location can be retrieved from the cache
      * @return The table info object
      */
-    @Cacheable(key = "'table.includeInfoDetails.' + #name", condition = "#useCache")
+    @Cacheable(cacheNames = "metacat", key = "'table.includeInfoDetails.' + #name", condition = "#useCache")
     public TableInfo getWithInfoDetails(final QualifiedName name,
                                         final GetTableServiceParameters getTableServiceParameters,
                                         final boolean useCache) {
@@ -131,7 +131,7 @@ public class ConnectorTableServiceProxy {
      * @param useCache true, if table can be retrieved from cache
      * @return table dto
      */
-    @Cacheable(key = "'table.' + #name", condition = "#useCache")
+    @Cacheable(cacheNames = "metacat", key = "'table.' + #name", condition = "#useCache")
     public TableInfo get(final QualifiedName name,
                          final GetTableServiceParameters getTableServiceParameters,
                          final boolean useCache) {
@@ -162,9 +162,9 @@ public class ConnectorTableServiceProxy {
      * @param isMView true, if the object is a view
      */
     @Caching(evict = {
-            @CacheEvict(key = "'table.' + #oldName", beforeInvocation = true),
-            @CacheEvict(key = "'table.includeInfoDetails.' + #oldName", beforeInvocation = true),
-            @CacheEvict(key = "'table.metadataLocationOnly.' + #oldName", beforeInvocation = true)
+            @CacheEvict(cacheNames = "metacat", key = "'table.' + #oldName", beforeInvocation = true),
+            @CacheEvict(cacheNames = "metacat", key = "'table.includeInfoDetails.' + #oldName", beforeInvocation = true),
+            @CacheEvict(cacheNames = "metacat", key = "'table.metadataLocationOnly.' + #oldName", beforeInvocation = true)
     })
     public void rename(
         final QualifiedName oldName,
@@ -190,9 +190,9 @@ public class ConnectorTableServiceProxy {
      * @return true if errors after this should be ignored.
      */
     @Caching(evict = {
-            @CacheEvict(key = "'table.' + #name", beforeInvocation = true),
-            @CacheEvict(key = "'table.includeInfoDetails.' + #name", beforeInvocation = true),
-            @CacheEvict(key = "'table.metadataLocationOnly.' + #name", beforeInvocation = true)
+            @CacheEvict(cacheNames = "metacat", key = "'table.' + #name", beforeInvocation = true),
+            @CacheEvict(cacheNames = "metacat", key = "'table.includeInfoDetails.' + #name", beforeInvocation = true),
+            @CacheEvict(cacheNames = "metacat", key = "'table.metadataLocationOnly.' + #name", beforeInvocation = true)
     })
     public boolean update(final QualifiedName name, final TableInfo tableInfo) {
         final MetacatRequestContext metacatRequestContext = MetacatContextManager.getContext();


### PR DESCRIPTION
Adding explicit cacheNames for all @Cacheable and @CacheEvict declarations to fix a potential issue with caching in SBN3 not enabled without explicit definition