### PR TITLE
Include audit info when loading table from Polaris

### DIFF
--- a/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/PolarisConnectorTableService.java
+++ b/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/PolarisConnectorTableService.java
@@ -170,6 +170,7 @@ public class PolarisConnectorTableService implements ConnectorTableService {
             if (connectorContext.getConfig().shouldFetchOnlyMetadataLocationEnabled()
                     && requestContext.isIncludeMetadataLocationOnly()) {
                 return TableInfo.builder()
+                        .auditInfo(info.getAudit())
                         .metadata(Maps.newHashMap(info.getMetadata()))
                         .fields(Collections.emptyList())
                         .build();


### PR DESCRIPTION
This PR includes table audit information in load table responses for Polaris, even when the flag to only include metadata location is present. The audit information is already loaded and does not require loading the Iceberg table. Also it is relatively small, so should have a negligible impact on performance.

Adding this allows us to capture audit fields in batch without loading the Iceberg table, for example, when running our table inventory process.