### PR TITLE
select definitionMetada with update

### DIFF
--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/Config.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/Config.java
@@ -649,5 +649,13 @@ public interface Config {
      * @return parentChildRelationshipProperties
      */
     ParentChildRelationshipProperties getParentChildRelationshipProperties();
+
+
+    /**
+     * Whether we enable select for update during saveDefinitionMetadata.
+     *
+     * @return True if it should be.
+     */
+    boolean isDefinitionMetadataSelectForUpdateEnabled();
 }
 

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/DefaultConfigImpl.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/DefaultConfigImpl.java
@@ -708,4 +708,9 @@ public class DefaultConfigImpl implements Config {
     public ParentChildRelationshipProperties getParentChildRelationshipProperties() {
         return this.metacatProperties.getParentChildRelationshipProperties();
     }
+
+    @Override
+    public boolean isDefinitionMetadataSelectForUpdateEnabled() {
+        return this.metacatProperties.getUsermetadata().isDefinitionMetadataSelectForUpdateEnabled();
+    }
 }

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/ServiceProperties.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/ServiceProperties.java
@@ -41,7 +41,6 @@ public class ServiceProperties {
     private int listTableNamesPageSize = 10000;
     private int listDatabaseEntitiesPageSize = 1000;
     private int listDatabaseNamesPageSize = 10000;
-
     /**
      * Max related properties.
      *

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/UserMetadata.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/properties/UserMetadata.java
@@ -32,6 +32,7 @@ public class UserMetadata {
     private Config config = new Config();
     private int queryTimeoutInSeconds = 60;
     private int longQueryTimeoutInSeconds = 120;
+    private boolean definitionMetadataSelectForUpdateEnabled;
 
     /**
      * config related properties.

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/usermetadata/MetadataPreMergeInterceptor.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/usermetadata/MetadataPreMergeInterceptor.java
@@ -1,0 +1,27 @@
+package com.netflix.metacat.common.server.usermetadata;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.netflix.metacat.common.QualifiedName;
+import com.netflix.metacat.common.server.connectors.exception.InvalidMetadataException;
+
+/**
+ * MetadataPreMergeInterceptor: This interceptor runs before merging the existing metadata and the new metadata.
+ * @author yingjianw
+ * @since 1.2.0
+ */
+public interface MetadataPreMergeInterceptor {
+    /**
+     * Validate ObjectNode before storing it.
+     * @param userMetadataService user metadata service
+     * @param name                qualified name
+     * @param existingMetadata    existing metadata
+     * @param newMetadata         newMetadata
+     * @throws InvalidMetadataException business validation exception
+     */
+    default void onWrite(final UserMetadataService userMetadataService,
+                         final QualifiedName name,
+                         final ObjectNode existingMetadata,
+                         final ObjectNode newMetadata) throws InvalidMetadataException {
+
+    }
+}

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/usermetadata/MetadataPreMergeInterceptor.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/usermetadata/MetadataPreMergeInterceptor.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.netflix.metacat.common.QualifiedName;
 import com.netflix.metacat.common.server.connectors.exception.InvalidMetadataException;
 
+import java.util.Optional;
+
 /**
  * MetadataPreMergeInterceptor: This interceptor runs before merging the existing metadata and the new metadata.
  * @author yingjianw
@@ -20,8 +22,8 @@ public interface MetadataPreMergeInterceptor {
      */
     default void onWrite(final UserMetadataService userMetadataService,
                          final QualifiedName name,
-                         final ObjectNode existingMetadata,
-                         final ObjectNode newMetadata) throws InvalidMetadataException {
+                         final Optional<ObjectNode> existingMetadata,
+                         final Optional<ObjectNode> newMetadata) throws InvalidMetadataException {
 
     }
 }

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/usermetadata/MetadataPreMergeInterceptorImpl.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/usermetadata/MetadataPreMergeInterceptorImpl.java
@@ -1,0 +1,10 @@
+package com.netflix.metacat.common.server.usermetadata;
+
+/**
+ * MetadataPreMergeInterceptorImpl.
+ *
+ * @author yingjianw
+ * @since 1.2.0
+ */
+public class MetadataPreMergeInterceptorImpl implements MetadataPreMergeInterceptor {
+}

