### PR TITLE
Adding parameters flag to all JavaCompile tasks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,6 +77,10 @@ allprojects {
             url 'https://jitpack.io'
         }
     }
+
+    tasks.withType(JavaCompile).configureEach {
+        options.compilerArgs.add("-parameters")
+    }
 }
 
 idea {


### PR DESCRIPTION
Per internal discussion and reference, it seems we need to add a compile-time `-parameters` flag for argument name resolution as needed by @Cacheable, @CacheEvict, etc.

Spring reference: https://github.com/spring-projects/spring-framework/wiki/Spring-Framework-6.1-Release-Notes