### PR TITLE
Skip metadata for sv load

### DIFF
--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/util/MetacatUtils.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/util/MetacatUtils.java
@@ -41,6 +41,7 @@ public class MetacatUtils {
      */
     public static final String COMMON_VIEW = "common_view";
     public static final String STORAGE_TABLE = "storage_table";
+    public static final String SECURE_VIEW = "secure_view";
 
     /**
      * Default Ctor.
@@ -173,5 +174,15 @@ public class MetacatUtils {
             return Optional.ofNullable(tableMetadata.get(STORAGE_TABLE));
         }
         return Optional.empty();
+    }
+
+    /**
+     * check if the table is a secure view.
+     *
+     * @param tableMetadata table metadata map
+     * @return true for secure view
+     */
+    public static boolean isSecureView(final Map<String, String> tableMetadata) {
+        return tableMetadata != null && Boolean.parseBoolean(tableMetadata.get(SECURE_VIEW));
     }
 }

--- a/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/util/HiveTableUtil.java
+++ b/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/util/HiveTableUtil.java
@@ -169,6 +169,16 @@ public final class HiveTableUtil {
                 && MetacatUtils.isCommonView(tableInfo.getMetadata());
     }
 
+    /** check if the table is a secure view.
+     *
+     * @param tableInfo table info
+     * @return true for common view
+     */
+    public static boolean isSecureView(final TableInfo tableInfo) {
+        return tableInfo != null && tableInfo.getMetadata() != null
+            && MetacatUtils.isSecureView(tableInfo.getMetadata());
+    }
+
     /**
      * get common view metadata location.
      *

--- a/metacat-connector-hive/src/test/groovy/com/netflix/metacat/connector/hive/HiveConnectorUtilSpec.groovy
+++ b/metacat-connector-hive/src/test/groovy/com/netflix/metacat/connector/hive/HiveConnectorUtilSpec.groovy
@@ -65,4 +65,24 @@ class HiveConnectorUtilSpec extends Specification{
         [:]    | false
         null | false
       }
+
+    def "Test for check secure view" () {
+        given:
+        def tableInfo = TableInfo.builder().metadata(metadata).build()
+        def isView = HiveTableUtil.isSecureView(tableInfo)
+        def isView2 = MetacatUtils.isSecureView(tableInfo.metadata)
+        expect:
+        isView == output
+        isView2 == output
+        where:
+        metadata     | output
+        ['secure_view' : "true"]    | true
+        ['secure_view' : "false"]    | false
+        ['secure_view_1' : "false"]    | false
+        ['secure_view' : null]    | false
+        ['secure_view' : "True"]    | true
+        ['secure_view' : ""]    | false
+        [:]    | false
+        null | false
+      }
 }

--- a/metacat-connector-polaris/src/functionalTest/java/com/netflix/metacat/connector/polaris/PolarisConnectorTableServiceFunctionalTest.java
+++ b/metacat-connector-polaris/src/functionalTest/java/com/netflix/metacat/connector/polaris/PolarisConnectorTableServiceFunctionalTest.java
@@ -433,6 +433,36 @@ public class PolarisConnectorTableServiceFunctionalTest {
     }
 
     /**
+     * Validate that secure view create and update are blocked in Polaris.
+     */
+    @Test
+    public void testSecureViewCreateAndUpdateBlocked() {
+        final QualifiedName qualifiedName = QualifiedName.ofTable(CATALOG_NAME_TEST, DB_NAME, "secure_view1");
+        // Not valid secure view metadata, but doesn't matter for this test
+        final String location = "src/test/resources/metadata/00000-9b5d4c36-130c-4288-9599-7d850c203d11.metadata.json";
+
+        final TableInfo createInfo = TableInfo.builder()
+            .name(qualifiedName)
+            .metadata(ImmutableMap.of("metadata_location", location, "secure_view", "true"))
+            .build();
+        final InvalidMetaException createEx = Assertions.assertThrows(InvalidMetaException.class,
+            () -> polarisTableService.create(requestContext, createInfo));
+        Assert.assertTrue(createEx.getMessage(),
+            createEx.getMessage().contains("Secure view creation is not permitted in Metacat."));
+        // secure view should not have been persisted
+        Assert.assertFalse(polarisTableService.exists(requestContext, qualifiedName));
+
+        final TableInfo updateInfo = TableInfo.builder()
+            .name(qualifiedName)
+            .metadata(ImmutableMap.of("metadata_location", location, "secure_view", "true"))
+            .build();
+        final InvalidMetaException updateEx = Assertions.assertThrows(InvalidMetaException.class,
+            () -> polarisTableService.update(requestContext, updateInfo));
+        Assert.assertTrue(updateEx.getMessage(),
+            updateEx.getMessage().contains("Secure view update is not permitted in Metacat"));
+    }
+
+    /**
      * Test get table names.
      */
     @Test

