### PR TITLE
add include databases name tag

### DIFF
--- a/metacat-main/src/main/java/com/netflix/metacat/main/api/v1/MetacatController.java
+++ b/metacat-main/src/main/java/com/netflix/metacat/main/api/v1/MetacatController.java
@@ -485,9 +485,13 @@ public class MetacatController implements MetacatV1 {
         @Parameter(description = "Whether to include user metadata information to the response")
         @RequestParam(name = "includeUserMetadata", defaultValue = "true") final boolean includeUserMetadata) {
         final QualifiedName name = this.requestWrapper.qualifyName(() -> QualifiedName.ofCatalog(catalogName));
+        final boolean includeDatabaseNamesEnable = includeDatabaseNames == null
+            ? config.listDatabaseNameByDefaultOnGetCatalog() : includeDatabaseNames;
+
         return this.requestWrapper.processRequest(
             name,
             "getCatalog",
+            Collections.singletonMap("includeDatabaseNames", String.valueOf(includeDatabaseNamesEnable)),
             () -> this.catalogService.get(name, GetCatalogServiceParameters.builder()
                 .includeDatabaseNames(includeDatabaseNames == null
                     ? config.listDatabaseNameByDefaultOnGetCatalog() : includeDatabaseNames)


### PR DESCRIPTION
This is to distinguish in our metrics if a getCatalog call need to list all databases or not