--- a/metacat-main/src/main/java/com/netflix/metacat/main/services/impl/TableServiceImpl.java
+++ b/metacat-main/src/main/java/com/netflix/metacat/main/services/impl/TableServiceImpl.java
@@ -684,11 +684,6 @@ public class TableServiceImpl implements TableService {
                 log.info("Saving user metadata for table {}", name);
                 final long start = registry.clock().wallTime();
                 userMetadataService.saveMetadata(metacatRequestContext.getUserName(), tableDto, true);
-                final long vtts = MetacatUtils.getVtts(tableDto.getDefinitionMetadata());
-                if (vtts > 0) {
-                    log.info("Received vtts update for {} to {}", name, vtts);
-                    userMetadataService.saveMetadata(metacatRequestContext.getUserName(), tableDto, true);
-                }
 
                 final long duration = registry.clock().wallTime() - start;
                 log.info("Time taken to save user metadata for table {} is {} ms", name, duration);

--- a/metacat-metadata-mysql/src/main/java/com/netflix/metacat/metadata/mysql/MySqlUserMetadataConfig.java
+++ b/metacat-metadata-mysql/src/main/java/com/netflix/metacat/metadata/mysql/MySqlUserMetadataConfig.java
@@ -17,6 +17,8 @@ import com.netflix.metacat.common.json.MetacatJson;
 import com.netflix.metacat.common.server.converter.ConverterUtil;
 import com.netflix.metacat.common.server.properties.Config;
 import com.netflix.metacat.common.server.properties.MetacatProperties;
+import com.netflix.metacat.common.server.usermetadata.MetadataPreMergeInterceptor;
+import com.netflix.metacat.common.server.usermetadata.MetadataPreMergeInterceptorImpl;
 import com.netflix.metacat.common.server.usermetadata.UserMetadataService;
 import com.netflix.metacat.common.server.usermetadata.LookupService;
 import com.netflix.metacat.common.server.usermetadata.TagService;
@@ -55,6 +57,17 @@ public class MySqlUserMetadataConfig {
     }
 
     /**
+     * MetadataSQLInterceptor layer.
+     * @return MetadataSQLInterceptor
+     */
+    @Bean
+    @ConditionalOnMissingBean(MetadataPreMergeInterceptor.class)
+    public MetadataPreMergeInterceptor metadataPreMergeInterceptor(
+    ) {
+        return new MetadataPreMergeInterceptorImpl();
+    }
+
+    /**
      * User Metadata service.
      *
      * @param jdbcTemplate JDBC template
@@ -68,9 +81,10 @@ public class MySqlUserMetadataConfig {
         @Qualifier("metadataJdbcTemplate") final JdbcTemplate jdbcTemplate,
         final Config config,
         final MetacatJson metacatJson,
-        final MetadataInterceptor metadataInterceptor
-    ) {
-        return new MysqlUserMetadataService(jdbcTemplate, metacatJson, config, metadataInterceptor);
+        final MetadataInterceptor metadataInterceptor,
+        final MetadataPreMergeInterceptor metadataPreMergeInterceptor
+        ) {
+        return new MysqlUserMetadataService(jdbcTemplate, metacatJson, config, metadataInterceptor, metadataPreMergeInterceptor);
     }
 
 

--- a/metacat-metadata-mysql/src/main/java/com/netflix/metacat/metadata/mysql/MySqlUserMetadataConfig.java
+++ b/metacat-metadata-mysql/src/main/java/com/netflix/metacat/metadata/mysql/MySqlUserMetadataConfig.java
@@ -74,6 +74,7 @@ public class MySqlUserMetadataConfig {
      * @param config       System config to use
      * @param metacatJson  Json Utilities to use
      * @param metadataInterceptor  business metadata manager
+     * @param metadataPreMergeInterceptor metadataPreMergeInterceptor
      * @return User metadata service based on MySql
      */
     @Bean
@@ -84,7 +85,13 @@ public class MySqlUserMetadataConfig {
         final MetadataInterceptor metadataInterceptor,
         final MetadataPreMergeInterceptor metadataPreMergeInterceptor
         ) {
-        return new MysqlUserMetadataService(jdbcTemplate, metacatJson, config, metadataInterceptor, metadataPreMergeInterceptor);
+        return new MysqlUserMetadataService(
+            jdbcTemplate,
+            metacatJson,
+            config,
+            metadataInterceptor,
+            metadataPreMergeInterceptor
+        );
     }
 
 

--- a/metacat-metadata-mysql/src/main/java/com/netflix/metacat/metadata/mysql/MysqlUserMetadataService.java
+++ b/metacat-metadata-mysql/src/main/java/com/netflix/metacat/metadata/mysql/MysqlUserMetadataService.java
@@ -581,6 +581,12 @@ public class MysqlUserMetadataService extends BaseUserMetadataService {
         @Nonnull final Optional<ObjectNode> metadata, final boolean merge)
         throws InvalidMetadataException {
         final Optional<ObjectNode> existingData = getDefinitionMetadata(name);
+        metadataPreMergeInterceptor.onWrite(
+            this,
+            name,
+            existingData,
+            metadata
+        );
         final int count;
         if (existingData.isPresent() && metadata.isPresent()) {
             ObjectNode merged = existingData.get();

--- a/metacat-metadata-mysql/src/main/java/com/netflix/metacat/metadata/mysql/MysqlUserMetadataService.java
+++ b/metacat-metadata-mysql/src/main/java/com/netflix/metacat/metadata/mysql/MysqlUserMetadataService.java
@@ -591,7 +591,9 @@ public class MysqlUserMetadataService extends BaseUserMetadataService {
         @Nonnull final String userId,
         @Nonnull final Optional<ObjectNode> metadata, final boolean merge)
         throws InvalidMetadataException {
-        final Optional<ObjectNode> existingData = getDefinitionMetadataForUpdate(name);
+        final Optional<ObjectNode> existingData =
+            config.isDefinitionMetadataSelectForUpdateEnabled()
+                ? getDefinitionMetadataForUpdate(name) : getDefinitionMetadata(name);
         metadataPreMergeInterceptor.onWrite(
             this,
             name,

--- a/metacat-metadata-mysql/src/main/java/com/netflix/metacat/metadata/mysql/MysqlUserMetadataService.java
+++ b/metacat-metadata-mysql/src/main/java/com/netflix/metacat/metadata/mysql/MysqlUserMetadataService.java
@@ -87,6 +87,7 @@ public class MysqlUserMetadataService extends BaseUserMetadataService {
      * @param metacatJson         json utility
      * @param config              config
      * @param metadataInterceptor metadata interceptor
+     * @param metadataPreMergeInterceptor metadataPreMergeInterceptor
      */
     public MysqlUserMetadataService(
         final JdbcTemplate jdbcTemplate,

--- a/metacat-metadata-mysql/src/main/java/com/netflix/metacat/metadata/mysql/MysqlUserMetadataService.java
+++ b/metacat-metadata-mysql/src/main/java/com/netflix/metacat/metadata/mysql/MysqlUserMetadataService.java
@@ -116,7 +116,7 @@ public class MysqlUserMetadataService extends BaseUserMetadataService {
 
     @Nonnull
     @Override
-    @Transactional(readOnly = false)
+    @Transactional(readOnly = true)
     public Optional<ObjectNode> getDefinitionMetadataWithInterceptor(
         @Nonnull final QualifiedName name,
         final GetMetadataInterceptorParameters getMetadataInterceptorParameters) {
@@ -358,11 +358,21 @@ public class MysqlUserMetadataService extends BaseUserMetadataService {
 
     @Nonnull
     @Override
-    @Transactional(readOnly = false)
+    @Transactional(readOnly = true)
     public Optional<ObjectNode> getDefinitionMetadata(
         @Nonnull final QualifiedName name) {
         final Optional<ObjectNode> retData = getJsonForKey(
             name.isPartitionDefinition() ? SQL.GET_PARTITION_DEFINITION_METADATA : SQL.GET_DEFINITION_METADATA,
+            name.toString());
+        return retData;
+    }
+
+    @Nonnull
+    protected Optional<ObjectNode> getDefinitionMetadataForUpdate(
+        @Nonnull final QualifiedName name) {
+        final Optional<ObjectNode> retData = getJsonForKey(
+            name.isPartitionDefinition()
+                ? SQL.GET_PARTITION_DEFINITION_METADATA : SQL.GET_DEFINITION_METADATA_FOR_UPDATE,
             name.toString());
         return retData;
     }
@@ -581,7 +591,7 @@ public class MysqlUserMetadataService extends BaseUserMetadataService {
         @Nonnull final String userId,
         @Nonnull final Optional<ObjectNode> metadata, final boolean merge)
         throws InvalidMetadataException {
-        final Optional<ObjectNode> existingData = getDefinitionMetadata(name);
+        final Optional<ObjectNode> existingData = getDefinitionMetadataForUpdate(name);
         metadataPreMergeInterceptor.onWrite(
             this,
             name,
@@ -992,6 +1002,8 @@ public class MysqlUserMetadataService extends BaseUserMetadataService {
         static final String GET_DATA_METADATAS =
             "select uri name,data from data_metadata where uri in (%s)";
         static final String GET_DEFINITION_METADATA =
+            "select name, data from definition_metadata where name=?";
+        static final String GET_DEFINITION_METADATA_FOR_UPDATE =
             "select name, data from definition_metadata where name=? for update";
         static final String GET_PARTITION_DEFINITION_METADATA =
             "select name, data from partition_definition_metadata where name=?";

--- a/metacat-metadata-mysql/src/main/java/com/netflix/metacat/metadata/mysql/MysqlUserMetadataService.java
+++ b/metacat-metadata-mysql/src/main/java/com/netflix/metacat/metadata/mysql/MysqlUserMetadataService.java
@@ -68,15 +68,15 @@ import java.util.stream.Collectors;
 @SuppressFBWarnings
 @Transactional("metadataTxManager")
 public class MysqlUserMetadataService extends BaseUserMetadataService {
-    private static final String NAME_OWNER = "owner";
-    private static final String NAME_USERID = "userId";
-    private static final List<String> DEFINITION_METADATA_SORT_BY_COLUMNS = Arrays.asList(
+    protected static final String NAME_OWNER = "owner";
+    protected static final String NAME_USERID = "userId";
+    protected static final List<String> DEFINITION_METADATA_SORT_BY_COLUMNS = Arrays.asList(
         "id", "date_created", "created_by", "last_updated_by", "name", "last_updated");
-    private static final List<String> VALID_SORT_ORDER = Arrays.asList("ASC", "DESC");
-    private final MetacatJson metacatJson;
-    private final Config config;
-    private JdbcTemplate jdbcTemplate;
-    private final MetadataInterceptor metadataInterceptor;
+    protected static final List<String> VALID_SORT_ORDER = Arrays.asList("ASC", "DESC");
+    protected final MetacatJson metacatJson;
+    protected final Config config;
+    protected JdbcTemplate jdbcTemplate;
+    protected final MetadataInterceptor metadataInterceptor;
 
     /**
      * Constructor.
@@ -528,7 +528,7 @@ public class MysqlUserMetadataService extends BaseUserMetadataService {
      * @param keyValues parameters
      * @return number of updated rows
      */
-    private int executeUpdateForKey(final String query, final String... keyValues) {
+    protected int executeUpdateForKey(final String query, final String... keyValues) {
         try {
             final SqlParameterValue[] values =
                 Arrays.stream(keyValues).map(keyValue -> new SqlParameterValue(Types.VARCHAR, keyValue))
@@ -541,7 +541,7 @@ public class MysqlUserMetadataService extends BaseUserMetadataService {
         }
     }
 
-    private void throwIfPartitionDefinitionMetadataDisabled() {
+    protected void throwIfPartitionDefinitionMetadataDisabled() {
         if (config.disablePartitionDefinitionMetadata()) {
             throw new MetacatBadRequestException("Partition Definition metadata updates are disabled");
         }
@@ -982,7 +982,7 @@ public class MysqlUserMetadataService extends BaseUserMetadataService {
         static final String GET_DATA_METADATAS =
             "select uri name,data from data_metadata where uri in (%s)";
         static final String GET_DEFINITION_METADATA =
-            "select name, data from definition_metadata where name=?";
+            "select name, data from definition_metadata where name=? for update";
         static final String GET_PARTITION_DEFINITION_METADATA =
             "select name, data from partition_definition_metadata where name=?";
         static final String GET_DEFINITION_METADATAS =

--- a/metacat-metadata-mysql/src/main/java/com/netflix/metacat/metadata/mysql/MysqlUserMetadataService.java
+++ b/metacat-metadata-mysql/src/main/java/com/netflix/metacat/metadata/mysql/MysqlUserMetadataService.java
@@ -354,7 +354,6 @@ public class MysqlUserMetadataService extends BaseUserMetadataService {
 
     @Nonnull
     @Override
-    @Transactional(readOnly = true)
     public Optional<ObjectNode> getDefinitionMetadata(
         @Nonnull final QualifiedName name) {
         final Optional<ObjectNode> retData = getJsonForKey(

--- a/metacat-metadata-mysql/src/main/java/com/netflix/metacat/metadata/mysql/MysqlUserMetadataService.java
+++ b/metacat-metadata-mysql/src/main/java/com/netflix/metacat/metadata/mysql/MysqlUserMetadataService.java
@@ -32,6 +32,7 @@ import com.netflix.metacat.common.server.properties.Config;
 import com.netflix.metacat.common.server.usermetadata.BaseUserMetadataService;
 import com.netflix.metacat.common.server.usermetadata.GetMetadataInterceptorParameters;
 import com.netflix.metacat.common.server.usermetadata.MetadataInterceptor;
+import com.netflix.metacat.common.server.usermetadata.MetadataPreMergeInterceptor;
 import com.netflix.metacat.common.server.usermetadata.UserMetadataServiceException;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.Data;
@@ -77,6 +78,7 @@ public class MysqlUserMetadataService extends BaseUserMetadataService {
     protected final Config config;
     protected JdbcTemplate jdbcTemplate;
     protected final MetadataInterceptor metadataInterceptor;
+    protected final MetadataPreMergeInterceptor metadataPreMergeInterceptor;
 
     /**
      * Constructor.
@@ -90,13 +92,14 @@ public class MysqlUserMetadataService extends BaseUserMetadataService {
         final JdbcTemplate jdbcTemplate,
         final MetacatJson metacatJson,
         final Config config,
-        final MetadataInterceptor metadataInterceptor
-
+        final MetadataInterceptor metadataInterceptor,
+        final MetadataPreMergeInterceptor metadataPreMergeInterceptor
     ) {
         this.metacatJson = metacatJson;
         this.config = config;
         this.jdbcTemplate = jdbcTemplate;
         this.metadataInterceptor = metadataInterceptor;
+        this.metadataPreMergeInterceptor = metadataPreMergeInterceptor;
     }
 
     @Override

--- a/metacat-metadata-mysql/src/main/java/com/netflix/metacat/metadata/mysql/MysqlUserMetadataService.java
+++ b/metacat-metadata-mysql/src/main/java/com/netflix/metacat/metadata/mysql/MysqlUserMetadataService.java
@@ -116,7 +116,7 @@ public class MysqlUserMetadataService extends BaseUserMetadataService {
 
     @Nonnull
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(readOnly = false)
     public Optional<ObjectNode> getDefinitionMetadataWithInterceptor(
         @Nonnull final QualifiedName name,
         final GetMetadataInterceptorParameters getMetadataInterceptorParameters) {

--- a/metacat-metadata-mysql/src/main/java/com/netflix/metacat/metadata/mysql/MysqlUserMetadataService.java
+++ b/metacat-metadata-mysql/src/main/java/com/netflix/metacat/metadata/mysql/MysqlUserMetadataService.java
@@ -358,6 +358,7 @@ public class MysqlUserMetadataService extends BaseUserMetadataService {
 
     @Nonnull
     @Override
+    @Transactional(readOnly = false)
     public Optional<ObjectNode> getDefinitionMetadata(
         @Nonnull final QualifiedName name) {
         final Optional<ObjectNode> retData = getJsonForKey(


### PR DESCRIPTION
This PR adds 2 new implementations:
1. Select for update for saveDefinitionMetadata as the current implementation can lead to lost of update. Using select For Update will hold a write lock which prevents other transactions concurrently read and then update the value. For simple select, this won't block for Isolation level that is weaker than serializable.
3. Add a preMergeInterceptor which happens before merging the definitionMetadata so we can pre-process the user definitionMetadata blob.