### PR TITLE
[BDW-885]: Upgrade to Iceberg 1.9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ allprojects {
             url "https://repo.spring.io/milestone"
         }
         maven {
-            url "https://redshift-maven-repository.s3-website-us-east-1.amazonaws.com/release"
+            url "https://repository.apache.org/content/repositories/releases"
         }
         maven {
             url 'https://jitpack.io'
@@ -153,7 +153,7 @@ configure(javaProjects) {
             dependency("org.elasticsearch.client:transport:5.4.1")
             dependency("net.snowflake:snowflake-jdbc:3.4.2")
             dependency("com.esotericsoftware.kryo:kryo:2.22")
-            dependency("org.apache.iceberg:iceberg-spark-runtime:${iceberg_version}")
+            dependency("org.apache.iceberg:iceberg-spark-runtime-${iceberg_spark_version}_${iceberg_scala_version}:${iceberg_version}")
             dependency("com.datastax.cassandra:cassandra-driver-core:3.7.2")
             dependency("mysql:mysql-connector-java:8.0.27")
         }

--- a/gradle.properties
+++ b/gradle.properties
@@ -31,9 +31,9 @@ elasticsearch.version=5.4.1
 
 hive_version=1.2.1
 
-iceberg_version=1.1.0
-iceberg_spark_version=3.3
-iceberg_scala_version=2.12
+iceberg_version=1.9.2
+iceberg_spark_version=3.5
+iceberg_scala_version=2.13
 
 org.gradle.jvmargs=-Xmx1g
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -31,7 +31,7 @@ elasticsearch.version=5.4.1
 
 hive_version=1.2.1
 
-iceberg_version=1.4.3
+iceberg_version=1.9.1
 iceberg_spark_version=3.5
 iceberg_scala_version=2.13
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -31,7 +31,7 @@ elasticsearch.version=5.4.1
 
 hive_version=1.2.1
 
-iceberg_version=1.9.2
+iceberg_version=1.4.3
 iceberg_spark_version=3.5
 iceberg_scala_version=2.13
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -31,7 +31,9 @@ elasticsearch.version=5.4.1
 
 hive_version=1.2.1
 
-iceberg_version=0.13.1
+iceberg_version=1.1.0
+iceberg_spark_version=3.3
+iceberg_scala_version=2.12
 
 org.gradle.jvmargs=-Xmx1g
 

--- a/metacat-app/dependencies.lock
+++ b/metacat-app/dependencies.lock
@@ -521,7 +521,7 @@
             "firstLevelTransitive": [
                 "com.netflix.metacat:metacat-connector-hive"
             ],
-            "locked": "1.9.2"
+            "locked": "1.9.1"
         },
         "org.apache.logging.log4j:log4j-core": {
             "firstLevelTransitive": [
@@ -999,7 +999,7 @@
             "firstLevelTransitive": [
                 "com.netflix.metacat:metacat-connector-hive"
             ],
-            "locked": "1.9.2"
+            "locked": "1.9.1"
         },
         "org.apache.logging.log4j:log4j-core": {
             "firstLevelTransitive": [
@@ -1723,7 +1723,7 @@
             "firstLevelTransitive": [
                 "com.netflix.metacat:metacat-connector-hive"
             ],
-            "locked": "1.9.2"
+            "locked": "1.9.1"
         },
         "org.apache.logging.log4j:log4j-core": {
             "firstLevelTransitive": [

--- a/metacat-app/dependencies.lock
+++ b/metacat-app/dependencies.lock
@@ -517,11 +517,11 @@
             ],
             "locked": "5.2.3"
         },
-        "org.apache.iceberg:iceberg-spark-runtime-3.3_2.12": {
+        "org.apache.iceberg:iceberg-spark-runtime-3.5_2.13": {
             "firstLevelTransitive": [
                 "com.netflix.metacat:metacat-connector-hive"
             ],
-            "locked": "1.1.0"
+            "locked": "1.9.2"
         },
         "org.apache.logging.log4j:log4j-core": {
             "firstLevelTransitive": [
@@ -995,11 +995,11 @@
             ],
             "locked": "5.2.3"
         },
-        "org.apache.iceberg:iceberg-spark-runtime-3.3_2.12": {
+        "org.apache.iceberg:iceberg-spark-runtime-3.5_2.13": {
             "firstLevelTransitive": [
                 "com.netflix.metacat:metacat-connector-hive"
             ],
-            "locked": "1.1.0"
+            "locked": "1.9.2"
         },
         "org.apache.logging.log4j:log4j-core": {
             "firstLevelTransitive": [
@@ -1719,11 +1719,11 @@
             ],
             "locked": "5.2.3"
         },
-        "org.apache.iceberg:iceberg-spark-runtime-3.3_2.12": {
+        "org.apache.iceberg:iceberg-spark-runtime-3.5_2.13": {
             "firstLevelTransitive": [
                 "com.netflix.metacat:metacat-connector-hive"
             ],
-            "locked": "1.1.0"
+            "locked": "1.9.2"
         },
         "org.apache.logging.log4j:log4j-core": {
             "firstLevelTransitive": [

--- a/metacat-app/dependencies.lock
+++ b/metacat-app/dependencies.lock
@@ -517,11 +517,11 @@
             ],
             "locked": "5.2.3"
         },
-        "org.apache.iceberg:iceberg-spark-runtime": {
+        "org.apache.iceberg:iceberg-spark-runtime-3.3_2.12": {
             "firstLevelTransitive": [
                 "com.netflix.metacat:metacat-connector-hive"
             ],
-            "locked": "0.13.1"
+            "locked": "1.1.0"
         },
         "org.apache.logging.log4j:log4j-core": {
             "firstLevelTransitive": [
@@ -995,11 +995,11 @@
             ],
             "locked": "5.2.3"
         },
-        "org.apache.iceberg:iceberg-spark-runtime": {
+        "org.apache.iceberg:iceberg-spark-runtime-3.3_2.12": {
             "firstLevelTransitive": [
                 "com.netflix.metacat:metacat-connector-hive"
             ],
-            "locked": "0.13.1"
+            "locked": "1.1.0"
         },
         "org.apache.logging.log4j:log4j-core": {
             "firstLevelTransitive": [
@@ -1719,11 +1719,11 @@
             ],
             "locked": "5.2.3"
         },
-        "org.apache.iceberg:iceberg-spark-runtime": {
+        "org.apache.iceberg:iceberg-spark-runtime-3.3_2.12": {
             "firstLevelTransitive": [
                 "com.netflix.metacat:metacat-connector-hive"
             ],
-            "locked": "0.13.1"
+            "locked": "1.1.0"
         },
         "org.apache.logging.log4j:log4j-core": {
             "firstLevelTransitive": [

--- a/metacat-connector-hive/build.gradle
+++ b/metacat-connector-hive/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     }
 
     api("commons-dbutils:commons-dbutils")
-    api("org.apache.iceberg:iceberg-spark-runtime")
+    api("org.apache.iceberg:iceberg-spark-runtime-${iceberg_spark_version}_${iceberg_scala_version}")
     /*******************************
      * Provided Dependencies
      *******************************/

--- a/metacat-connector-hive/dependencies.lock
+++ b/metacat-connector-hive/dependencies.lock
@@ -78,7 +78,7 @@
             "locked": "1.2.1"
         },
         "org.apache.iceberg:iceberg-spark-runtime-3.5_2.13": {
-            "locked": "1.9.2"
+            "locked": "1.9.1"
         },
         "org.apache.tomcat:tomcat-jdbc": {
             "firstLevelTransitive": [
@@ -206,7 +206,7 @@
             "locked": "1.2.1"
         },
         "org.apache.iceberg:iceberg-spark-runtime-3.5_2.13": {
-            "locked": "1.9.2"
+            "locked": "1.9.1"
         },
         "org.apache.tomcat:tomcat-jdbc": {
             "firstLevelTransitive": [
@@ -358,7 +358,7 @@
             "locked": "1.2.1"
         },
         "org.apache.iceberg:iceberg-spark-runtime-3.5_2.13": {
-            "locked": "1.9.2"
+            "locked": "1.9.1"
         },
         "org.apache.tomcat:tomcat-jdbc": {
             "firstLevelTransitive": [
@@ -514,7 +514,7 @@
             "locked": "1.2.1"
         },
         "org.apache.iceberg:iceberg-spark-runtime-3.5_2.13": {
-            "locked": "1.9.2"
+            "locked": "1.9.1"
         },
         "org.apache.tomcat:tomcat-jdbc": {
             "firstLevelTransitive": [

--- a/metacat-connector-hive/dependencies.lock
+++ b/metacat-connector-hive/dependencies.lock
@@ -77,8 +77,8 @@
         "org.apache.hive:hive-metastore": {
             "locked": "1.2.1"
         },
-        "org.apache.iceberg:iceberg-spark-runtime-3.3_2.12": {
-            "locked": "1.1.0"
+        "org.apache.iceberg:iceberg-spark-runtime-3.5_2.13": {
+            "locked": "1.9.2"
         },
         "org.apache.tomcat:tomcat-jdbc": {
             "firstLevelTransitive": [
@@ -205,8 +205,8 @@
         "org.apache.hive:hive-metastore": {
             "locked": "1.2.1"
         },
-        "org.apache.iceberg:iceberg-spark-runtime-3.3_2.12": {
-            "locked": "1.1.0"
+        "org.apache.iceberg:iceberg-spark-runtime-3.5_2.13": {
+            "locked": "1.9.2"
         },
         "org.apache.tomcat:tomcat-jdbc": {
             "firstLevelTransitive": [
@@ -357,8 +357,8 @@
         "org.apache.hive:hive-metastore": {
             "locked": "1.2.1"
         },
-        "org.apache.iceberg:iceberg-spark-runtime-3.3_2.12": {
-            "locked": "1.1.0"
+        "org.apache.iceberg:iceberg-spark-runtime-3.5_2.13": {
+            "locked": "1.9.2"
         },
         "org.apache.tomcat:tomcat-jdbc": {
             "firstLevelTransitive": [
@@ -513,8 +513,8 @@
         "org.apache.hive:hive-metastore": {
             "locked": "1.2.1"
         },
-        "org.apache.iceberg:iceberg-spark-runtime-3.3_2.12": {
-            "locked": "1.1.0"
+        "org.apache.iceberg:iceberg-spark-runtime-3.5_2.13": {
+            "locked": "1.9.2"
         },
         "org.apache.tomcat:tomcat-jdbc": {
             "firstLevelTransitive": [

--- a/metacat-connector-hive/dependencies.lock
+++ b/metacat-connector-hive/dependencies.lock
@@ -77,8 +77,8 @@
         "org.apache.hive:hive-metastore": {
             "locked": "1.2.1"
         },
-        "org.apache.iceberg:iceberg-spark-runtime": {
-            "locked": "0.13.1"
+        "org.apache.iceberg:iceberg-spark-runtime-3.3_2.12": {
+            "locked": "1.1.0"
         },
         "org.apache.tomcat:tomcat-jdbc": {
             "firstLevelTransitive": [
@@ -205,8 +205,8 @@
         "org.apache.hive:hive-metastore": {
             "locked": "1.2.1"
         },
-        "org.apache.iceberg:iceberg-spark-runtime": {
-            "locked": "0.13.1"
+        "org.apache.iceberg:iceberg-spark-runtime-3.3_2.12": {
+            "locked": "1.1.0"
         },
         "org.apache.tomcat:tomcat-jdbc": {
             "firstLevelTransitive": [
@@ -357,8 +357,8 @@
         "org.apache.hive:hive-metastore": {
             "locked": "1.2.1"
         },
-        "org.apache.iceberg:iceberg-spark-runtime": {
-            "locked": "0.13.1"
+        "org.apache.iceberg:iceberg-spark-runtime-3.3_2.12": {
+            "locked": "1.1.0"
         },
         "org.apache.tomcat:tomcat-jdbc": {
             "firstLevelTransitive": [
@@ -513,8 +513,8 @@
         "org.apache.hive:hive-metastore": {
             "locked": "1.2.1"
         },
-        "org.apache.iceberg:iceberg-spark-runtime": {
-            "locked": "0.13.1"
+        "org.apache.iceberg:iceberg-spark-runtime-3.3_2.12": {
+            "locked": "1.1.0"
         },
         "org.apache.tomcat:tomcat-jdbc": {
             "firstLevelTransitive": [

--- a/metacat-connector-hive/src/test/groovy/com/netflix/metacat/connector/hive/iceberg/IcebergVersionValidationSpec.groovy
+++ b/metacat-connector-hive/src/test/groovy/com/netflix/metacat/connector/hive/iceberg/IcebergVersionValidationSpec.groovy
@@ -100,8 +100,8 @@ class IcebergVersionValidationSpec extends Specification {
         
         then: "Should indicate we're using version 1.x"
         println "Iceberg version info: ${icebergVersion}"
-        icebergVersion.contains("1.") || icebergVersion.contains("post-0.13")
-        !icebergVersion.contains("0.13.1") // Should not be the old version
+        icebergVersion.contains("1.")
+        !icebergVersion.contains("0.13.1") && !icebergVersion.contains("pre-1.0") // Should not be the older than 1.1
     }
 
     private String getIcebergVersionInfo() {

--- a/metacat-connector-hive/src/test/groovy/com/netflix/metacat/connector/hive/iceberg/IcebergVersionValidationSpec.groovy
+++ b/metacat-connector-hive/src/test/groovy/com/netflix/metacat/connector/hive/iceberg/IcebergVersionValidationSpec.groovy
@@ -99,6 +99,18 @@ class IcebergVersionValidationSpec extends Specification {
         currentMethods.any { it.returnType == TableMetadata.class }
     }
 
+    def "test Table refs method exists for branching support"() {
+        expect: "Table should have refs() method for branching and tagging functionality"
+        def tableClass = Class.forName('org.apache.iceberg.Table')
+        def refsMethods = tableClass.getMethods().findAll { it.name == 'refs' }
+        refsMethods.size() > 0
+        
+        // Verify the method returns something that could be table references
+        def refsMethod = refsMethods.first()
+        refsMethod.returnType != null
+        refsMethod.parameterCount == 0
+    }
+
     def "test version detection"() {
         when: "Check Iceberg version information"
         def icebergVersion = getIcebergVersionInfo()

--- a/metacat-connector-hive/src/test/groovy/com/netflix/metacat/connector/hive/iceberg/IcebergVersionValidationSpec.groovy
+++ b/metacat-connector-hive/src/test/groovy/com/netflix/metacat/connector/hive/iceberg/IcebergVersionValidationSpec.groovy
@@ -16,7 +16,12 @@
 
 package com.netflix.metacat.connector.hive.iceberg
 
-import org.apache.iceberg.*
+import org.apache.iceberg.BaseMetastoreTableOperations
+import org.apache.iceberg.ScanSummary
+import org.apache.iceberg.Schema
+import org.apache.iceberg.UpdateSchema
+import org.apache.iceberg.TableMetadata
+import org.apache.iceberg.TableMetadataParser
 import org.apache.iceberg.types.Types
 import spock.lang.Specification
 
@@ -63,8 +68,8 @@ class IcebergVersionValidationSpec extends Specification {
         schema != null
         schema.columns().size() == 3
         schema.findField("name").doc() == "Test comment"
-        schema.findField("id").isRequired() == true
-        schema.findField("name").isOptional() == true
+        schema.findField("id").isRequired()
+        schema.findField("name").isOptional()
     }
 
     def "test TableMetadataParser API exists"() {

--- a/metacat-connector-hive/src/test/groovy/com/netflix/metacat/connector/hive/iceberg/IcebergVersionValidationSpec.groovy
+++ b/metacat-connector-hive/src/test/groovy/com/netflix/metacat/connector/hive/iceberg/IcebergVersionValidationSpec.groovy
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2024 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.metacat.connector.hive.iceberg
+
+import org.apache.iceberg.*
+import org.apache.iceberg.types.Types
+import spock.lang.Specification
+
+/**
+ * Simple validation tests to ensure Iceberg 1.1.0 upgrade is working correctly.
+ * These tests focus on API compatibility and version verification.
+ */
+class IcebergVersionValidationSpec extends Specification {
+
+    def "test Iceberg 1.1.0 API classes are available"() {
+        expect: "All critical Iceberg classes should be available"
+        Class.forName('org.apache.iceberg.ScanSummary') != null
+        Class.forName('org.apache.iceberg.Table') != null
+        Class.forName('org.apache.iceberg.TableMetadataParser') != null
+        Class.forName('org.apache.iceberg.UpdateSchema') != null
+        Class.forName('org.apache.iceberg.BaseMetastoreTableOperations') != null
+        Class.forName('org.apache.iceberg.hadoop.HadoopFileIO') != null
+    }
+
+    def "test ScanSummary.PartitionMetrics constructor works"() {
+        when: "Create PartitionMetrics using Iceberg 1.1.0 constructor"
+        def metrics = new ScanSummary.PartitionMetrics(
+            fileCount: 10,
+            recordCount: 1000,
+            dataTimestampMillis: System.currentTimeMillis()
+        )
+        
+        then: "Should create successfully"
+        metrics != null
+        metrics.fileCount() == 10
+        metrics.recordCount() == 1000
+        metrics.dataTimestampMillis() != null
+    }
+
+    def "test Schema creation and field access works"() {
+        when: "Create Iceberg schema using 1.1.0 API"
+        def schema = new Schema([
+            Types.NestedField.required(1, "id", Types.LongType.get()),
+            Types.NestedField.optional(2, "name", Types.StringType.get(), "Test comment"),
+            Types.NestedField.optional(3, "value", Types.DoubleType.get())
+        ])
+        
+        then: "Schema should be created correctly"
+        schema != null
+        schema.columns().size() == 3
+        schema.findField("name").doc() == "Test comment"
+        schema.findField("id").isRequired() == true
+        schema.findField("name").isOptional() == true
+    }
+
+    def "test TableMetadataParser API exists"() {
+        expect: "TableMetadataParser.toJson method should exist"
+        def method = TableMetadataParser.class.getDeclaredMethod('toJson', TableMetadata.class)
+        method != null
+        method.getReturnType() == String.class
+    }
+
+    def "test UpdateSchema API exists"() {
+        expect: "UpdateSchema should have expected methods"
+        def updateColumnDocMethod = UpdateSchema.class.getDeclaredMethod('updateColumnDoc', String.class, String.class)
+        updateColumnDocMethod != null
+        
+        // Check if commit method exists (might be inherited or have different signature)
+        def commitMethods = UpdateSchema.class.getMethods().findAll { it.name == 'commit' }
+        commitMethods.size() > 0
+    }
+
+    def "test BaseMetastoreTableOperations methods exist"() {
+        expect: "BaseMetastoreTableOperations should have expected methods"
+        def ioMethods = BaseMetastoreTableOperations.class.getMethods().findAll { it.name == 'io' }
+        ioMethods.size() > 0
+        
+        def currentMethods = BaseMetastoreTableOperations.class.getMethods().findAll { it.name == 'current' }
+        currentMethods.size() > 0
+        currentMethods.any { it.returnType == TableMetadata.class }
+    }
+
+    def "test version detection"() {
+        when: "Check Iceberg version information"
+        def icebergVersion = getIcebergVersionInfo()
+        
+        then: "Should indicate we're using version 1.x"
+        println "Iceberg version info: ${icebergVersion}"
+        icebergVersion.contains("1.") || icebergVersion.contains("post-0.13")
+        !icebergVersion.contains("0.13.1") // Should not be the old version
+    }
+
+    private String getIcebergVersionInfo() {
+        try {
+            // Try to get version from package
+            def packageInfo = Package.getPackage("org.apache.iceberg")
+            if (packageInfo?.implementationVersion) {
+                return "Package version: ${packageInfo.implementationVersion}"
+            }
+            
+            // Check for new 1.1+ features that didn't exist in 0.13
+            try {
+                // This class exists in Iceberg 1.0+
+                Class.forName("org.apache.iceberg.actions.RewriteDataFiles")
+                return "1.0+ (has RewriteDataFiles)"
+            } catch (ClassNotFoundException e) {
+                // This means we're on an older version
+                return "pre-1.0"
+            }
+        } catch (Exception e) {
+            return "unknown: ${e.message}"
+        }
+    }
+}

--- a/metacat-connector-polaris/dependencies.lock
+++ b/metacat-connector-polaris/dependencies.lock
@@ -113,7 +113,7 @@
             "firstLevelTransitive": [
                 "com.netflix.metacat:metacat-connector-hive"
             ],
-            "locked": "1.9.2"
+            "locked": "1.9.1"
         },
         "org.apache.tomcat:tomcat-jdbc": {
             "firstLevelTransitive": [
@@ -288,7 +288,7 @@
             "firstLevelTransitive": [
                 "com.netflix.metacat:metacat-connector-hive"
             ],
-            "locked": "1.9.2"
+            "locked": "1.9.1"
         },
         "org.apache.tomcat:tomcat-jdbc": {
             "firstLevelTransitive": [
@@ -494,7 +494,7 @@
             "firstLevelTransitive": [
                 "com.netflix.metacat:metacat-connector-hive"
             ],
-            "locked": "1.9.2"
+            "locked": "1.9.1"
         },
         "org.apache.tomcat:tomcat-jdbc": {
             "firstLevelTransitive": [
@@ -713,7 +713,7 @@
             "firstLevelTransitive": [
                 "com.netflix.metacat:metacat-connector-hive"
             ],
-            "locked": "1.9.2"
+            "locked": "1.9.1"
         },
         "org.apache.tomcat:tomcat-jdbc": {
             "firstLevelTransitive": [
@@ -907,7 +907,7 @@
             "firstLevelTransitive": [
                 "com.netflix.metacat:metacat-connector-hive"
             ],
-            "locked": "1.9.2"
+            "locked": "1.9.1"
         },
         "org.apache.tomcat:tomcat-jdbc": {
             "firstLevelTransitive": [
@@ -1113,7 +1113,7 @@
             "firstLevelTransitive": [
                 "com.netflix.metacat:metacat-connector-hive"
             ],
-            "locked": "1.9.2"
+            "locked": "1.9.1"
         },
         "org.apache.tomcat:tomcat-jdbc": {
             "firstLevelTransitive": [

--- a/metacat-connector-polaris/dependencies.lock
+++ b/metacat-connector-polaris/dependencies.lock
@@ -109,11 +109,11 @@
             ],
             "locked": "1.2.1"
         },
-        "org.apache.iceberg:iceberg-spark-runtime-3.3_2.12": {
+        "org.apache.iceberg:iceberg-spark-runtime-3.5_2.13": {
             "firstLevelTransitive": [
                 "com.netflix.metacat:metacat-connector-hive"
             ],
-            "locked": "1.1.0"
+            "locked": "1.9.2"
         },
         "org.apache.tomcat:tomcat-jdbc": {
             "firstLevelTransitive": [
@@ -284,11 +284,11 @@
             ],
             "locked": "1.2.1"
         },
-        "org.apache.iceberg:iceberg-spark-runtime-3.3_2.12": {
+        "org.apache.iceberg:iceberg-spark-runtime-3.5_2.13": {
             "firstLevelTransitive": [
                 "com.netflix.metacat:metacat-connector-hive"
             ],
-            "locked": "1.1.0"
+            "locked": "1.9.2"
         },
         "org.apache.tomcat:tomcat-jdbc": {
             "firstLevelTransitive": [
@@ -490,11 +490,11 @@
             ],
             "locked": "1.2.1"
         },
-        "org.apache.iceberg:iceberg-spark-runtime-3.3_2.12": {
+        "org.apache.iceberg:iceberg-spark-runtime-3.5_2.13": {
             "firstLevelTransitive": [
                 "com.netflix.metacat:metacat-connector-hive"
             ],
-            "locked": "1.1.0"
+            "locked": "1.9.2"
         },
         "org.apache.tomcat:tomcat-jdbc": {
             "firstLevelTransitive": [
@@ -709,11 +709,11 @@
             ],
             "locked": "1.2.1"
         },
-        "org.apache.iceberg:iceberg-spark-runtime-3.3_2.12": {
+        "org.apache.iceberg:iceberg-spark-runtime-3.5_2.13": {
             "firstLevelTransitive": [
                 "com.netflix.metacat:metacat-connector-hive"
             ],
-            "locked": "1.1.0"
+            "locked": "1.9.2"
         },
         "org.apache.tomcat:tomcat-jdbc": {
             "firstLevelTransitive": [
@@ -903,11 +903,11 @@
             ],
             "locked": "1.2.1"
         },
-        "org.apache.iceberg:iceberg-spark-runtime-3.3_2.12": {
+        "org.apache.iceberg:iceberg-spark-runtime-3.5_2.13": {
             "firstLevelTransitive": [
                 "com.netflix.metacat:metacat-connector-hive"
             ],
-            "locked": "1.1.0"
+            "locked": "1.9.2"
         },
         "org.apache.tomcat:tomcat-jdbc": {
             "firstLevelTransitive": [
@@ -1109,11 +1109,11 @@
             ],
             "locked": "1.2.1"
         },
-        "org.apache.iceberg:iceberg-spark-runtime-3.3_2.12": {
+        "org.apache.iceberg:iceberg-spark-runtime-3.5_2.13": {
             "firstLevelTransitive": [
                 "com.netflix.metacat:metacat-connector-hive"
             ],
-            "locked": "1.1.0"
+            "locked": "1.9.2"
         },
         "org.apache.tomcat:tomcat-jdbc": {
             "firstLevelTransitive": [

--- a/metacat-connector-polaris/dependencies.lock
+++ b/metacat-connector-polaris/dependencies.lock
@@ -109,11 +109,11 @@
             ],
             "locked": "1.2.1"
         },
-        "org.apache.iceberg:iceberg-spark-runtime": {
+        "org.apache.iceberg:iceberg-spark-runtime-3.3_2.12": {
             "firstLevelTransitive": [
                 "com.netflix.metacat:metacat-connector-hive"
             ],
-            "locked": "0.13.1"
+            "locked": "1.1.0"
         },
         "org.apache.tomcat:tomcat-jdbc": {
             "firstLevelTransitive": [
@@ -284,11 +284,11 @@
             ],
             "locked": "1.2.1"
         },
-        "org.apache.iceberg:iceberg-spark-runtime": {
+        "org.apache.iceberg:iceberg-spark-runtime-3.3_2.12": {
             "firstLevelTransitive": [
                 "com.netflix.metacat:metacat-connector-hive"
             ],
-            "locked": "0.13.1"
+            "locked": "1.1.0"
         },
         "org.apache.tomcat:tomcat-jdbc": {
             "firstLevelTransitive": [
@@ -490,11 +490,11 @@
             ],
             "locked": "1.2.1"
         },
-        "org.apache.iceberg:iceberg-spark-runtime": {
+        "org.apache.iceberg:iceberg-spark-runtime-3.3_2.12": {
             "firstLevelTransitive": [
                 "com.netflix.metacat:metacat-connector-hive"
             ],
-            "locked": "0.13.1"
+            "locked": "1.1.0"
         },
         "org.apache.tomcat:tomcat-jdbc": {
             "firstLevelTransitive": [
@@ -709,11 +709,11 @@
             ],
             "locked": "1.2.1"
         },
-        "org.apache.iceberg:iceberg-spark-runtime": {
+        "org.apache.iceberg:iceberg-spark-runtime-3.3_2.12": {
             "firstLevelTransitive": [
                 "com.netflix.metacat:metacat-connector-hive"
             ],
-            "locked": "0.13.1"
+            "locked": "1.1.0"
         },
         "org.apache.tomcat:tomcat-jdbc": {
             "firstLevelTransitive": [
@@ -903,11 +903,11 @@
             ],
             "locked": "1.2.1"
         },
-        "org.apache.iceberg:iceberg-spark-runtime": {
+        "org.apache.iceberg:iceberg-spark-runtime-3.3_2.12": {
             "firstLevelTransitive": [
                 "com.netflix.metacat:metacat-connector-hive"
             ],
-            "locked": "0.13.1"
+            "locked": "1.1.0"
         },
         "org.apache.tomcat:tomcat-jdbc": {
             "firstLevelTransitive": [
@@ -1109,11 +1109,11 @@
             ],
             "locked": "1.2.1"
         },
-        "org.apache.iceberg:iceberg-spark-runtime": {
+        "org.apache.iceberg:iceberg-spark-runtime-3.3_2.12": {
             "firstLevelTransitive": [
                 "com.netflix.metacat:metacat-connector-hive"
             ],
-            "locked": "0.13.1"
+            "locked": "1.1.0"
         },
         "org.apache.tomcat:tomcat-jdbc": {
             "firstLevelTransitive": [

--- a/metacat-functional-tests/dependencies.lock
+++ b/metacat-functional-tests/dependencies.lock
@@ -174,11 +174,11 @@
             ],
             "locked": "1.2.1"
         },
-        "org.apache.iceberg:iceberg-spark-runtime-3.3_2.12": {
+        "org.apache.iceberg:iceberg-spark-runtime-3.5_2.13": {
             "firstLevelTransitive": [
                 "com.netflix.metacat:metacat-connector-hive"
             ],
-            "locked": "1.1.0"
+            "locked": "1.9.2"
         },
         "org.apache.tomcat:tomcat-jdbc": {
             "firstLevelTransitive": [
@@ -414,11 +414,11 @@
             ],
             "locked": "1.2.1"
         },
-        "org.apache.iceberg:iceberg-spark-runtime-3.3_2.12": {
+        "org.apache.iceberg:iceberg-spark-runtime-3.5_2.13": {
             "firstLevelTransitive": [
                 "com.netflix.metacat:metacat-connector-hive"
             ],
-            "locked": "1.1.0"
+            "locked": "1.9.2"
         },
         "org.apache.tomcat:tomcat-jdbc": {
             "firstLevelTransitive": [
@@ -650,11 +650,11 @@
             ],
             "locked": "1.2.1"
         },
-        "org.apache.iceberg:iceberg-spark-runtime-3.3_2.12": {
+        "org.apache.iceberg:iceberg-spark-runtime-3.5_2.13": {
             "firstLevelTransitive": [
                 "com.netflix.metacat:metacat-connector-hive"
             ],
-            "locked": "1.1.0"
+            "locked": "1.9.2"
         },
         "org.apache.tomcat:tomcat-jdbc": {
             "firstLevelTransitive": [
@@ -852,11 +852,11 @@
             ],
             "locked": "1.2.1"
         },
-        "org.apache.iceberg:iceberg-spark-runtime-3.3_2.12": {
+        "org.apache.iceberg:iceberg-spark-runtime-3.5_2.13": {
             "firstLevelTransitive": [
                 "com.netflix.metacat:metacat-connector-hive"
             ],
-            "locked": "1.1.0"
+            "locked": "1.9.2"
         },
         "org.apache.tomcat:tomcat-jdbc": {
             "firstLevelTransitive": [

--- a/metacat-functional-tests/dependencies.lock
+++ b/metacat-functional-tests/dependencies.lock
@@ -174,11 +174,11 @@
             ],
             "locked": "1.2.1"
         },
-        "org.apache.iceberg:iceberg-spark-runtime": {
+        "org.apache.iceberg:iceberg-spark-runtime-3.3_2.12": {
             "firstLevelTransitive": [
                 "com.netflix.metacat:metacat-connector-hive"
             ],
-            "locked": "0.13.1"
+            "locked": "1.1.0"
         },
         "org.apache.tomcat:tomcat-jdbc": {
             "firstLevelTransitive": [
@@ -414,11 +414,11 @@
             ],
             "locked": "1.2.1"
         },
-        "org.apache.iceberg:iceberg-spark-runtime": {
+        "org.apache.iceberg:iceberg-spark-runtime-3.3_2.12": {
             "firstLevelTransitive": [
                 "com.netflix.metacat:metacat-connector-hive"
             ],
-            "locked": "0.13.1"
+            "locked": "1.1.0"
         },
         "org.apache.tomcat:tomcat-jdbc": {
             "firstLevelTransitive": [
@@ -650,11 +650,11 @@
             ],
             "locked": "1.2.1"
         },
-        "org.apache.iceberg:iceberg-spark-runtime": {
+        "org.apache.iceberg:iceberg-spark-runtime-3.3_2.12": {
             "firstLevelTransitive": [
                 "com.netflix.metacat:metacat-connector-hive"
             ],
-            "locked": "0.13.1"
+            "locked": "1.1.0"
         },
         "org.apache.tomcat:tomcat-jdbc": {
             "firstLevelTransitive": [
@@ -852,11 +852,11 @@
             ],
             "locked": "1.2.1"
         },
-        "org.apache.iceberg:iceberg-spark-runtime": {
+        "org.apache.iceberg:iceberg-spark-runtime-3.3_2.12": {
             "firstLevelTransitive": [
                 "com.netflix.metacat:metacat-connector-hive"
             ],
-            "locked": "0.13.1"
+            "locked": "1.1.0"
         },
         "org.apache.tomcat:tomcat-jdbc": {
             "firstLevelTransitive": [

--- a/metacat-functional-tests/dependencies.lock
+++ b/metacat-functional-tests/dependencies.lock
@@ -178,7 +178,7 @@
             "firstLevelTransitive": [
                 "com.netflix.metacat:metacat-connector-hive"
             ],
-            "locked": "1.9.2"
+            "locked": "1.9.1"
         },
         "org.apache.tomcat:tomcat-jdbc": {
             "firstLevelTransitive": [
@@ -418,7 +418,7 @@
             "firstLevelTransitive": [
                 "com.netflix.metacat:metacat-connector-hive"
             ],
-            "locked": "1.9.2"
+            "locked": "1.9.1"
         },
         "org.apache.tomcat:tomcat-jdbc": {
             "firstLevelTransitive": [
@@ -654,7 +654,7 @@
             "firstLevelTransitive": [
                 "com.netflix.metacat:metacat-connector-hive"
             ],
-            "locked": "1.9.2"
+            "locked": "1.9.1"
         },
         "org.apache.tomcat:tomcat-jdbc": {
             "firstLevelTransitive": [
@@ -856,7 +856,7 @@
             "firstLevelTransitive": [
                 "com.netflix.metacat:metacat-connector-hive"
             ],
-            "locked": "1.9.2"
+            "locked": "1.9.1"
         },
         "org.apache.tomcat:tomcat-jdbc": {
             "firstLevelTransitive": [

--- a/metacat-main/dependencies.lock
+++ b/metacat-main/dependencies.lock
@@ -441,11 +441,11 @@
             ],
             "locked": "5.2.3"
         },
-        "org.apache.iceberg:iceberg-spark-runtime": {
+        "org.apache.iceberg:iceberg-spark-runtime-3.3_2.12": {
             "firstLevelTransitive": [
                 "com.netflix.metacat:metacat-connector-hive"
             ],
-            "locked": "0.13.1"
+            "locked": "1.1.0"
         },
         "org.apache.logging.log4j:log4j-core": {
             "locked": "2.21.1"
@@ -1086,11 +1086,11 @@
             ],
             "locked": "5.2.3"
         },
-        "org.apache.iceberg:iceberg-spark-runtime": {
+        "org.apache.iceberg:iceberg-spark-runtime-3.3_2.12": {
             "firstLevelTransitive": [
                 "com.netflix.metacat:metacat-connector-hive"
             ],
-            "locked": "0.13.1"
+            "locked": "1.1.0"
         },
         "org.apache.logging.log4j:log4j-core": {
             "locked": "2.21.1"

--- a/metacat-main/dependencies.lock
+++ b/metacat-main/dependencies.lock
@@ -445,7 +445,7 @@
             "firstLevelTransitive": [
                 "com.netflix.metacat:metacat-connector-hive"
             ],
-            "locked": "1.9.2"
+            "locked": "1.9.1"
         },
         "org.apache.logging.log4j:log4j-core": {
             "locked": "2.21.1"
@@ -1090,7 +1090,7 @@
             "firstLevelTransitive": [
                 "com.netflix.metacat:metacat-connector-hive"
             ],
-            "locked": "1.9.2"
+            "locked": "1.9.1"
         },
         "org.apache.logging.log4j:log4j-core": {
             "locked": "2.21.1"

--- a/metacat-main/dependencies.lock
+++ b/metacat-main/dependencies.lock
@@ -441,11 +441,11 @@
             ],
             "locked": "5.2.3"
         },
-        "org.apache.iceberg:iceberg-spark-runtime-3.3_2.12": {
+        "org.apache.iceberg:iceberg-spark-runtime-3.5_2.13": {
             "firstLevelTransitive": [
                 "com.netflix.metacat:metacat-connector-hive"
             ],
-            "locked": "1.1.0"
+            "locked": "1.9.2"
         },
         "org.apache.logging.log4j:log4j-core": {
             "locked": "2.21.1"
@@ -1086,11 +1086,11 @@
             ],
             "locked": "5.2.3"
         },
-        "org.apache.iceberg:iceberg-spark-runtime-3.3_2.12": {
+        "org.apache.iceberg:iceberg-spark-runtime-3.5_2.13": {
             "firstLevelTransitive": [
                 "com.netflix.metacat:metacat-connector-hive"
             ],
-            "locked": "1.1.0"
+            "locked": "1.9.2"
         },
         "org.apache.logging.log4j:log4j-core": {
             "locked": "2.21.1"

--- a/metacat-war/dependencies.lock
+++ b/metacat-war/dependencies.lock
@@ -523,11 +523,11 @@
             ],
             "locked": "5.2.3"
         },
-        "org.apache.iceberg:iceberg-spark-runtime-3.3_2.12": {
+        "org.apache.iceberg:iceberg-spark-runtime-3.5_2.13": {
             "firstLevelTransitive": [
                 "com.netflix.metacat:metacat-connector-hive"
             ],
-            "locked": "1.1.0"
+            "locked": "1.9.2"
         },
         "org.apache.logging.log4j:log4j-core": {
             "firstLevelTransitive": [
@@ -1250,11 +1250,11 @@
             ],
             "locked": "5.2.3"
         },
-        "org.apache.iceberg:iceberg-spark-runtime-3.3_2.12": {
+        "org.apache.iceberg:iceberg-spark-runtime-3.5_2.13": {
             "firstLevelTransitive": [
                 "com.netflix.metacat:metacat-connector-hive"
             ],
-            "locked": "1.1.0"
+            "locked": "1.9.2"
         },
         "org.apache.logging.log4j:log4j-core": {
             "firstLevelTransitive": [

--- a/metacat-war/dependencies.lock
+++ b/metacat-war/dependencies.lock
@@ -527,7 +527,7 @@
             "firstLevelTransitive": [
                 "com.netflix.metacat:metacat-connector-hive"
             ],
-            "locked": "1.9.2"
+            "locked": "1.9.1"
         },
         "org.apache.logging.log4j:log4j-core": {
             "firstLevelTransitive": [
@@ -1254,7 +1254,7 @@
             "firstLevelTransitive": [
                 "com.netflix.metacat:metacat-connector-hive"
             ],
-            "locked": "1.9.2"
+            "locked": "1.9.1"
         },
         "org.apache.logging.log4j:log4j-core": {
             "firstLevelTransitive": [

--- a/metacat-war/dependencies.lock
+++ b/metacat-war/dependencies.lock
@@ -523,11 +523,11 @@
             ],
             "locked": "5.2.3"
         },
-        "org.apache.iceberg:iceberg-spark-runtime": {
+        "org.apache.iceberg:iceberg-spark-runtime-3.3_2.12": {
             "firstLevelTransitive": [
                 "com.netflix.metacat:metacat-connector-hive"
             ],
-            "locked": "0.13.1"
+            "locked": "1.1.0"
         },
         "org.apache.logging.log4j:log4j-core": {
             "firstLevelTransitive": [
@@ -1250,11 +1250,11 @@
             ],
             "locked": "5.2.3"
         },
-        "org.apache.iceberg:iceberg-spark-runtime": {
+        "org.apache.iceberg:iceberg-spark-runtime-3.3_2.12": {
             "firstLevelTransitive": [
                 "com.netflix.metacat:metacat-connector-hive"
             ],
-            "locked": "0.13.1"
+            "locked": "1.1.0"
         },
         "org.apache.logging.log4j:log4j-core": {
             "firstLevelTransitive": [


### PR DESCRIPTION
Upgrading Metacat client version to 1.9 to load methods related to branches when blocking writes from unsupported iceberg clients (<1.1)