### PR TITLE
Remove secure view create/update blocking in Polaris connector

### DIFF
--- a/metacat-connector-polaris/src/functionalTest/java/com/netflix/metacat/connector/polaris/PolarisConnectorTableServiceFunctionalTest.java
+++ b/metacat-connector-polaris/src/functionalTest/java/com/netflix/metacat/connector/polaris/PolarisConnectorTableServiceFunctionalTest.java
@@ -433,36 +433,6 @@ public class PolarisConnectorTableServiceFunctionalTest {
     }
 
     /**
-     * Validate that secure view create and update are blocked in Polaris.
-     */
-    @Test
-    public void testSecureViewCreateAndUpdateBlocked() {
-        final QualifiedName qualifiedName = QualifiedName.ofTable(CATALOG_NAME_TEST, DB_NAME, "secure_view1");
-        // Not valid secure view metadata, but doesn't matter for this test
-        final String location = "src/test/resources/metadata/00000-9b5d4c36-130c-4288-9599-7d850c203d11.metadata.json";
-
-        final TableInfo createInfo = TableInfo.builder()
-            .name(qualifiedName)
-            .metadata(ImmutableMap.of("metadata_location", location, "secure_view", "true"))
-            .build();
-        final InvalidMetaException createEx = Assertions.assertThrows(InvalidMetaException.class,
-            () -> polarisTableService.create(requestContext, createInfo));
-        Assert.assertTrue(createEx.getMessage(),
-            createEx.getMessage().contains("Secure view creation is not permitted in Metacat."));
-        // secure view should not have been persisted
-        Assert.assertFalse(polarisTableService.exists(requestContext, qualifiedName));
-
-        final TableInfo updateInfo = TableInfo.builder()
-            .name(qualifiedName)
-            .metadata(ImmutableMap.of("metadata_location", location, "secure_view", "true"))
-            .build();
-        final InvalidMetaException updateEx = Assertions.assertThrows(InvalidMetaException.class,
-            () -> polarisTableService.update(requestContext, updateInfo));
-        Assert.assertTrue(updateEx.getMessage(),
-            updateEx.getMessage().contains("Secure view update is not permitted in Metacat"));
-    }
-
-    /**
      * Validate that loading a secure view returns only metadata with no field information.
      */
     @Test

--- a/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/PolarisConnectorTableService.java
+++ b/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/PolarisConnectorTableService.java
@@ -95,9 +95,6 @@ public class PolarisConnectorTableService implements ConnectorTableService {
     public void create(final ConnectorRequestContext requestContext, final TableInfo tableInfo) {
         final QualifiedName name = tableInfo.getName();
         final String createdBy = PolarisUtils.getUserOrDefault(requestContext);
-        if (HiveTableUtil.isSecureView(tableInfo)) {
-            throw new InvalidMetaException("Secure view creation is not permitted in Metacat.", null);
-        }
         // check exists then create in non-transactional optimistic manner
         if (exists(requestContext, name)) {
             throw new TableAlreadyExistsException(name);
@@ -239,10 +236,6 @@ public class PolarisConnectorTableService implements ConnectorTableService {
         final Config conf = connectorContext.getConfig();
         final String lastModifiedBy = PolarisUtils.getUserOrDefault(requestContext);
         final boolean isView = HiveTableUtil.isCommonView(tableInfo);
-        final boolean isSecureView = HiveTableUtil.isSecureView(tableInfo);
-        if (isSecureView) {
-            throw new InvalidMetaException("Secure view update is not permitted in Metacat", null);
-        }
         if (isView) {
             commonViewHandler.update(tableInfo);
         } else {


### PR DESCRIPTION
Secure views previously threw InvalidMetaException on create and update. Allow both operations to flow through the normal create/update paths, and drop the obsolete blocking test verification.

Should fix an sv creation issue--currently IRC goes through metacat. 