### PR TITLE
Suppress TABLE_DELETE event when deleting a non-existent table

### DIFF
--- a/metacat-main/src/main/java/com/netflix/metacat/main/services/impl/TableServiceImpl.java
+++ b/metacat-main/src/main/java/com/netflix/metacat/main/services/impl/TableServiceImpl.java
@@ -356,6 +356,7 @@ public class TableServiceImpl implements TableService {
         TableDto tableDto = new TableDto();
         tableDto.setName(name);
 
+        boolean tableExists = false;
         try {
             final Optional<TableDto> oTable = get(name,
                 GetTableServiceParameters.builder()
@@ -364,8 +365,11 @@ public class TableServiceImpl implements TableService {
                     .includeDefinitionMetadata(true)
                     .includeDataMetadata(true)
                     .build());
+            tableExists = oTable.isPresent();
             tableDto = oTable.orElse(tableDto);
         } catch (Exception e) {
+            // Non-NotFoundException: table may exist but we couldn't read its metadata.
+            tableExists = true;
             handleException(name, true, "deleteAndReturn_get", e);
         }
 
@@ -449,7 +453,12 @@ public class TableServiceImpl implements TableService {
                     Lists.newArrayList(tableDto.getDataUri()));
             }
         }
-        eventBus.post(new MetacatDeleteTablePostEvent(name, metacatRequestContext, this, tableDto, isMView));
+        if (tableExists) {
+            eventBus.post(
+                new MetacatDeleteTablePostEvent(name, metacatRequestContext, this, tableDto, isMView));
+        } else {
+            log.info("Skipping delete event for non-existent table {}", name);
+        }
         return tableDto;
     }
 

--- a/metacat-main/src/test/groovy/com/netflix/metacat/main/services/impl/TableServiceImplSpec.groovy
+++ b/metacat-main/src/test/groovy/com/netflix/metacat/main/services/impl/TableServiceImplSpec.groovy
@@ -32,6 +32,7 @@ import com.netflix.metacat.common.server.connectors.ConnectorTableService
 import com.netflix.metacat.common.server.connectors.exception.InvalidMetadataException
 import com.netflix.metacat.common.server.connectors.exception.TableNotFoundException
 import com.netflix.metacat.common.server.converter.ConverterUtil
+import com.netflix.metacat.common.server.events.MetacatDeleteTablePostEvent
 import com.netflix.metacat.common.server.events.MetacatEventBus
 import com.netflix.metacat.common.server.events.MetacatUpdateTablePostEvent
 import com.netflix.metacat.common.server.events.MetacatUpdateTablePreEvent
@@ -258,6 +259,27 @@ class TableServiceImplSpec extends Specification {
         1 * config.canDeleteTableDefinitionMetadata() >> true
         1 * usermetadataService.deleteMetadata(_,_)
         noExceptionThrown()
+    }
+
+    def testDeleteAndReturn_nonExistentTable() {
+        given:
+        // Override the default mock to simulate table not found
+        connectorTableService.get(_, _) >> { throw new TableNotFoundException(name) }
+
+        when:
+        def result = service.deleteAndReturn(name, false)
+
+        then:
+        1 * config.getNoTableDeleteOnTags() >> []
+        1 * config.canDeleteTableDefinitionMetadata() >> true
+        // Metadata cleanup should still happen (metacat metadata can exist independently)
+        1 * usermetadataService.deleteMetadata(_, _)
+        // Post-delete event should NOT be emitted for non-existent table
+        0 * eventBus.post({ it instanceof MetacatDeleteTablePostEvent })
+        // Should still return without exception (idempotent)
+        noExceptionThrown()
+        result != null
+        result.name == name
     }
 
     def testUpdateAndReturn() {


### PR DESCRIPTION
## Summary

When `deleteAndReturn()` is called on a table that does not exist in the connector, Metacat was emitting a `TABLE_DELETE` event with only the table name and no UUID or metadata. This caused issues for downstream consumers (e.g. DSI's `dpprojectservice`) that rely on UUID from events.

- Track whether the table was found via the existing `get()` call
- Skip only the `MetacatDeleteTablePostEvent` emission when the table does not exist
- All other logic (tag/parent-child validation, metadata cleanup, connector delete) remains unconditional to prevent orphaned metacat metadata
- If `get()` throws a non-`NotFoundException` (e.g. `InvalidMetadataException`), assume the table exists so the event is still emitted

## Notes

- The `MetacatDeleteTablePreEvent` is still emitted unconditionally before we know whether the table exists. Downstream consumers that correlate pre/post event pairs may see orphaned pre-events. This could be addressed in a follow-up.
- In the catch path where `get()` throws a non-`NotFoundException`, the event is emitted with a skeleton `TableDto` (name only, no UUID/metadata) since `get()` failed before returning a result. This matches the previous behavior.

## Test plan

- [x] Added `testDeleteAndReturn_nonExistentTable` — verifies that deleting a non-existent table does not emit `MetacatDeleteTablePostEvent` but still runs metadata cleanup
- [x] Existing `testDeleteAndReturn` cases continue to pass (tag validation, metadata delete, soft delete, etc.)
```