### PR TITLE
increasing thrift connection wait time

### DIFF
--- a/metacat-thrift/src/main/java/com/netflix/metacat/thrift/AbstractThriftServer.java
+++ b/metacat-thrift/src/main/java/com/netflix/metacat/thrift/AbstractThriftServer.java
@@ -49,7 +49,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 @Slf4j
 public abstract class AbstractThriftServer {
     private static final int MAX_SOCKET_BIND_ATTEMPTS = 5;
-    private static final long MAX_SOCKET_BIND_WAIT_SECONDS = 30;
+    private static final long MAX_SOCKET_BIND_WAIT_SECONDS = 120;
     private static final Retryer<TServerTransport> RETRY_THRIFT_SOCKET = RetryerBuilder.<TServerTransport>newBuilder()
         .retryIfExceptionOfType(TTransportException.class)
         .withWaitStrategy(WaitStrategies.exponentialWait(1, MAX_SOCKET_BIND_WAIT_SECONDS, TimeUnit.SECONDS))


### PR DESCRIPTION
Increasing the thrift server connection wait time to decrease connection failure on startup