### PR TITLE
Support compound app:userName rules in connector authorization

### DIFF
--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/connectors/AuthorizingConnectorCatalogService.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/connectors/AuthorizingConnectorCatalogService.java
@@ -21,6 +21,7 @@ import com.netflix.metacat.common.QualifiedName;
 import com.netflix.metacat.common.dto.Pageable;
 import com.netflix.metacat.common.dto.Sort;
 import com.netflix.metacat.common.server.connectors.model.CatalogInfo;
+import com.netflix.metacat.common.server.util.AuthorizedCaller;
 import com.netflix.metacat.common.server.util.ConnectorAuthorizationUtil;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.Getter;
@@ -45,7 +46,7 @@ public class AuthorizingConnectorCatalogService implements ConnectorCatalogServi
     private final ConnectorCatalogService delegate;
 
     @NonNull
-    private final Set<String> allowedCallers;
+    private final Set<AuthorizedCaller> allowedCallers;
 
     @NonNull
     private final String catalogName;

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/connectors/AuthorizingConnectorDatabaseService.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/connectors/AuthorizingConnectorDatabaseService.java
@@ -21,6 +21,7 @@ import com.netflix.metacat.common.QualifiedName;
 import com.netflix.metacat.common.dto.Pageable;
 import com.netflix.metacat.common.dto.Sort;
 import com.netflix.metacat.common.server.connectors.model.DatabaseInfo;
+import com.netflix.metacat.common.server.util.AuthorizedCaller;
 import com.netflix.metacat.common.server.util.ConnectorAuthorizationUtil;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.Getter;
@@ -45,7 +46,7 @@ public class AuthorizingConnectorDatabaseService implements ConnectorDatabaseSer
     private final ConnectorDatabaseService delegate;
 
     @NonNull
-    private final Set<String> allowedCallers;
+    private final Set<AuthorizedCaller> allowedCallers;
 
     @NonNull
     private final String catalogName;

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/connectors/AuthorizingConnectorPartitionService.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/connectors/AuthorizingConnectorPartitionService.java
@@ -25,6 +25,7 @@ import com.netflix.metacat.common.server.connectors.model.PartitionListRequest;
 import com.netflix.metacat.common.server.connectors.model.PartitionsSaveRequest;
 import com.netflix.metacat.common.server.connectors.model.PartitionsSaveResponse;
 import com.netflix.metacat.common.server.connectors.model.TableInfo;
+import com.netflix.metacat.common.server.util.AuthorizedCaller;
 import com.netflix.metacat.common.server.util.ConnectorAuthorizationUtil;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.Getter;
@@ -50,7 +51,7 @@ public class AuthorizingConnectorPartitionService implements ConnectorPartitionS
     private final ConnectorPartitionService delegate;
 
     @NonNull
-    private final Set<String> allowedCallers;
+    private final Set<AuthorizedCaller> allowedCallers;
 
     @NonNull
     private final String catalogName;

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/connectors/AuthorizingConnectorTableService.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/connectors/AuthorizingConnectorTableService.java
@@ -21,6 +21,7 @@ import com.netflix.metacat.common.QualifiedName;
 import com.netflix.metacat.common.dto.Pageable;
 import com.netflix.metacat.common.dto.Sort;
 import com.netflix.metacat.common.server.connectors.model.TableInfo;
+import com.netflix.metacat.common.server.util.AuthorizedCaller;
 import com.netflix.metacat.common.server.util.ConnectorAuthorizationUtil;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.Getter;
