### PR TITLE
BDW-496 Adding common view support to the Polaris Connector 

### DIFF
--- a/metacat-connector-polaris/src/functionalTest/resources/schema.sql
+++ b/metacat-connector-polaris/src/functionalTest/resources/schema.sql
@@ -19,6 +19,7 @@ create table TBLS (
   tbl_name varchar(255) not null,
   previous_metadata_location varchar(8192),
   metadata_location varchar(8192),
+  params TEXT,
   constraint uniq_name unique(db_name, tbl_name),
   created_by STRING(255),
   created_date TIMESTAMP not null,

--- a/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/PolarisConnectorTableService.java
+++ b/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/PolarisConnectorTableService.java
@@ -18,7 +18,10 @@ import com.netflix.metacat.common.server.connectors.exception.TableNotFoundExcep
 import com.netflix.metacat.common.server.connectors.exception.TablePreconditionFailedException;
 import com.netflix.metacat.common.server.connectors.model.TableInfo;
 import com.netflix.metacat.common.server.properties.Config;
+import com.netflix.metacat.common.server.util.MetacatUtils;
+import com.netflix.metacat.connector.hive.commonview.CommonViewHandler;
 import com.netflix.metacat.connector.hive.converters.HiveConnectorInfoConverter;
+import com.netflix.metacat.connector.hive.converters.HiveTypeConverter;
 import com.netflix.metacat.connector.hive.iceberg.IcebergTableHandler;
 import com.netflix.metacat.connector.hive.iceberg.IcebergTableWrapper;
 import com.netflix.metacat.connector.hive.sql.DirectSqlTable;
@@ -53,6 +56,7 @@ public class PolarisConnectorTableService implements ConnectorTableService {
     protected final HiveConnectorInfoConverter connectorConverter;
     protected final ConnectorContext connectorContext;
     protected final IcebergTableHandler icebergTableHandler;
+    protected final CommonViewHandler commonViewHandler;
     protected final PolarisTableMapper polarisTableMapper;
     protected final String catalogName;
 
@@ -64,6 +68,7 @@ public class PolarisConnectorTableService implements ConnectorTableService {
      * @param polarisConnectorDatabaseService   connector database service
      * @param connectorConverter                converter
      * @param icebergTableHandler               iceberg table handler
+     * @param commonViewHandler                 common view handler
      * @param polarisTableMapper                polaris table polarisTableMapper
      * @param connectorContext                  the connector context
      */
@@ -73,6 +78,7 @@ public class PolarisConnectorTableService implements ConnectorTableService {
         final PolarisConnectorDatabaseService polarisConnectorDatabaseService,
         final HiveConnectorInfoConverter connectorConverter,
         final IcebergTableHandler icebergTableHandler,
+        final CommonViewHandler commonViewHandler,
         final PolarisTableMapper polarisTableMapper,
         final ConnectorContext connectorContext
     ) {
@@ -81,6 +87,7 @@ public class PolarisConnectorTableService implements ConnectorTableService {
         this.connectorConverter = connectorConverter;
         this.connectorContext = connectorContext;
         this.icebergTableHandler = icebergTableHandler;
+        this.commonViewHandler = commonViewHandler;
         this.polarisTableMapper = polarisTableMapper;
         this.catalogName = catalogName;
     }
@@ -98,8 +105,13 @@ public class PolarisConnectorTableService implements ConnectorTableService {
         }
         try {
             final PolarisTableEntity entity = polarisTableMapper.toEntity(tableInfo);
-            polarisStoreService.createTable(entity.getDbName(), entity.getTblName(),
+            if (HiveTableUtil.isCommonView(tableInfo)) {
+                polarisStoreService.createTable(entity.getDbName(), entity.getTblName(),
+                    entity.getMetadataLocation(), entity.getParams(), createdBy);
+            } else {
+                polarisStoreService.createTable(entity.getDbName(), entity.getTblName(),
                     entity.getMetadataLocation(), createdBy);
+            }
         } catch (DataIntegrityViolationException | InvalidMetaException exception) {
             throw new InvalidMetaException(name, exception);
         } catch (Exception exception) {
@@ -150,8 +162,10 @@ public class PolarisConnectorTableService implements ConnectorTableService {
             final PolarisTableEntity polarisTableEntity = polarisStoreService
                 .getTable(name.getDatabaseName(), name.getTableName())
                 .orElseThrow(() -> new TableNotFoundException(name));
-            final TableInfo info = polarisTableMapper.toInfo(polarisTableEntity);
+            final boolean isView = MetacatUtils.isCommonView(polarisTableEntity.getParams());
+            final TableInfo info = polarisTableMapper.toInfo(polarisTableEntity, isView);
             final String tableLoc = HiveTableUtil.getIcebergTableMetadataLocation(info);
+
             // Return the iceberg table with just the metadata location included if requested.
             if (connectorContext.getConfig().shouldFetchOnlyMetadataLocationEnabled()
                     && requestContext.isIncludeMetadataLocationOnly()) {
@@ -160,8 +174,12 @@ public class PolarisConnectorTableService implements ConnectorTableService {
                         .fields(Collections.emptyList())
                         .build();
             }
-            return getIcebergTable(name, tableLoc, info,
-                requestContext.isIncludeMetadata(), connectorContext.getConfig().isIcebergCacheEnabled());
+            if (isView) {
+                return getCommonView(name, tableLoc, info, connectorContext.getConfig().isIcebergCacheEnabled());
+            } else {
+                return getIcebergTable(name, tableLoc, info,
+                        requestContext.isIncludeMetadata(), connectorContext.getConfig().isIcebergCacheEnabled());
+            }
         } catch (TableNotFoundException | IllegalArgumentException exception) {
             log.error(String.format("Not found exception for polaris table %s", name), exception);
             throw exception;
@@ -219,13 +237,19 @@ public class PolarisConnectorTableService implements ConnectorTableService {
         final QualifiedName name = tableInfo.getName();
         final Config conf = connectorContext.getConfig();
         final String lastModifiedBy = PolarisUtils.getUserOrDefault(requestContext);
-        icebergTableHandler.update(tableInfo);
+        final boolean isView = HiveTableUtil.isCommonView(tableInfo);
+        if (isView) {
+            commonViewHandler.update(tableInfo);
+        } else {
+            icebergTableHandler.update(tableInfo);
+        }
         try {
             final Map<String, String> newTableMetadata = tableInfo.getMetadata();
             if (MapUtils.isEmpty(newTableMetadata)) {
                 log.warn("No parameters defined for iceberg table %s, no data update needed", name);
                 return;
             }
+
             final String prevLoc = newTableMetadata.get(DirectSqlTable.PARAM_PREVIOUS_METADATA_LOCATION);
             final String newLoc = newTableMetadata.get(DirectSqlTable.PARAM_METADATA_LOCATION);
             if (StringUtils.isBlank(prevLoc)) {
@@ -248,10 +272,25 @@ public class PolarisConnectorTableService implements ConnectorTableService {
                 log.error(message);
                 throw new InvalidMetaException(name, message, null);
             }
-            // optimistically attempt to update metadata location
-            final boolean updated = polarisStoreService.updateTableMetadataLocation(
-                    name.getDatabaseName(), name.getTableName(),
-                    prevLoc, newLoc, lastModifiedBy);
+
+            boolean updated = false;
+            if (isView) {
+                final Map<String, String> newTableParams = polarisTableMapper.filterMetadata(newTableMetadata);
+                final Map<String, String> existingTableParams = polarisStoreService
+                    .getTable(name.getDatabaseName(), name.getTableName())
+                    .orElseThrow(() -> new TableNotFoundException(name))
+                    .getParams();
+                // optimistically attempt to update metadata location and/or params
+                updated = polarisStoreService.updateTableMetadataLocationAndParams(
+                    name.getDatabaseName(), name.getTableName(), prevLoc, newLoc,
+                    existingTableParams, newTableParams, lastModifiedBy);
+            } else {
+                // optimistically attempt to update metadata location
+                updated = polarisStoreService.updateTableMetadataLocation(
+                    name.getDatabaseName(), name.getTableName(), prevLoc, newLoc, lastModifiedBy
+                );
+            }
+
             // if succeeded then done, else try to figure out why and throw corresponding exception
             if (updated) {
                 requestContext.setIgnoreErrorsAfterUpdate(true);
@@ -350,7 +389,10 @@ public class PolarisConnectorTableService implements ConnectorTableService {
                 ConnectorUtils.sort(tbls, sort, Comparator.comparing(t -> t.getTblName()));
             }
             return ConnectorUtils.paginate(tbls, pageable).stream()
-                .map(t -> polarisTableMapper.toInfo(t)).collect(Collectors.toList());
+                .map(
+                    t -> polarisTableMapper.toInfo(t, MetacatUtils.isCommonView(t.getParams()))
+                )
+                .collect(Collectors.toList());
         } catch (Exception exception) {
             final String msg = String.format("Failed polaris list tables %s using prefix %s", name, prefix);
             log.error(msg, exception);
@@ -362,7 +404,7 @@ public class PolarisConnectorTableService implements ConnectorTableService {
      * Return the table metadata from cache if exists else make the iceberg call and refresh it.
      * @param tableName             table name
      * @param tableMetadataLocation table metadata location
-     * @param info                  table info stored in hive metastore
+     * @param info                  table info stored in Polaris
      * @param includeInfoDetails    if true, will include more details like the manifest file content
      * @param useCache              true, if table can be retrieved from cache
      * @return TableInfo
@@ -380,6 +422,24 @@ public class PolarisConnectorTableService implements ConnectorTableService {
         final IcebergTableWrapper icebergTable =
             this.icebergTableHandler.getIcebergTable(tableName, tableMetadataLocation, includeInfoDetails);
         return connectorConverter.fromIcebergTableToTableInfo(tableName, icebergTable, tableMetadataLocation, info);
+    }
+
+    /**
+     * Return the view metadata from cache if exists else make the iceberg call and refresh it.
+     * @param tableName             table name
+     * @param tableMetadataLocation table metadata location
+     * @param info                  table info stored in Polaris
+     * @param useCache              true, if table can be retrieved from cache
+     * @return TableInfo
+     */
+    @Cacheable(key = "'iceberg.view.' + #tableMetadataLocation", condition = "#useCache")
+    public TableInfo getCommonView(final QualifiedName tableName,
+                                   final String tableMetadataLocation,
+                                   final TableInfo info,
+                                   final boolean useCache) {
+        return commonViewHandler.getCommonViewTableInfo(
+                tableName, tableMetadataLocation, info, new HiveTypeConverter()
+        );
     }
 
     @Override

--- a/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/configs/PolarisConnectorConfig.java
+++ b/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/configs/PolarisConnectorConfig.java
@@ -3,6 +3,7 @@ package com.netflix.metacat.connector.polaris.configs;
 import com.google.common.collect.ImmutableMap;
 import com.netflix.metacat.common.server.connectors.ConnectorContext;
 import com.netflix.metacat.common.server.util.ThreadServiceManager;
+import com.netflix.metacat.connector.hive.commonview.CommonViewHandler;
 import com.netflix.metacat.connector.hive.converters.HiveConnectorInfoConverter;
 import com.netflix.metacat.connector.hive.iceberg.IcebergTableCriteria;
 import com.netflix.metacat.connector.hive.iceberg.IcebergTableCriteriaImpl;
@@ -67,6 +68,7 @@ public class PolarisConnectorConfig {
      * @param connectorConverter        connector converter
      * @param connectorDatabaseService  polaris database service
      * @param icebergTableHandler       iceberg table handler
+     * @param commonViewHandler         common view handler
      * @param polarisTableMapper        polaris table mapper
      * @param connectorContext          connector context
      * @return PolarisConnectorTableService
@@ -78,6 +80,7 @@ public class PolarisConnectorConfig {
         final HiveConnectorInfoConverter connectorConverter,
         final PolarisConnectorDatabaseService connectorDatabaseService,
         final IcebergTableHandler icebergTableHandler,
+        final CommonViewHandler commonViewHandler,
         final PolarisTableMapper polarisTableMapper,
         final ConnectorContext connectorContext
     ) {
@@ -87,6 +90,7 @@ public class PolarisConnectorConfig {
             connectorDatabaseService,
             connectorConverter,
             icebergTableHandler,
+            commonViewHandler,
             polarisTableMapper,
             connectorContext
         );
@@ -120,6 +124,16 @@ public class PolarisConnectorConfig {
             icebergTableCriteria,
             icebergTableOpWrapper,
             icebergTableOpsProxy);
+    }
+
+    /**
+     * Create common view handler.
+     * @param connectorContext server context
+     * @return CommonViewHandler
+     */
+    @Bean
+    public CommonViewHandler commonViewHandler(final ConnectorContext connectorContext) {
+        return new CommonViewHandler(connectorContext);
     }
 
     /**

--- a/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/mappers/PolarisTableMapper.java
+++ b/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/mappers/PolarisTableMapper.java
@@ -1,6 +1,6 @@
 package com.netflix.metacat.connector.polaris.mappers;
 
-import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.netflix.metacat.common.QualifiedName;
 import com.netflix.metacat.common.server.connectors.exception.InvalidMetaException;
 import com.netflix.metacat.common.server.connectors.model.AuditInfo;
@@ -12,7 +12,10 @@ import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import java.sql.Date;
+import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Table object mapper implementations.
@@ -24,6 +27,13 @@ public class PolarisTableMapper implements
     private static final String PARAMETER_SPARK_SQL_PROVIDER = "spark.sql.sources.provider";
     private static final String PARAMETER_EXTERNAL = "EXTERNAL";
     private static final String PARAMETER_METADATA_PREFIX = "/metadata/";
+    private static final Set<String> EXCLUDED_PARAM_KEYS = ImmutableSet.of(
+        DirectSqlTable.PARAM_METADATA_LOCATION,
+        DirectSqlTable.PARAM_PREVIOUS_METADATA_LOCATION,
+        DirectSqlTable.PARAM_TABLE_TYPE,
+        DirectSqlTable.PARAM_PARTITION_SPEC,
+        DirectSqlTable.PARAM_METADATA_CONTENT
+    );
     private final String catalogName;
 
     /**
@@ -39,26 +49,57 @@ public class PolarisTableMapper implements
      */
     @Override
     public TableInfo toInfo(final PolarisTableEntity entity) {
+        return toInfo(entity, false);
+    }
+
+    /**
+     * Maps an Entity to the Info object.
+     *
+     * @param entity The entity to map from.
+     * @param isView Whether the given entity represents a common view
+     * @return The result info object.
+     */
+    public TableInfo toInfo(final PolarisTableEntity entity, final boolean isView) {
         final int uriIndex = entity.getMetadataLocation().indexOf(PARAMETER_METADATA_PREFIX);
+
+        final HashMap<String, String> metadata = new HashMap<>();
+        metadata.put(DirectSqlTable.PARAM_METADATA_LOCATION, entity.getMetadataLocation());
+
+        if (isView) {
+            metadata.putAll(entity.getParams());
+        } else {
+            metadata.put(PARAMETER_EXTERNAL, "TRUE");
+            metadata.put(PARAMETER_SPARK_SQL_PROVIDER, "iceberg");
+            metadata.put(DirectSqlTable.PARAM_TABLE_TYPE, DirectSqlTable.ICEBERG_TABLE_TYPE);
+        }
+
         final TableInfo tableInfo = TableInfo.builder()
             .name(QualifiedName.ofTable(catalogName, entity.getDbName(), entity.getTblName()))
-            .metadata(ImmutableMap.of(
-                DirectSqlTable.PARAM_METADATA_LOCATION, entity.getMetadataLocation(),
-                PARAMETER_EXTERNAL, "TRUE", PARAMETER_SPARK_SQL_PROVIDER, "iceberg",
-                DirectSqlTable.PARAM_TABLE_TYPE, DirectSqlTable.ICEBERG_TABLE_TYPE))
+            .metadata(metadata)
             .serde(StorageInfo.builder().inputFormat("org.apache.hadoop.mapred.FileInputFormat")
                 .outputFormat("org.apache.hadoop.mapred.FileOutputFormat")
                 .serializationLib("org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe")
                 .uri(uriIndex > 0 ? entity.getMetadataLocation().substring(0, uriIndex) : "")
                 .build())
             .auditInfo(AuditInfo.builder()
-                    .createdBy(entity.getAudit().getCreatedBy())
-                    .createdDate(Date.from(entity.getAudit().getCreatedDate()))
-                    .lastModifiedBy(entity.getAudit().getLastModifiedBy())
-                    .lastModifiedDate(Date.from(entity.getAudit().getLastModifiedDate()))
-                    .build())
+                .createdBy(entity.getAudit().getCreatedBy())
+                .createdDate(Date.from(entity.getAudit().getCreatedDate()))
+                .lastModifiedBy(entity.getAudit().getLastModifiedBy())
+                .lastModifiedDate(Date.from(entity.getAudit().getLastModifiedDate()))
+                .build())
             .build();
         return tableInfo;
+    }
+
+    /**
+     * Given TableInfo.metadata, filter out reserved metadata keys which should not be stored as table params.
+     * @param metadata TableInfo.metadata
+     * @return Map of table params which can be stored in PolarisTableEntity.params
+     */
+    public Map<String, String> filterMetadata(final Map<String, String> metadata) {
+        return metadata.entrySet()
+            .stream().filter(entry -> !EXCLUDED_PARAM_KEYS.contains(entry.getKey()))
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
     /**
@@ -76,10 +117,12 @@ public class PolarisTableMapper implements
             final String message = String.format("No metadata location defined for iceberg table %s", info.getName());
             throw new InvalidMetaException(info.getName(), message, null);
         }
+
         final PolarisTableEntity tableEntity = PolarisTableEntity.builder()
             .dbName(info.getName().getDatabaseName())
             .tblName(info.getName().getTableName())
             .metadataLocation(location)
+            .params(filterMetadata(metadata))
             .build();
         return tableEntity;
     }

--- a/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/store/PolarisStoreConnector.java
+++ b/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/store/PolarisStoreConnector.java
@@ -12,7 +12,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import javax.annotation.Nullable;
 import java.time.Instant;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -115,6 +117,24 @@ public class PolarisStoreConnector implements PolarisStoreService {
                                           final String tableName,
                                           final String metadataLocation,
                                           final String createdBy) {
+        return createTable(dbName, tableName, metadataLocation, new HashMap<>(), createdBy);
+    }
+
+    /**
+     * Creates entry for new table (with parameters).
+     * @param dbName database name
+     * @param tableName table name
+     * @param metadataLocation metadata location of the table.
+     * @param params table parameters
+     * @param createdBy user creating this table.
+     * @return entity corresponding to created table entry
+     */
+    @Override
+    public PolarisTableEntity createTable(final String dbName,
+                                          final String tableName,
+                                          final String metadataLocation,
+                                          final Map<String, String> params,
+                                          final String createdBy) {
         final AuditEntity auditEntity = AuditEntity.builder()
                 .createdBy(createdBy)
                 .lastModifiedBy(createdBy)
@@ -124,6 +144,7 @@ public class PolarisStoreConnector implements PolarisStoreService {
                 .dbName(dbName)
                 .tblName(tableName)
                 .metadataLocation(metadataLocation)
+                .params(params)
                 .build();
         return tblRepo.save(e);
     }
@@ -221,6 +242,31 @@ public class PolarisStoreConnector implements PolarisStoreService {
         final int updatedRowCount =
                 tblRepo.updateMetadataLocation(databaseName, tableName,
                         expectedLocation, newLocation, lastModifiedBy, Instant.now());
+        return updatedRowCount > 0;
+    }
+
+    /**
+     * Do an atomic compare-and-swap to update the table's metdata location and params.
+     * @param databaseName database name of the table
+     * @param tableName table name
+     * @param expectedLocation expected current metadata-location of the table
+     * @param newLocation new metadata location of the table
+     * @param existingParams current parameters of the table
+     * @param newParams new parameters of the table (should only include changed values)
+     * @param lastModifiedBy user updating the location
+     * @return true, if the location update was successful. false, otherwise
+     */
+    public boolean updateTableMetadataLocationAndParams(
+        final String databaseName, final String tableName,
+        final String expectedLocation, final String newLocation,
+        final Map<String, String> existingParams, final Map<String, String> newParams,
+        final String lastModifiedBy) {
+        final Map<String, String> mergedParams = existingParams == null
+            ? new HashMap<>() : new HashMap<>(existingParams);
+        mergedParams.putAll(newParams);
+        final int updatedRowCount =
+            tblRepo.updateMetadataLocationAndParams(databaseName, tableName,
+                expectedLocation, newLocation, mergedParams, lastModifiedBy, Instant.now());
         return updatedRowCount > 0;
     }
 }

--- a/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/store/PolarisStoreService.java
+++ b/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/store/PolarisStoreService.java
@@ -5,6 +5,7 @@ import com.netflix.metacat.connector.polaris.store.entities.PolarisDatabaseEntit
 import com.netflix.metacat.connector.polaris.store.entities.PolarisTableEntity;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -77,6 +78,18 @@ public interface PolarisStoreService {
     PolarisTableEntity createTable(String dbName, String tableName, String metadataLocation, String createdBy);
 
     /**
+     * Creates entry for new table (with parameters).
+     * @param dbName database name
+     * @param tableName table name
+     * @param metadataLocation metadata location of the table.
+     * @param params table parameters
+     * @param createdBy user creating this table.
+     * @return entity corresponding to created table entry
+     */
+    PolarisTableEntity createTable(String dbName, String tableName,
+                                   String metadataLocation, Map<String, String> params, String createdBy);
+
+    /**
      * Fetches table entry.
      * @param dbName database name
      * @param tableName table name
@@ -137,4 +150,22 @@ public interface PolarisStoreService {
         String databaseName, String tableName,
         String expectedLocation, String newLocation,
         String lastModifiedBy);
+
+    /**
+     * Do an atomic compare-and-swap to update the table's metdata location and params.
+     * @param databaseName database name of the table
+     * @param tableName table name
+     * @param expectedLocation expected current metadata-location of the table
+     * @param newLocation new metadata location of the table
+     * @param existingParams current parameters of the table
+     * @param newParams new parameters of the table (should only include changed values)
+     * @param lastModifiedBy user updating the location
+     * @return true, if the location update was successful. false, otherwise
+     */
+    boolean updateTableMetadataLocationAndParams(
+        final String databaseName, final String tableName,
+        final String expectedLocation, final String newLocation,
+        final Map<String, String> existingParams, final Map<String, String> newParams,
+        final String lastModifiedBy
+    );
 }

--- a/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/store/entities/PolarisTableEntity.java
+++ b/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/store/entities/PolarisTableEntity.java
@@ -1,5 +1,6 @@
 package com.netflix.metacat.connector.polaris.store.entities;
 
+import jakarta.persistence.Convert;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -19,6 +20,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.persistence.Version;
+import java.util.Map;
 
 
 /**
@@ -65,6 +67,11 @@ public class PolarisTableEntity {
 
     @Embedded
     private AuditEntity audit;
+
+    @Setter
+    @Convert(converter = StringParamsConverter.class)
+    @Column(name = "params", nullable = true, updatable = true)
+    private Map<String, String> params;
 
     /**
      * Constructor for Polaris Table Entity.

--- a/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/store/entities/StringParamsConverter.java
+++ b/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/store/entities/StringParamsConverter.java
@@ -1,0 +1,43 @@
+package com.netflix.metacat.connector.polaris.store.entities;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * Converter to represent String Map as a JSON-formatted String in the database.
+ */
+@Converter
+public class StringParamsConverter implements AttributeConverter<Map<String, String>, String> {
+    @Override
+    public String convertToDatabaseColumn(final Map<String, String> attribute) {
+        if (attribute == null || attribute.isEmpty()) {
+            return null;
+        }
+        final TreeMap<String, String> map = new TreeMap<>(attribute);
+        try {
+            return new ObjectMapper().writeValueAsString(map);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Error converting params Map to String", e);
+        }
+    }
+
+    @Override
+    public Map<String, String> convertToEntityAttribute(final String dbData) {
+        if (dbData == null || dbData.isEmpty()) {
+            return new HashMap<>();
+        }
+
+        try {
+            return new ObjectMapper().readValue(dbData, new TypeReference<Map<String, String>>() { });
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Error converting params String to Map", e);
+        }
+    }
+}

--- a/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/store/repos/PolarisTableRepository.java
+++ b/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/store/repos/PolarisTableRepository.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -89,6 +90,32 @@ public interface PolarisTableRepository extends JpaRepository<PolarisTableEntity
         @Param("tableName") final String tableName,
         @Param("expectedLocation") final String expectedLocation,
         @Param("newLocation") final String newLocation,
+        @Param("lastModifiedBy") final String lastModifiedBy,
+        @Param("lastModifiedDate") final Instant lastModifiedDate);
+
+    /**
+     * Do an atomic compare-and-swap on the metadata location and parameters of the table.
+     * @param dbName database name of the table
+     * @param tableName table name
+     * @param expectedLocation expected metadata location before the update is done.
+     * @param newLocation new metadata location of the table.
+     * @param newParams new parameters of the table
+     * @param lastModifiedBy user updating the location.
+     * @param lastModifiedDate timestamp for when the location was updated.
+     * @return number of rows that are updated.
+     */
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
+    @Query("UPDATE PolarisTableEntity t SET t.metadataLocation = :newLocation, t.params = :newParams,"
+        + "t.audit.lastModifiedBy = :lastModifiedBy, t.audit.lastModifiedDate = :lastModifiedDate, "
+        + "t.previousMetadataLocation = t.metadataLocation, t.version = t.version + 1 "
+        + "WHERE t.metadataLocation = :expectedLocation AND t.dbName = :dbName AND t.tblName = :tableName")
+    @Transactional
+    int updateMetadataLocationAndParams(
+        @Param("dbName") final String dbName,
+        @Param("tableName") final String tableName,
+        @Param("expectedLocation") final String expectedLocation,
+        @Param("newLocation") final String newLocation,
+        @Param("newParams") final Map<String, String> newParams,
         @Param("lastModifiedBy") final String lastModifiedBy,
         @Param("lastModifiedDate") final Instant lastModifiedDate);
 }

--- a/metacat-connector-polaris/src/test/java/com/netflix/metacat/connector/polaris/store/entities/StringParamsConverterTest.java
+++ b/metacat-connector-polaris/src/test/java/com/netflix/metacat/connector/polaris/store/entities/StringParamsConverterTest.java
@@ -1,0 +1,61 @@
+package com.netflix.metacat.connector.polaris.store.entities;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+class StringParamsConverterTest {
+    private static final Map<String, String> VALID_MAP_PARAM = new HashMap<>() { {
+        put("keyA", "value1");
+        put("keyB", "value2");
+        put("keyC", "value3");
+    } };
+    private static final String VALID_STRING_PARAM = "{\"keyA\":\"value1\",\"keyB\":\"value2\",\"keyC\":\"value3\"}";
+    private static final String NESTED_STRING_PARAM = "{\"keyA\":{\"keyB\":\"value2\"},\"keyC\":\"value3\"}";
+
+    private final StringParamsConverter converter = new StringParamsConverter();
+
+    @Test
+    void validMapToStringConversion() {
+        String converted = converter.convertToDatabaseColumn(VALID_MAP_PARAM);
+        Assertions.assertEquals(
+            VALID_STRING_PARAM,
+            converted
+        );
+    }
+
+    @Test
+    void validStringToMapConversion() {
+        Map<String, String> converted = converter.convertToEntityAttribute(VALID_STRING_PARAM);
+        Assertions.assertEquals(
+            VALID_MAP_PARAM,
+            converted
+        );
+    }
+
+    @Test
+    void invalidStringToMapConversion() {
+        Assertions.assertThrowsExactly(
+            RuntimeException.class,
+            () -> converter.convertToEntityAttribute(VALID_STRING_PARAM.substring(10)),
+            "Error converting params String to Map"
+        );
+
+        Assertions.assertThrowsExactly(
+            RuntimeException.class,
+            () -> converter.convertToEntityAttribute(NESTED_STRING_PARAM),
+            "Error converting params String to Map"
+        );
+    }
+
+    @Test
+    void nullEmptyConversionBehavior() {
+        Assertions.assertNull(converter.convertToDatabaseColumn(null));
+        Assertions.assertNull(converter.convertToDatabaseColumn(new HashMap<>()));
+
+        Assertions.assertEquals(new HashMap<>(), converter.convertToEntityAttribute(null));
+        Assertions.assertEquals(new HashMap<>(), converter.convertToEntityAttribute(""));
+    }
+}

--- a/metacat-connector-polaris/src/test/java/com/netflix/metacat/connector/polaris/store/entities/package-info.java
+++ b/metacat-connector-polaris/src/test/java/com/netflix/metacat/connector/polaris/store/entities/package-info.java
@@ -1,0 +1,22 @@
+/*
+ *
+ *  Copyright 2021 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+/**
+ * Polaris connector test classes.
+ */
+package com.netflix.metacat.connector.polaris.store.entities;

--- a/metacat-connector-polaris/src/test/resources/h2db/schema.sql
+++ b/metacat-connector-polaris/src/test/resources/h2db/schema.sql
@@ -19,6 +19,7 @@ create table TBLS (
   tbl_name varchar(255) not null,
   previous_metadata_location varchar(1024),
   metadata_location varchar(1024),
+  params TEXT,
   constraint uniq_name unique(db_name, tbl_name),
   created_by varchar(255),
   created_date TIMESTAMP not null,

--- a/metacat-functional-tests/metacat-test-cluster/datastores/crdb/sql/schema.sql
+++ b/metacat-functional-tests/metacat-test-cluster/datastores/crdb/sql/schema.sql
@@ -19,6 +19,7 @@ create table TBLS (
     tbl_name varchar(255) not null,
     previous_metadata_location varchar(8192),
     metadata_location varchar(8192),
+    params text,
     created_by STRING(255),
     created_date TIMESTAMP not null,
     last_updated_by STRING(255),

--- a/metacat-functional-tests/src/functionalTest/groovy/com/netflix/metacat/MetacatSmokeSpec.groovy
+++ b/metacat-functional-tests/src/functionalTest/groovy/com/netflix/metacat/MetacatSmokeSpec.groovy
@@ -108,6 +108,7 @@ class MetacatSmokeSpec extends Specification {
         def catalog = api.getCatalog(catalogName)
         if (!catalog.databases.contains(databaseName)) {
             api.createDatabase(catalogName, databaseName, new DatabaseCreateRequestDto())
+            Thread.sleep(5000)
         }
         def database = api.getDatabase(catalogName, databaseName, false, true)
         def owner = 'amajumdar'
@@ -590,7 +591,6 @@ class MetacatSmokeSpec extends Specification {
 
     def "Test materialized common view create/drop"() {
         given:
-        def catalogName = 'hive-metastore'
         def databaseName = 'iceberg_db'
         def storageTableName = 'st_iceberg_table'
         def commonViewName = 'test_common_view'
@@ -610,6 +610,7 @@ class MetacatSmokeSpec extends Specification {
         def catalog = api.getCatalog(catalogName)
         if (!catalog.databases.contains(databaseName)) {
             api.createDatabase(catalogName, databaseName, new DatabaseCreateRequestDto())
+            Thread.sleep(5000)
         }
         api.createTable(catalogName, databaseName, storageTableName, tableDto)
         then:
@@ -623,6 +624,8 @@ class MetacatSmokeSpec extends Specification {
         api.getTable(catalogName, databaseName, storageTableName, true, false, false)
         then:
         thrown(MetacatNotFoundException)
+        where:
+        catalogName << ['polaris-metastore', 'hive-metastore']
     }
 
     @Unroll


### PR DESCRIPTION
* Adding support for table parameters in Polaris
  * Update the PolarisTableEntity to include a params field
  * Add AttributeConverter for storing params in JSON-formatted string
  * Update PolarisTableMapper to include and filter params when mapping to/from TableInfo
  * Add support in PolarisConnectorTableService + PolarisTableRepository + PolarisStore to update params
  * Update test schemas to enable testing table params
* Repurpose CommonViewHandler to add common view support to Polaris

note: cherry-picked from https://github.com/Netflix/metacat/commit/4fe3671731534138a365dcaa8b72c994cabff51a