--- a/metacat-connector-polaris/src/functionalTest/java/com/netflix/metacat/connector/polaris/PolarisConnectorTableServiceFunctionalTest.java
+++ b/metacat-connector-polaris/src/functionalTest/java/com/netflix/metacat/connector/polaris/PolarisConnectorTableServiceFunctionalTest.java
@@ -463,6 +463,26 @@ public class PolarisConnectorTableServiceFunctionalTest {
     }
 
     /**
+     * Validate that loading a secure view returns only metadata with no field information.
+     */
+    @Test
+    public void testSecureViewLoadRestricted() {
+        final QualifiedName qualifiedName = QualifiedName.ofTable(CATALOG_NAME_TEST, DB_NAME, "secure_view2");
+        final String location = "src/test/resources/metadata/00001-abf48887-aa4f-4bcc-9219-1e1721314ee1.metadata.json";
+        // Plant the row directly via the store (bypassing the service-layer block) to simulate an existing secure view.
+        polarisStoreService.createTable(CATALOG_NAME_TEST, DB_NAME, "secure_view2",
+            location, ImmutableMap.of("secure_view", "true"), "metacat_user");
+
+        final TableInfo result = polarisTableService.get(requestContext, qualifiedName);
+        Assert.assertEquals("true", result.getMetadata().get("secure_view"));
+        Assert.assertEquals(location, result.getMetadata().get("metadata_location"));
+        Assert.assertEquals(result.getMetadata().toString(),
+            ImmutableSet.of("secure_view", "metadata_location"), result.getMetadata().keySet());
+
+        polarisTableService.delete(requestContext, qualifiedName);
+    }
+
+    /**
      * Test get table names.
      */
     @Test