@@ -46,7 +47,7 @@ public class AuthorizingConnectorTableService implements ConnectorTableService {
     private final ConnectorTableService delegate;
 
     @NonNull
-    private final Set<String> allowedCallers;
+    private final Set<AuthorizedCaller> allowedCallers;
 
     @NonNull
     private final String catalogName;

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/connectors/ConnectorFactoryDecorator.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/connectors/ConnectorFactoryDecorator.java
@@ -18,6 +18,7 @@
 package com.netflix.metacat.common.server.connectors;
 
 import com.netflix.metacat.common.server.api.ratelimiter.RateLimiter;
+import com.netflix.metacat.common.server.util.AuthorizedCaller;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
@@ -55,7 +56,7 @@ public class ConnectorFactoryDecorator implements ConnectorFactory {
     private final RateLimiter rateLimiter;
     private final boolean rateLimiterEnabled;
     private final boolean authorizationRequired;
-    private final Set<String> authorizedCallers;
+    private final Set<AuthorizedCaller> authorizedCallers;
 
     /**
      * Creates the decorated connector factory that wraps connector services
@@ -225,7 +226,7 @@ public class ConnectorFactoryDecorator implements ConnectorFactory {
         );
     }
 
-    private Set<String> getAuthorizedCallers() {
+    private Set<AuthorizedCaller> getAuthorizedCallers() {
         if (connectorContext.getConfiguration() == null) {
             return Collections.emptySet();
         }
@@ -237,11 +238,24 @@ public class ConnectorFactoryDecorator implements ConnectorFactory {
             return Collections.emptySet();
         }
 
-        // Split by comma, trim whitespace, filter empty strings, collect to set
+        // Split by comma, trim whitespace, filter empty strings, parse each token.
+        // Plain entry "app" matches on SsoDirectCallerAppName only.
+        // Compound entry "app:userName" requires both SsoDirectCallerAppName AND userName to match.
         // Note: matching is case-sensitive (e.g., "IRC" will not match "irc")
         return Arrays.stream(callers.split(","))
             .map(String::trim)
             .filter(s -> !s.isEmpty())
+            .map(ConnectorFactoryDecorator::parseAuthorizedCaller)
             .collect(Collectors.toSet());
+    }
+
+    private static AuthorizedCaller parseAuthorizedCaller(final String token) {
+        final int colon = token.indexOf(':');
+        if (colon < 0) {
+            return new AuthorizedCaller(token, null);
+        }
+        final String app = token.substring(0, colon);
+        final String user = token.substring(colon + 1);
+        return new AuthorizedCaller(app, user);
     }
 }

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/util/AuthorizedCaller.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/util/AuthorizedCaller.java
@@ -1,0 +1,64 @@
+/*
+ *
+ *  Copyright 2024 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.metacat.common.server.util;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+import javax.annotation.Nullable;
+
+/**
+ * An entry in a connector authorization allow list.
+ * Matches on SsoDirectCallerAppName, and optionally on userName when {@link #userName} is set.
+ *
+ * @author jursetta
+ */
+@RequiredArgsConstructor
+@EqualsAndHashCode
+@ToString
+@Getter
+public final class AuthorizedCaller {
+
+    @NonNull
+    private final String appName;
+
+    @Nullable
+    private final String userName;
+
+    /**
+     * Tests whether the given caller identity satisfies this rule.
+     * appName must always match exactly. If this rule has a userName, the caller's userName must
+     * match it exactly; if this rule has no userName, the caller's userName is ignored.
+     *
+     * @param callerAppName  the SsoDirectCallerAppName from the request
+     * @param callerUserName the userName from the request (may be null)
+     * @return true if the caller is allowed by this rule
+     */
+    public boolean matches(final String callerAppName, @Nullable final String callerUserName) {
+        if (!appName.equals(callerAppName)) {
+            return false;
+        }
+        if (userName == null) {
+            return true;
+        }
+        return userName.equals(callerUserName);
+    }
+}

--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/util/ConnectorAuthorizationUtil.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/util/ConnectorAuthorizationUtil.java
@@ -39,38 +39,43 @@ public final class ConnectorAuthorizationUtil {
 
     /**
      * Checks if the current caller is authorized to access the specified catalog.
-     * Authorization is based on the SsoDirectCallerAppName from the request context's additionalContext.
+     * Authorization is based on the SsoDirectCallerAppName from the request context's additionalContext,
+     * and optionally the request's userName when a rule specifies one.
      *
      * @param catalogName    the name of the catalog being accessed
-     * @param allowedCallers the set of callers allowed to access this catalog
+     * @param allowedCallers the set of caller rules allowed to access this catalog
      * @param operation      the operation being performed (for logging)
      * @param resource       the resource being accessed (for logging)
      * @throws CatalogUnauthorizedException if the caller is not authorized
      */
     public static void checkAuthorization(
         final String catalogName,
-        final Set<String> allowedCallers,
+        final Set<AuthorizedCaller> allowedCallers,
         final String operation,
         final QualifiedName resource
     ) {
         final MetacatRequestContext context = MetacatContextManager.getContext();
-        final String caller = context.getAdditionalContext()
+        final String callerApp = context.getAdditionalContext()
             .get(MetacatRequestContext.SSO_DIRECT_CALLER_APP_NAME);
+        final String callerUser = context.getUserName();
 
-        if (caller == null) {
+        if (callerApp == null) {
             log.warn("Authorization denied for catalog {}: No SsoDirectCallerAppName in request context for {} on {}",
                 catalogName, operation, resource);
             throw new CatalogUnauthorizedException(catalogName);
         }
 
-        if (!allowedCallers.contains(caller)) {
+        final boolean allowed = allowedCallers.stream()
+            .anyMatch(rule -> rule.matches(callerApp, callerUser));
+
+        if (!allowed) {
             log.warn("Authorization denied for catalog {}: "
-                    + "SsoDirectCallerAppName '{}' not in allowed list for {} on {}",
-                catalogName, caller, operation, resource);
-            throw new CatalogUnauthorizedException(catalogName, caller);
+                    + "SsoDirectCallerAppName '{}' (userName '{}') not in allowed list for {} on {}",
+                catalogName, callerApp, callerUser, operation, resource);
+            throw new CatalogUnauthorizedException(catalogName, callerApp);
         }
 
-        log.debug("Authorization granted for catalog {}: SsoDirectCallerAppName '{}' for {} on {}",
-            catalogName, caller, operation, resource);
+        log.debug("Authorization granted for catalog {}: SsoDirectCallerAppName '{}' (userName '{}') for {} on {}",
+            catalogName, callerApp, callerUser, operation, resource);
     }
 }

--- a/metacat-common-server/src/test/groovy/com/netflix/metacat/common/server/connectors/AuthorizingConnectorCatalogServiceSpec.groovy
+++ b/metacat-common-server/src/test/groovy/com/netflix/metacat/common/server/connectors/AuthorizingConnectorCatalogServiceSpec.groovy
@@ -21,6 +21,7 @@ import com.netflix.metacat.common.MetacatRequestContext
 import com.netflix.metacat.common.QualifiedName
 import com.netflix.metacat.common.server.connectors.exception.CatalogUnauthorizedException
 import com.netflix.metacat.common.server.connectors.model.CatalogInfo
+import com.netflix.metacat.common.server.util.AuthorizedCaller
 import com.netflix.metacat.common.server.util.MetacatContextManager
 import spock.lang.Specification
 
@@ -58,7 +59,7 @@ class AuthorizingConnectorCatalogServiceSpec extends Specification {
 
     def "create - authorized caller succeeds"() {
         given:
-        def allowedCallers = ["irc", "irc-server"] as Set
+        def allowedCallers = [new AuthorizedCaller("irc", null), new AuthorizedCaller("irc-server", null)] as Set
         service = new AuthorizingConnectorCatalogService(delegate, allowedCallers, catalogName)
         MetacatContextManager.setContext(buildContextWithCaller("irc"))
 
@@ -71,7 +72,7 @@ class AuthorizingConnectorCatalogServiceSpec extends Specification {
 
     def "create - unauthorized caller throws exception"() {
         given:
-        def allowedCallers = ["irc", "irc-server"] as Set
+        def allowedCallers = [new AuthorizedCaller("irc", null), new AuthorizedCaller("irc-server", null)] as Set
         service = new AuthorizingConnectorCatalogService(delegate, allowedCallers, catalogName)
         MetacatContextManager.setContext(buildContextWithCaller("unauthorized-app"))
 
@@ -85,7 +86,7 @@ class AuthorizingConnectorCatalogServiceSpec extends Specification {
 
     def "create - missing SsoDirectCallerAppName throws exception"() {
         given:
-        def allowedCallers = ["irc", "irc-server"] as Set
+        def allowedCallers = [new AuthorizedCaller("irc", null), new AuthorizedCaller("irc-server", null)] as Set
         service = new AuthorizingConnectorCatalogService(delegate, allowedCallers, catalogName)
 
         // No SsoDirectCallerAppName in additionalContext
@@ -102,7 +103,7 @@ class AuthorizingConnectorCatalogServiceSpec extends Specification {
 
     def "update - authorized caller succeeds"() {
         given:
-        def allowedCallers = ["irc"] as Set
+        def allowedCallers = [new AuthorizedCaller("irc", null)] as Set
         service = new AuthorizingConnectorCatalogService(delegate, allowedCallers, catalogName)
         MetacatContextManager.setContext(buildContextWithCaller("irc"))
 
@@ -115,7 +116,7 @@ class AuthorizingConnectorCatalogServiceSpec extends Specification {
 
     def "update - unauthorized caller throws exception"() {
         given:
-        def allowedCallers = ["irc"] as Set
+        def allowedCallers = [new AuthorizedCaller("irc", null)] as Set
         service = new AuthorizingConnectorCatalogService(delegate, allowedCallers, catalogName)
         MetacatContextManager.setContext(buildContextWithCaller("spark"))
 
@@ -129,7 +130,7 @@ class AuthorizingConnectorCatalogServiceSpec extends Specification {
 
     def "delete - authorized caller succeeds"() {
         given:
-        def allowedCallers = ["irc"] as Set
+        def allowedCallers = [new AuthorizedCaller("irc", null)] as Set
         service = new AuthorizingConnectorCatalogService(delegate, allowedCallers, catalogName)
         MetacatContextManager.setContext(buildContextWithCaller("irc"))
 
@@ -142,7 +143,7 @@ class AuthorizingConnectorCatalogServiceSpec extends Specification {
 
     def "get - authorized caller succeeds"() {
         given:
-        def allowedCallers = ["irc"] as Set
+        def allowedCallers = [new AuthorizedCaller("irc", null)] as Set
         service = new AuthorizingConnectorCatalogService(delegate, allowedCallers, catalogName)
         MetacatContextManager.setContext(buildContextWithCaller("irc"))
 
@@ -155,7 +156,7 @@ class AuthorizingConnectorCatalogServiceSpec extends Specification {
 
     def "exists - authorized caller succeeds"() {
         given:
-        def allowedCallers = ["irc"] as Set
+        def allowedCallers = [new AuthorizedCaller("irc", null)] as Set
         service = new AuthorizingConnectorCatalogService(delegate, allowedCallers, catalogName)
         MetacatContextManager.setContext(buildContextWithCaller("irc"))
 
@@ -168,7 +169,7 @@ class AuthorizingConnectorCatalogServiceSpec extends Specification {
 
     def "list - authorized caller succeeds"() {
         given:
-        def allowedCallers = ["irc"] as Set
+        def allowedCallers = [new AuthorizedCaller("irc", null)] as Set
         service = new AuthorizingConnectorCatalogService(delegate, allowedCallers, catalogName)
         MetacatContextManager.setContext(buildContextWithCaller("irc"))
 
@@ -181,7 +182,7 @@ class AuthorizingConnectorCatalogServiceSpec extends Specification {
 
     def "listNames - authorized caller succeeds"() {
         given:
-        def allowedCallers = ["irc"] as Set
+        def allowedCallers = [new AuthorizedCaller("irc", null)] as Set
         service = new AuthorizingConnectorCatalogService(delegate, allowedCallers, catalogName)
         MetacatContextManager.setContext(buildContextWithCaller("irc"))
 
@@ -194,7 +195,7 @@ class AuthorizingConnectorCatalogServiceSpec extends Specification {
 
     def "rename - authorized caller succeeds"() {
         given:
-        def allowedCallers = ["irc"] as Set
+        def allowedCallers = [new AuthorizedCaller("irc", null)] as Set
         service = new AuthorizingConnectorCatalogService(delegate, allowedCallers, catalogName)
         MetacatContextManager.setContext(buildContextWithCaller("irc"))
 
@@ -207,7 +208,7 @@ class AuthorizingConnectorCatalogServiceSpec extends Specification {
 
     def "exception message contains caller name when unauthorized"() {
         given:
-        def allowedCallers = ["irc"] as Set
+        def allowedCallers = [new AuthorizedCaller("irc", null)] as Set
         service = new AuthorizingConnectorCatalogService(delegate, allowedCallers, catalogName)
         MetacatContextManager.setContext(buildContextWithCaller("bad-actor"))
 

--- a/metacat-common-server/src/test/groovy/com/netflix/metacat/common/server/connectors/AuthorizingConnectorDatabaseServiceSpec.groovy
+++ b/metacat-common-server/src/test/groovy/com/netflix/metacat/common/server/connectors/AuthorizingConnectorDatabaseServiceSpec.groovy
@@ -21,6 +21,7 @@ import com.netflix.metacat.common.MetacatRequestContext
 import com.netflix.metacat.common.QualifiedName
 import com.netflix.metacat.common.server.connectors.exception.CatalogUnauthorizedException
 import com.netflix.metacat.common.server.connectors.model.DatabaseInfo
+import com.netflix.metacat.common.server.util.AuthorizedCaller
 import com.netflix.metacat.common.server.util.MetacatContextManager
 import spock.lang.Specification
 
@@ -58,7 +59,7 @@ class AuthorizingConnectorDatabaseServiceSpec extends Specification {
 
     def "create - authorized caller succeeds"() {
         given:
-        def allowedCallers = ["irc", "irc-server"] as Set
+        def allowedCallers = [new AuthorizedCaller("irc", null), new AuthorizedCaller("irc-server", null)] as Set
         service = new AuthorizingConnectorDatabaseService(delegate, allowedCallers, catalogName)
         MetacatContextManager.setContext(buildContextWithCaller("irc"))
 
@@ -71,7 +72,7 @@ class AuthorizingConnectorDatabaseServiceSpec extends Specification {
 
     def "create - unauthorized caller throws exception"() {
         given:
-        def allowedCallers = ["irc", "irc-server"] as Set
+        def allowedCallers = [new AuthorizedCaller("irc", null), new AuthorizedCaller("irc-server", null)] as Set
         service = new AuthorizingConnectorDatabaseService(delegate, allowedCallers, catalogName)
         MetacatContextManager.setContext(buildContextWithCaller("unauthorized-app"))
 
@@ -85,7 +86,7 @@ class AuthorizingConnectorDatabaseServiceSpec extends Specification {
 
     def "create - missing SsoDirectCallerAppName throws exception"() {
         given:
-        def allowedCallers = ["irc", "irc-server"] as Set
+        def allowedCallers = [new AuthorizedCaller("irc", null), new AuthorizedCaller("irc-server", null)] as Set
         service = new AuthorizingConnectorDatabaseService(delegate, allowedCallers, catalogName)
 
         def ctx = MetacatRequestContext.builder().build()
@@ -101,7 +102,7 @@ class AuthorizingConnectorDatabaseServiceSpec extends Specification {
 
     def "update - authorized caller succeeds"() {
         given:
-        def allowedCallers = ["irc"] as Set
+        def allowedCallers = [new AuthorizedCaller("irc", null)] as Set
         service = new AuthorizingConnectorDatabaseService(delegate, allowedCallers, catalogName)
         MetacatContextManager.setContext(buildContextWithCaller("irc"))
 
@@ -114,7 +115,7 @@ class AuthorizingConnectorDatabaseServiceSpec extends Specification {
 
     def "update - unauthorized caller throws exception"() {
         given:
-        def allowedCallers = ["irc"] as Set
+        def allowedCallers = [new AuthorizedCaller("irc", null)] as Set
         service = new AuthorizingConnectorDatabaseService(delegate, allowedCallers, catalogName)
         MetacatContextManager.setContext(buildContextWithCaller("spark"))
 
@@ -128,7 +129,7 @@ class AuthorizingConnectorDatabaseServiceSpec extends Specification {
 
     def "delete - authorized caller succeeds"() {
         given:
-        def allowedCallers = ["irc"] as Set
+        def allowedCallers = [new AuthorizedCaller("irc", null)] as Set
         service = new AuthorizingConnectorDatabaseService(delegate, allowedCallers, catalogName)
         MetacatContextManager.setContext(buildContextWithCaller("irc"))
 
@@ -141,7 +142,7 @@ class AuthorizingConnectorDatabaseServiceSpec extends Specification {
 
     def "get - authorized caller succeeds"() {
         given:
-        def allowedCallers = ["irc"] as Set
+        def allowedCallers = [new AuthorizedCaller("irc", null)] as Set
         service = new AuthorizingConnectorDatabaseService(delegate, allowedCallers, catalogName)
         MetacatContextManager.setContext(buildContextWithCaller("irc"))
 
@@ -154,7 +155,7 @@ class AuthorizingConnectorDatabaseServiceSpec extends Specification {
 
     def "exists - authorized caller succeeds"() {
         given:
-        def allowedCallers = ["irc"] as Set
+        def allowedCallers = [new AuthorizedCaller("irc", null)] as Set
         service = new AuthorizingConnectorDatabaseService(delegate, allowedCallers, catalogName)
         MetacatContextManager.setContext(buildContextWithCaller("irc"))
 
@@ -167,7 +168,7 @@ class AuthorizingConnectorDatabaseServiceSpec extends Specification {
 
     def "list - authorized caller succeeds"() {
         given:
-        def allowedCallers = ["irc"] as Set
+        def allowedCallers = [new AuthorizedCaller("irc", null)] as Set
         service = new AuthorizingConnectorDatabaseService(delegate, allowedCallers, catalogName)
         MetacatContextManager.setContext(buildContextWithCaller("irc"))
 
@@ -180,7 +181,7 @@ class AuthorizingConnectorDatabaseServiceSpec extends Specification {
 
     def "listNames - authorized caller succeeds"() {
         given:
-        def allowedCallers = ["irc"] as Set
+        def allowedCallers = [new AuthorizedCaller("irc", null)] as Set
         service = new AuthorizingConnectorDatabaseService(delegate, allowedCallers, catalogName)
         MetacatContextManager.setContext(buildContextWithCaller("irc"))
 
@@ -193,7 +194,7 @@ class AuthorizingConnectorDatabaseServiceSpec extends Specification {
 
     def "rename - authorized caller succeeds"() {
         given:
-        def allowedCallers = ["irc"] as Set
+        def allowedCallers = [new AuthorizedCaller("irc", null)] as Set
         service = new AuthorizingConnectorDatabaseService(delegate, allowedCallers, catalogName)
         MetacatContextManager.setContext(buildContextWithCaller("irc"))
 
@@ -206,7 +207,7 @@ class AuthorizingConnectorDatabaseServiceSpec extends Specification {
 
     def "listViewNames - authorized caller succeeds"() {
         given:
-        def allowedCallers = ["irc"] as Set
+        def allowedCallers = [new AuthorizedCaller("irc", null)] as Set
         service = new AuthorizingConnectorDatabaseService(delegate, allowedCallers, catalogName)
         MetacatContextManager.setContext(buildContextWithCaller("irc"))
 
@@ -219,7 +220,7 @@ class AuthorizingConnectorDatabaseServiceSpec extends Specification {
 
     def "exception message contains caller name when unauthorized"() {
         given:
-        def allowedCallers = ["irc"] as Set
+        def allowedCallers = [new AuthorizedCaller("irc", null)] as Set
         service = new AuthorizingConnectorDatabaseService(delegate, allowedCallers, catalogName)
         MetacatContextManager.setContext(buildContextWithCaller("bad-actor"))
 

--- a/metacat-common-server/src/test/groovy/com/netflix/metacat/common/server/connectors/AuthorizingConnectorPartitionServiceSpec.groovy
+++ b/metacat-common-server/src/test/groovy/com/netflix/metacat/common/server/connectors/AuthorizingConnectorPartitionServiceSpec.groovy
@@ -24,6 +24,7 @@ import com.netflix.metacat.common.server.connectors.model.PartitionInfo
 import com.netflix.metacat.common.server.connectors.model.PartitionListRequest
 import com.netflix.metacat.common.server.connectors.model.PartitionsSaveRequest
 import com.netflix.metacat.common.server.connectors.model.TableInfo
+import com.netflix.metacat.common.server.util.AuthorizedCaller
 import com.netflix.metacat.common.server.util.MetacatContextManager
 import spock.lang.Specification
 
@@ -69,7 +70,7 @@ class AuthorizingConnectorPartitionServiceSpec extends Specification {
 
     def "create - authorized caller succeeds"() {
         given:
-        def allowedCallers = ["irc", "irc-server"] as Set
+        def allowedCallers = [new AuthorizedCaller("irc", null), new AuthorizedCaller("irc-server", null)] as Set
         service = new AuthorizingConnectorPartitionService(delegate, allowedCallers, catalogName)
         MetacatContextManager.setContext(buildContextWithCaller("irc"))
 
@@ -82,7 +83,7 @@ class AuthorizingConnectorPartitionServiceSpec extends Specification {
 
     def "create - unauthorized caller throws exception"() {
         given:
-        def allowedCallers = ["irc", "irc-server"] as Set
+        def allowedCallers = [new AuthorizedCaller("irc", null), new AuthorizedCaller("irc-server", null)] as Set
         service = new AuthorizingConnectorPartitionService(delegate, allowedCallers, catalogName)
         MetacatContextManager.setContext(buildContextWithCaller("unauthorized-app"))
 
@@ -96,7 +97,7 @@ class AuthorizingConnectorPartitionServiceSpec extends Specification {
 
     def "create - missing SsoDirectCallerAppName throws exception"() {
         given:
-        def allowedCallers = ["irc", "irc-server"] as Set
+        def allowedCallers = [new AuthorizedCaller("irc", null), new AuthorizedCaller("irc-server", null)] as Set
         service = new AuthorizingConnectorPartitionService(delegate, allowedCallers, catalogName)
 
         // No SsoDirectCallerAppName in additionalContext
@@ -113,7 +114,7 @@ class AuthorizingConnectorPartitionServiceSpec extends Specification {
 
     def "update - authorized caller succeeds"() {
         given:
-        def allowedCallers = ["irc"] as Set
+        def allowedCallers = [new AuthorizedCaller("irc", null)] as Set
         service = new AuthorizingConnectorPartitionService(delegate, allowedCallers, catalogName)
         MetacatContextManager.setContext(buildContextWithCaller("irc"))
 
@@ -126,7 +127,7 @@ class AuthorizingConnectorPartitionServiceSpec extends Specification {
 
     def "delete - authorized caller succeeds"() {
         given:
-        def allowedCallers = ["irc"] as Set
+        def allowedCallers = [new AuthorizedCaller("irc", null)] as Set
         service = new AuthorizingConnectorPartitionService(delegate, allowedCallers, catalogName)
         MetacatContextManager.setContext(buildContextWithCaller("irc"))
 
@@ -139,7 +140,7 @@ class AuthorizingConnectorPartitionServiceSpec extends Specification {
 
     def "get - authorized caller succeeds"() {
         given:
-        def allowedCallers = ["irc"] as Set
+        def allowedCallers = [new AuthorizedCaller("irc", null)] as Set
         service = new AuthorizingConnectorPartitionService(delegate, allowedCallers, catalogName)
         MetacatContextManager.setContext(buildContextWithCaller("irc"))
 
@@ -152,7 +153,7 @@ class AuthorizingConnectorPartitionServiceSpec extends Specification {
 
     def "exists - authorized caller succeeds"() {
         given:
-        def allowedCallers = ["irc"] as Set
+        def allowedCallers = [new AuthorizedCaller("irc", null)] as Set
         service = new AuthorizingConnectorPartitionService(delegate, allowedCallers, catalogName)
         MetacatContextManager.setContext(buildContextWithCaller("irc"))
 
@@ -165,7 +166,7 @@ class AuthorizingConnectorPartitionServiceSpec extends Specification {
 
     def "list - authorized caller succeeds"() {
         given:
-        def allowedCallers = ["irc"] as Set
+        def allowedCallers = [new AuthorizedCaller("irc", null)] as Set
         service = new AuthorizingConnectorPartitionService(delegate, allowedCallers, catalogName)
         MetacatContextManager.setContext(buildContextWithCaller("irc"))
 
@@ -178,7 +179,7 @@ class AuthorizingConnectorPartitionServiceSpec extends Specification {
 
     def "listNames - authorized caller succeeds"() {
         given:
-        def allowedCallers = ["irc"] as Set
+        def allowedCallers = [new AuthorizedCaller("irc", null)] as Set
         service = new AuthorizingConnectorPartitionService(delegate, allowedCallers, catalogName)
         MetacatContextManager.setContext(buildContextWithCaller("irc"))
 
@@ -191,7 +192,7 @@ class AuthorizingConnectorPartitionServiceSpec extends Specification {
 
     def "rename - authorized caller succeeds"() {
         given:
-        def allowedCallers = ["irc"] as Set
+        def allowedCallers = [new AuthorizedCaller("irc", null)] as Set
         service = new AuthorizingConnectorPartitionService(delegate, allowedCallers, catalogName)
         MetacatContextManager.setContext(buildContextWithCaller("irc"))
 
@@ -204,7 +205,7 @@ class AuthorizingConnectorPartitionServiceSpec extends Specification {
 
     def "getPartitions - authorized caller succeeds"() {
         given:
-        def allowedCallers = ["irc"] as Set
+        def allowedCallers = [new AuthorizedCaller("irc", null)] as Set
         service = new AuthorizingConnectorPartitionService(delegate, allowedCallers, catalogName)
         MetacatContextManager.setContext(buildContextWithCaller("irc"))
 
@@ -217,7 +218,7 @@ class AuthorizingConnectorPartitionServiceSpec extends Specification {
 
     def "getPartitions - unauthorized caller throws exception"() {
         given:
-        def allowedCallers = ["irc"] as Set
+        def allowedCallers = [new AuthorizedCaller("irc", null)] as Set
         service = new AuthorizingConnectorPartitionService(delegate, allowedCallers, catalogName)
         MetacatContextManager.setContext(buildContextWithCaller("spark"))
 
@@ -231,7 +232,7 @@ class AuthorizingConnectorPartitionServiceSpec extends Specification {
 
     def "savePartitions - authorized caller succeeds"() {
         given:
-        def allowedCallers = ["irc"] as Set
+        def allowedCallers = [new AuthorizedCaller("irc", null)] as Set
         service = new AuthorizingConnectorPartitionService(delegate, allowedCallers, catalogName)
         MetacatContextManager.setContext(buildContextWithCaller("irc"))
 
@@ -244,7 +245,7 @@ class AuthorizingConnectorPartitionServiceSpec extends Specification {
 
     def "savePartitions - unauthorized caller throws exception"() {
         given:
-        def allowedCallers = ["irc"] as Set
+        def allowedCallers = [new AuthorizedCaller("irc", null)] as Set
         service = new AuthorizingConnectorPartitionService(delegate, allowedCallers, catalogName)
         MetacatContextManager.setContext(buildContextWithCaller("hive"))
 
@@ -258,7 +259,7 @@ class AuthorizingConnectorPartitionServiceSpec extends Specification {
 
     def "deletePartitions - authorized caller succeeds"() {
         given:
-        def allowedCallers = ["irc"] as Set
+        def allowedCallers = [new AuthorizedCaller("irc", null)] as Set
         service = new AuthorizingConnectorPartitionService(delegate, allowedCallers, catalogName)
         def partitionNames = ["dateint=20240101"]
         MetacatContextManager.setContext(buildContextWithCaller("irc"))
@@ -272,7 +273,7 @@ class AuthorizingConnectorPartitionServiceSpec extends Specification {
 
     def "getPartitionCount - authorized caller succeeds"() {
         given:
-        def allowedCallers = ["irc"] as Set
+        def allowedCallers = [new AuthorizedCaller("irc", null)] as Set
         service = new AuthorizingConnectorPartitionService(delegate, allowedCallers, catalogName)
         MetacatContextManager.setContext(buildContextWithCaller("irc"))
 
@@ -285,7 +286,7 @@ class AuthorizingConnectorPartitionServiceSpec extends Specification {
 
     def "getPartitionNames - authorized caller succeeds"() {
         given:
-        def allowedCallers = ["irc"] as Set
+        def allowedCallers = [new AuthorizedCaller("irc", null)] as Set
         service = new AuthorizingConnectorPartitionService(delegate, allowedCallers, catalogName)
         def uris = ["s3://bucket/path"]
         MetacatContextManager.setContext(buildContextWithCaller("irc"))
@@ -299,7 +300,7 @@ class AuthorizingConnectorPartitionServiceSpec extends Specification {
 
     def "getPartitionKeys - authorized caller succeeds"() {
         given:
-        def allowedCallers = ["irc"] as Set
+        def allowedCallers = [new AuthorizedCaller("irc", null)] as Set
         service = new AuthorizingConnectorPartitionService(delegate, allowedCallers, catalogName)
         MetacatContextManager.setContext(buildContextWithCaller("irc"))
 
@@ -312,7 +313,7 @@ class AuthorizingConnectorPartitionServiceSpec extends Specification {
 
     def "getPartitionUris - authorized caller succeeds"() {
         given:
-        def allowedCallers = ["irc"] as Set
+        def allowedCallers = [new AuthorizedCaller("irc", null)] as Set
         service = new AuthorizingConnectorPartitionService(delegate, allowedCallers, catalogName)
         MetacatContextManager.setContext(buildContextWithCaller("irc"))
 
@@ -325,7 +326,7 @@ class AuthorizingConnectorPartitionServiceSpec extends Specification {
 
     def "exception message contains caller name when unauthorized"() {
         given:
-        def allowedCallers = ["irc"] as Set
+        def allowedCallers = [new AuthorizedCaller("irc", null)] as Set
         service = new AuthorizingConnectorPartitionService(delegate, allowedCallers, catalogName)
         MetacatContextManager.setContext(buildContextWithCaller("bad-actor"))
 
@@ -340,7 +341,7 @@ class AuthorizingConnectorPartitionServiceSpec extends Specification {
 
     def "exception message indicates missing caller when no SsoDirectCallerAppName"() {
         given:
-        def allowedCallers = ["irc"] as Set
+        def allowedCallers = [new AuthorizedCaller("irc", null)] as Set
         service = new AuthorizingConnectorPartitionService(delegate, allowedCallers, catalogName)
 
         def ctx = MetacatRequestContext.builder().build()

--- a/metacat-common-server/src/test/groovy/com/netflix/metacat/common/server/connectors/AuthorizingConnectorTableServiceSpec.groovy
+++ b/metacat-common-server/src/test/groovy/com/netflix/metacat/common/server/connectors/AuthorizingConnectorTableServiceSpec.groovy
@@ -21,6 +21,7 @@ import com.netflix.metacat.common.MetacatRequestContext
 import com.netflix.metacat.common.QualifiedName
 import com.netflix.metacat.common.server.connectors.exception.CatalogUnauthorizedException
 import com.netflix.metacat.common.server.connectors.model.TableInfo
+import com.netflix.metacat.common.server.util.AuthorizedCaller
 import com.netflix.metacat.common.server.util.MetacatContextManager
 import spock.lang.Specification
 
@@ -60,7 +61,7 @@ class AuthorizingConnectorTableServiceSpec extends Specification {
 
     def "create - authorized caller succeeds"() {
         given:
-        def allowedCallers = ["irc", "irc-server"] as Set
+        def allowedCallers = [new AuthorizedCaller("irc", null), new AuthorizedCaller("irc-server", null)] as Set
         service = new AuthorizingConnectorTableService(delegate, allowedCallers, catalogName)
         MetacatContextManager.setContext(buildContextWithCaller("irc"))
 
@@ -73,7 +74,7 @@ class AuthorizingConnectorTableServiceSpec extends Specification {
 
     def "create - unauthorized caller throws exception"() {
         given:
-        def allowedCallers = ["irc", "irc-server"] as Set
+        def allowedCallers = [new AuthorizedCaller("irc", null), new AuthorizedCaller("irc-server", null)] as Set
         service = new AuthorizingConnectorTableService(delegate, allowedCallers, catalogName)
         MetacatContextManager.setContext(buildContextWithCaller("unauthorized-app"))
 
@@ -87,7 +88,7 @@ class AuthorizingConnectorTableServiceSpec extends Specification {
 
     def "create - missing SsoDirectCallerAppName throws exception"() {
         given:
-        def allowedCallers = ["irc", "irc-server"] as Set
+        def allowedCallers = [new AuthorizedCaller("irc", null), new AuthorizedCaller("irc-server", null)] as Set
         service = new AuthorizingConnectorTableService(delegate, allowedCallers, catalogName)
 
         // No SsoDirectCallerAppName in additionalContext
@@ -104,7 +105,7 @@ class AuthorizingConnectorTableServiceSpec extends Specification {
 
     def "update - authorized caller succeeds"() {
         given:
-        def allowedCallers = ["irc"] as Set
+        def allowedCallers = [new AuthorizedCaller("irc", null)] as Set
         service = new AuthorizingConnectorTableService(delegate, allowedCallers, catalogName)
         MetacatContextManager.setContext(buildContextWithCaller("irc"))
 
@@ -117,7 +118,7 @@ class AuthorizingConnectorTableServiceSpec extends Specification {
 
     def "update - unauthorized caller throws exception"() {
         given:
-        def allowedCallers = ["irc"] as Set
+        def allowedCallers = [new AuthorizedCaller("irc", null)] as Set
         service = new AuthorizingConnectorTableService(delegate, allowedCallers, catalogName)
         MetacatContextManager.setContext(buildContextWithCaller("spark"))
 
@@ -131,7 +132,7 @@ class AuthorizingConnectorTableServiceSpec extends Specification {
 
     def "delete - authorized caller succeeds"() {
         given:
-        def allowedCallers = ["irc"] as Set
+        def allowedCallers = [new AuthorizedCaller("irc", null)] as Set
         service = new AuthorizingConnectorTableService(delegate, allowedCallers, catalogName)
         MetacatContextManager.setContext(buildContextWithCaller("irc"))
 
@@ -144,7 +145,7 @@ class AuthorizingConnectorTableServiceSpec extends Specification {
 
     def "delete - unauthorized caller throws exception"() {
         given:
-        def allowedCallers = ["irc"] as Set
+        def allowedCallers = [new AuthorizedCaller("irc", null)] as Set
         service = new AuthorizingConnectorTableService(delegate, allowedCallers, catalogName)
         MetacatContextManager.setContext(buildContextWithCaller("hive"))
 
@@ -158,7 +159,7 @@ class AuthorizingConnectorTableServiceSpec extends Specification {
 
     def "get - authorized caller succeeds"() {
         given:
-        def allowedCallers = ["irc"] as Set
+        def allowedCallers = [new AuthorizedCaller("irc", null)] as Set
         service = new AuthorizingConnectorTableService(delegate, allowedCallers, catalogName)
         MetacatContextManager.setContext(buildContextWithCaller("irc"))
 
@@ -171,7 +172,7 @@ class AuthorizingConnectorTableServiceSpec extends Specification {
 
     def "get - unauthorized caller throws exception"() {
         given:
-        def allowedCallers = ["irc"] as Set
+        def allowedCallers = [new AuthorizedCaller("irc", null)] as Set
         service = new AuthorizingConnectorTableService(delegate, allowedCallers, catalogName)
         MetacatContextManager.setContext(buildContextWithCaller("presto"))
 
@@ -185,7 +186,7 @@ class AuthorizingConnectorTableServiceSpec extends Specification {
 
     def "exists - authorized caller succeeds"() {
         given:
-        def allowedCallers = ["irc"] as Set
+        def allowedCallers = [new AuthorizedCaller("irc", null)] as Set
         service = new AuthorizingConnectorTableService(delegate, allowedCallers, catalogName)
         MetacatContextManager.setContext(buildContextWithCaller("irc"))
 
@@ -198,7 +199,7 @@ class AuthorizingConnectorTableServiceSpec extends Specification {
 
     def "list - authorized caller succeeds"() {
         given:
-        def allowedCallers = ["irc"] as Set
+        def allowedCallers = [new AuthorizedCaller("irc", null)] as Set
         service = new AuthorizingConnectorTableService(delegate, allowedCallers, catalogName)
         MetacatContextManager.setContext(buildContextWithCaller("irc"))
 
@@ -211,7 +212,7 @@ class AuthorizingConnectorTableServiceSpec extends Specification {
 
     def "listNames - authorized caller succeeds"() {
         given:
-        def allowedCallers = ["irc"] as Set
+        def allowedCallers = [new AuthorizedCaller("irc", null)] as Set
         service = new AuthorizingConnectorTableService(delegate, allowedCallers, catalogName)
         MetacatContextManager.setContext(buildContextWithCaller("irc"))
 
@@ -224,7 +225,7 @@ class AuthorizingConnectorTableServiceSpec extends Specification {
 
     def "rename - authorized caller succeeds"() {
         given:
-        def allowedCallers = ["irc"] as Set
+        def allowedCallers = [new AuthorizedCaller("irc", null)] as Set
         service = new AuthorizingConnectorTableService(delegate, allowedCallers, catalogName)
         MetacatContextManager.setContext(buildContextWithCaller("irc"))
 
@@ -237,7 +238,7 @@ class AuthorizingConnectorTableServiceSpec extends Specification {
 
     def "getTableNames with filter - authorized caller succeeds"() {
         given:
-        def allowedCallers = ["irc"] as Set
+        def allowedCallers = [new AuthorizedCaller("irc", null)] as Set
         service = new AuthorizingConnectorTableService(delegate, allowedCallers, catalogName)
         MetacatContextManager.setContext(buildContextWithCaller("irc"))
 
@@ -250,7 +251,7 @@ class AuthorizingConnectorTableServiceSpec extends Specification {
 
     def "getTableNames with URIs - authorized caller succeeds"() {
         given:
-        def allowedCallers = ["irc"] as Set
+        def allowedCallers = [new AuthorizedCaller("irc", null)] as Set
         service = new AuthorizingConnectorTableService(delegate, allowedCallers, catalogName)
         MetacatContextManager.setContext(buildContextWithCaller("irc"))
 
@@ -263,7 +264,7 @@ class AuthorizingConnectorTableServiceSpec extends Specification {
 
     def "exception message contains caller name when unauthorized"() {
         given:
-        def allowedCallers = ["irc"] as Set
+        def allowedCallers = [new AuthorizedCaller("irc", null)] as Set
         service = new AuthorizingConnectorTableService(delegate, allowedCallers, catalogName)
         MetacatContextManager.setContext(buildContextWithCaller("bad-actor"))
 
@@ -278,7 +279,7 @@ class AuthorizingConnectorTableServiceSpec extends Specification {
 
     def "exception message indicates missing caller when no SsoDirectCallerAppName"() {
         given:
-        def allowedCallers = ["irc"] as Set
+        def allowedCallers = [new AuthorizedCaller("irc", null)] as Set
         service = new AuthorizingConnectorTableService(delegate, allowedCallers, catalogName)
 
         def ctx = MetacatRequestContext.builder().build()
@@ -295,7 +296,7 @@ class AuthorizingConnectorTableServiceSpec extends Specification {
 
     def "caller matching is case sensitive - uppercase caller rejected"() {
         given:
-        def allowedCallers = ["irc"] as Set  // lowercase
+        def allowedCallers = [new AuthorizedCaller("irc", null)] as Set  // lowercase
         service = new AuthorizingConnectorTableService(delegate, allowedCallers, catalogName)
         MetacatContextManager.setContext(buildContextWithCaller("IRC"))  // uppercase
 
@@ -309,7 +310,7 @@ class AuthorizingConnectorTableServiceSpec extends Specification {
 
     def "caller matching is case sensitive - lowercase caller accepted"() {
         given:
-        def allowedCallers = ["irc"] as Set  // lowercase
+        def allowedCallers = [new AuthorizedCaller("irc", null)] as Set  // lowercase
         service = new AuthorizingConnectorTableService(delegate, allowedCallers, catalogName)
         MetacatContextManager.setContext(buildContextWithCaller("irc"))  // lowercase matches
 
@@ -322,7 +323,7 @@ class AuthorizingConnectorTableServiceSpec extends Specification {
 
     def "multiple allowed callers - second caller in list succeeds"() {
         given:
-        def allowedCallers = ["irc", "irc-server", "spark"] as Set
+        def allowedCallers = [new AuthorizedCaller("irc", null), new AuthorizedCaller("irc-server", null), new AuthorizedCaller("spark", null)] as Set
         service = new AuthorizingConnectorTableService(delegate, allowedCallers, catalogName)
         MetacatContextManager.setContext(buildContextWithCaller("spark"))
 

--- a/metacat-common-server/src/test/groovy/com/netflix/metacat/common/server/connectors/ConnectorFactoryDecoratorSpec.groovy
+++ b/metacat-common-server/src/test/groovy/com/netflix/metacat/common/server/connectors/ConnectorFactoryDecoratorSpec.groovy
@@ -316,6 +316,23 @@ class ConnectorFactoryDecoratorSpec extends Specification {
         // The whitespace should be trimmed, so "irc", "irc-server", and "spark" should all be valid
     }
 
+    def "authorized callers list accepts compound app:userName syntax"() {
+        given:
+        connectorContext.getConfiguration() >> [
+            "connector.rate-limiter-exempted": "true",
+            "connector.authorization-required": "true",
+            "connector.authorized-callers": "irc,hadoop:idm-worker"
+        ]
+        connectorContext.getCatalogName() >> "ads"
+        factory = new ConnectorFactoryDecorator(connectorPlugin, connectorContext)
+
+        when:
+        def tblSvc = factory.getTableService()
+
+        then: "authorization is applied; compound entry parses without error"
+        tblSvc instanceof AuthorizingConnectorTableService
+    }
+
     def "authorized callers with only whitespace entries are filtered"() {
         given:
         connectorContext.getConfiguration() >> [

--- a/metacat-common-server/src/test/groovy/com/netflix/metacat/common/server/util/ConnectorAuthorizationUtilSpec.groovy
+++ b/metacat-common-server/src/test/groovy/com/netflix/metacat/common/server/util/ConnectorAuthorizationUtilSpec.groovy
@@ -38,7 +38,7 @@ class ConnectorAuthorizationUtilSpec extends Specification {
 
     def "checkAuthorization - authorized SsoDirectCallerAppName succeeds"() {
         given:
-        def allowedCallers = ["bdpauthzservice", "irc-server"] as Set
+        def allowedCallers = [new AuthorizedCaller("bdpauthzservice", null), new AuthorizedCaller("irc-server", null)] as Set
         def ctx = MetacatRequestContext.builder().build()
         ctx.getAdditionalContext().put(MetacatRequestContext.SSO_DIRECT_CALLER_APP_NAME, "bdpauthzservice")
         MetacatContextManager.setContext(ctx)
@@ -52,7 +52,7 @@ class ConnectorAuthorizationUtilSpec extends Specification {
 
     def "checkAuthorization - unauthorized SsoDirectCallerAppName throws exception"() {
         given:
-        def allowedCallers = ["bdpauthzservice", "irc-server"] as Set
+        def allowedCallers = [new AuthorizedCaller("bdpauthzservice", null), new AuthorizedCaller("irc-server", null)] as Set
         def ctx = MetacatRequestContext.builder().build()
         ctx.getAdditionalContext().put(MetacatRequestContext.SSO_DIRECT_CALLER_APP_NAME, "unauthorized-app")
         MetacatContextManager.setContext(ctx)
@@ -68,7 +68,7 @@ class ConnectorAuthorizationUtilSpec extends Specification {
 
     def "checkAuthorization - missing SsoDirectCallerAppName throws exception"() {
         given:
-        def allowedCallers = ["bdpauthzservice"] as Set
+        def allowedCallers = [new AuthorizedCaller("bdpauthzservice", null)] as Set
         def ctx = MetacatRequestContext.builder().build()
         // No SsoDirectCallerAppName in additionalContext
         MetacatContextManager.setContext(ctx)
@@ -100,7 +100,7 @@ class ConnectorAuthorizationUtilSpec extends Specification {
 
     def "checkAuthorization - case sensitive matching"() {
         given:
-        def allowedCallers = ["bdpauthzservice"] as Set  // lowercase
+        def allowedCallers = [new AuthorizedCaller("bdpauthzservice", null)] as Set  // lowercase
         def ctx = MetacatRequestContext.builder().build()
         ctx.getAdditionalContext().put(MetacatRequestContext.SSO_DIRECT_CALLER_APP_NAME, "BDPAUTHZSERVICE")  // uppercase
         MetacatContextManager.setContext(ctx)
@@ -114,7 +114,7 @@ class ConnectorAuthorizationUtilSpec extends Specification {
 
     def "checkAuthorization - exact match required"() {
         given:
-        def allowedCallers = ["bdpauthzservice"] as Set
+        def allowedCallers = [new AuthorizedCaller("bdpauthzservice", null)] as Set
         def ctx = MetacatRequestContext.builder().build()
         ctx.getAdditionalContext().put(MetacatRequestContext.SSO_DIRECT_CALLER_APP_NAME, "bdpauthz")  // partial match
         MetacatContextManager.setContext(ctx)
@@ -128,7 +128,7 @@ class ConnectorAuthorizationUtilSpec extends Specification {
 
     def "checkAuthorization - multiple allowed callers - any match succeeds"() {
         given:
-        def allowedCallers = ["app1", "app2", "app3"] as Set
+        def allowedCallers = [new AuthorizedCaller("app1", null), new AuthorizedCaller("app2", null), new AuthorizedCaller("app3", null)] as Set
         def ctx = MetacatRequestContext.builder().build()
         ctx.getAdditionalContext().put(MetacatRequestContext.SSO_DIRECT_CALLER_APP_NAME, caller)
         MetacatContextManager.setContext(ctx)
@@ -141,5 +141,83 @@ class ConnectorAuthorizationUtilSpec extends Specification {
 
         where:
         caller << ["app1", "app2", "app3"]
+    }
+
+    def "checkAuthorization - compound rule allows when both app and userName match"() {
+        given:
+        def allowedCallers = [new AuthorizedCaller("hadoop", "idm-worker")] as Set
+        def ctx = MetacatRequestContext.builder().build()
+        ctx.getAdditionalContext().put(MetacatRequestContext.SSO_DIRECT_CALLER_APP_NAME, "hadoop")
+        ctx.setUserName("idm-worker")
+        MetacatContextManager.setContext(ctx)
+
+        when:
+        ConnectorAuthorizationUtil.checkAuthorization(catalogName, allowedCallers, operation, resource)
+
+        then:
+        noExceptionThrown()
+    }
+
+    def "checkAuthorization - compound rule denies when userName does not match"() {
+        given:
+        def allowedCallers = [new AuthorizedCaller("hadoop", "idm-worker")] as Set
+        def ctx = MetacatRequestContext.builder().build()
+        ctx.getAdditionalContext().put(MetacatRequestContext.SSO_DIRECT_CALLER_APP_NAME, "hadoop")
+        ctx.setUserName("alice")
+        MetacatContextManager.setContext(ctx)
+
+        when:
+        ConnectorAuthorizationUtil.checkAuthorization(catalogName, allowedCallers, operation, resource)
+
+        then:
+        thrown(CatalogUnauthorizedException)
+    }
+
+    def "checkAuthorization - compound rule denies when userName is null"() {
+        given:
+        def allowedCallers = [new AuthorizedCaller("hadoop", "idm-worker")] as Set
+        def ctx = MetacatRequestContext.builder().build()
+        ctx.getAdditionalContext().put(MetacatRequestContext.SSO_DIRECT_CALLER_APP_NAME, "hadoop")
+        // userName not set - defaults to null
+        MetacatContextManager.setContext(ctx)
+
+        when:
+        ConnectorAuthorizationUtil.checkAuthorization(catalogName, allowedCallers, operation, resource)
+
+        then:
+        thrown(CatalogUnauthorizedException)
+    }
+
+    def "checkAuthorization - mixed list - plain rule still matches any userName"() {
+        given:
+        def allowedCallers = [
+            new AuthorizedCaller("irc", null),
+            new AuthorizedCaller("hadoop", "idm-worker")
+        ] as Set
+        def ctx = MetacatRequestContext.builder().build()
+        ctx.getAdditionalContext().put(MetacatRequestContext.SSO_DIRECT_CALLER_APP_NAME, "irc")
+        ctx.setUserName("anyone")
+        MetacatContextManager.setContext(ctx)
+
+        when:
+        ConnectorAuthorizationUtil.checkAuthorization(catalogName, allowedCallers, operation, resource)
+
+        then:
+        noExceptionThrown()
+    }
+
+    def "checkAuthorization - compound rule does not match a different app"() {
+        given:
+        def allowedCallers = [new AuthorizedCaller("hadoop", "idm-worker")] as Set
+        def ctx = MetacatRequestContext.builder().build()
+        ctx.getAdditionalContext().put(MetacatRequestContext.SSO_DIRECT_CALLER_APP_NAME, "other")
+        ctx.setUserName("idm-worker")
+        MetacatContextManager.setContext(ctx)
+
+        when:
+        ConnectorAuthorizationUtil.checkAuthorization(catalogName, allowedCallers, operation, resource)
+
+        then:
+        thrown(CatalogUnauthorizedException)
     }
 }


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                        
  Extends connector authorization (`connector.authorized-callers`) to support compound rules of the form `app:userName`, in addition to the existing plain `app` entries.                                                                                               
                                      
  - **Plain entry** (e.g. `app1`) — matches on `SsoDirectCallerAppName` only. Unchanged behavior.                                                                                                                                                                        
  - **Compound entry** (e.g. `app2:user2`) — requires **both** `SsoDirectCallerAppName` AND the request `userName` to match exactly.                                                                                       
                                                                                                                                                                                                                                                                        
  ## Motivation                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                        
  After #690, connector authorization checks `SsoDirectCallerAppName` against a flat allow list. This is too coarse for callers like:                                                                                                                                   
                                                                                                                                                                                                                                  
  MetacatRequestContext{userName='user2', ..., additionalContext='{SsoDirectCallerAppName=app2, ...}'}                                                                                                                                                           
                                                                                                                                                                                                                                  
  Allowing all of `app2` would over-grant. We want a way to grant access only when both the direct caller app and the userName line up — e.g. `app2` + `user2` only — while leaving existing app-only entries working for other callers.                       
                                                                                                                                                                                                                                                                        
  ## Changes                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                        
  - **New** `AuthorizedCaller` value class (`appName` required, `userName` nullable) with a `matches(callerApp, callerUserName)` method.                                                                                                                                
  - `ConnectorFactoryDecorator` now parses each comma token, splitting on the first `:` to build compound rules. Empty tokens are skipped; matching remains case-sensitive.                                                       
  - `ConnectorAuthorizationUtil.checkAuthorization` reads `userName` from the request context and uses `anyMatch` over the allow-list rules. Deny logs include the userName for easier debugging.                                                                       
  - The four `Authorizing*Service` decorators (`Catalog`, `Database`, `Table`, `Partition`) now hold `Set<AuthorizedCaller>` instead of `Set<String>`.                                                                                                                  
                                                                                                                                                                                                                                                                        
  ## Config example                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                        
  connector.authorization-required=true                                                                                                                                                                                                                                 
  connector.authorized-callers=app1,app2,app3:user1                                                                                                                              
                                                                                                                                                                                                                                                                        
  Behavior with the above:                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                        
  | `SsoDirectCallerAppName` | `userName`   | Result   |                                                                                                                                                                                                                
  | ------------------------ | ------------ | -------- |                                                                                                                                                                                                                
  | `app1`                    | any          | allowed  |                                                                                                                                                                                                                
  | `app3`                 | `user1` | allowed  |                                                                                                                                                                          
  | `app3`                 | `user2`      | denied   |                                                                                                                                                                                                                
  | `app3`                 | `null`       | denied   |                                                                                                                                                                          
  | `other`                  | `user2` | denied   |                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                        
  ## Backwards compatibility                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                        
  Configs with no `:` in any entry parse to rules with `userName=null` and behave identically to the previous implementation. No deployment-time action needed for existing connectors.                                                                                 
                                                                                                                                                                                                                                  
  ## Test plan                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                  
  - [x] `./gradlew :metacat-common-server:test` — all targeted specs pass                                                                                                                                                                                               
  - [x] New cases in `ConnectorAuthorizationUtilSpec`: compound match, userName mismatch, null userName, mixed plain+compound list, app mismatch
  - [x] New parsing test in `ConnectorFactoryDecoratorSpec` for `app:userName` syntax                                                                                                                                                                                   
  - [x] Existing `Authorizing*ServiceSpec` tests migrated to `AuthorizedCaller` and continue to pass