--- a/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/PolarisConnectorTableService.java
+++ b/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/PolarisConnectorTableService.java
@@ -101,6 +101,10 @@ public class PolarisConnectorTableService implements ConnectorTableService {
         }
         try {
             final PolarisTableEntity entity = polarisTableMapper.toEntity(tableInfo);
+            if (HiveTableUtil.isSecureView(tableInfo)) {
+                throw new InvalidMetaException(tableInfo.getName(),
+                    "Secure view creation is not permitted in Metacat.", null);
+            }
             if (HiveTableUtil.isCommonView(tableInfo)) {
                 polarisStoreService.createTable(entity.getCatalogName(), entity.getDbName(), entity.getTblName(),
                     entity.getMetadataLocation(), entity.getParams(), createdBy);
@@ -236,6 +240,11 @@ public class PolarisConnectorTableService implements ConnectorTableService {
         final Config conf = connectorContext.getConfig();
         final String lastModifiedBy = PolarisUtils.getUserOrDefault(requestContext);
         final boolean isView = HiveTableUtil.isCommonView(tableInfo);
+        final boolean isSecureView = HiveTableUtil.isSecureView(tableInfo);
+        if (isSecureView) {
+            throw new InvalidMetaException(tableInfo.getName(),
+                "Secure view update is not permitted in Metacat", null);
+        }
         if (isView) {
             commonViewHandler.update(tableInfo);
         } else {

--- a/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/PolarisConnectorTableService.java
+++ b/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/PolarisConnectorTableService.java
@@ -163,7 +163,7 @@ public class PolarisConnectorTableService implements ConnectorTableService {
                 .orElseThrow(() -> new TableNotFoundException(name));
             final boolean isView = MetacatUtils.isCommonView(polarisTableEntity.getParams());
             final boolean isSecureView = MetacatUtils.isSecureView(polarisTableEntity.getParams());
-            final TableInfo info = polarisTableMapper.toInfo(polarisTableEntity, isView);
+            final TableInfo info = polarisTableMapper.toInfo(polarisTableEntity, isView || isSecureView);
             final String tableLoc = HiveTableUtil.getIcebergTableMetadataLocation(info);
 
             // Return the iceberg table with just the metadata location included if requested.

--- a/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/PolarisConnectorTableService.java
+++ b/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/PolarisConnectorTableService.java
@@ -95,16 +95,15 @@ public class PolarisConnectorTableService implements ConnectorTableService {
     public void create(final ConnectorRequestContext requestContext, final TableInfo tableInfo) {
         final QualifiedName name = tableInfo.getName();
         final String createdBy = PolarisUtils.getUserOrDefault(requestContext);
+        if (HiveTableUtil.isSecureView(tableInfo)) {
+            throw new InvalidMetaException("Secure view creation is not permitted in Metacat.", null);
+        }
         // check exists then create in non-transactional optimistic manner
         if (exists(requestContext, name)) {
             throw new TableAlreadyExistsException(name);
         }
         try {
             final PolarisTableEntity entity = polarisTableMapper.toEntity(tableInfo);
-            if (HiveTableUtil.isSecureView(tableInfo)) {
-                throw new InvalidMetaException(tableInfo.getName(),
-                    "Secure view creation is not permitted in Metacat.", null);
-            }
             if (HiveTableUtil.isCommonView(tableInfo)) {
                 polarisStoreService.createTable(entity.getCatalogName(), entity.getDbName(), entity.getTblName(),
                     entity.getMetadataLocation(), entity.getParams(), createdBy);
@@ -242,8 +241,7 @@ public class PolarisConnectorTableService implements ConnectorTableService {
         final boolean isView = HiveTableUtil.isCommonView(tableInfo);
         final boolean isSecureView = HiveTableUtil.isSecureView(tableInfo);
         if (isSecureView) {
-            throw new InvalidMetaException(tableInfo.getName(),
-                "Secure view update is not permitted in Metacat", null);
+            throw new InvalidMetaException("Secure view update is not permitted in Metacat", null);
         }
         if (isView) {
             commonViewHandler.update(tableInfo);

--- a/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/PolarisConnectorTableService.java
+++ b/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/PolarisConnectorTableService.java
@@ -159,12 +159,13 @@ public class PolarisConnectorTableService implements ConnectorTableService {
                 .getTable(name.getCatalogName(), name.getDatabaseName(), name.getTableName())
                 .orElseThrow(() -> new TableNotFoundException(name));
             final boolean isView = MetacatUtils.isCommonView(polarisTableEntity.getParams());
+            final boolean isSecureView = MetacatUtils.isSecureView(polarisTableEntity.getParams());
             final TableInfo info = polarisTableMapper.toInfo(polarisTableEntity, isView);
             final String tableLoc = HiveTableUtil.getIcebergTableMetadataLocation(info);
 
             // Return the iceberg table with just the metadata location included if requested.
-            if (connectorContext.getConfig().shouldFetchOnlyMetadataLocationEnabled()
-                    && requestContext.isIncludeMetadataLocationOnly()) {
+            if (isSecureView || (connectorContext.getConfig().shouldFetchOnlyMetadataLocationEnabled()
+                    && requestContext.isIncludeMetadataLocationOnly())) {
                 return TableInfo.builder()
                         .auditInfo(info.getAudit())
                         .metadata(Maps.newHashMap(info.getMetadata()))


### PR DESCRIPTION
Loading a secure view via Metacat will fail currently because Metacat cannot parse the OSS view format. This forces Polaris to treat secure view loads as though includeMetadataLocationOnly is enabled. We also disable secure view creation. Will quickly verify during deployment. 