### PR TITLE
exposing connector factory to allow access to required beans

### DIFF
--- a/metacat-common-server/src/main/java/com/netflix/metacat/common/server/connectors/SpringConnectorFactory.java
+++ b/metacat-common-server/src/main/java/com/netflix/metacat/common/server/connectors/SpringConnectorFactory.java
@@ -22,6 +22,8 @@ import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import org.springframework.core.env.MapPropertySource;
 import org.springframework.core.env.StandardEnvironment;
 
+import javax.annotation.Nullable;
+
 /**
  * Spring based Connector Factory.
  *
@@ -73,6 +75,17 @@ public abstract class SpringConnectorFactory implements ConnectorFactory {
      */
     public void refresh() {
         this.ctx.refresh();
+    }
+
+    /**
+     * Returns the bean of the given type from this connector's context if one is registered.
+     *
+     * @param type bean type
+     * @return the bean, or null if no bean of that type is registered for this connector
+     */
+    @Nullable
+    public <T> T getBeanIfAvailable(final Class<T> type) {
+        return this.ctx.getBeanProvider(type).getIfAvailable();
     }
 
     /**

--- a/metacat-main/src/main/java/com/netflix/metacat/main/manager/ConnectorManager.java
+++ b/metacat-main/src/main/java/com/netflix/metacat/main/manager/ConnectorManager.java
@@ -307,7 +307,7 @@ public class ConnectorManager {
      * @param name qualified name
      * @return Returns the connector factory for the given <code>name</code>
      */
-    private ConnectorFactory getConnectorFactory(final QualifiedName name) {
+    public ConnectorFactory getConnectorFactory(final QualifiedName name) {
         Preconditions.checkNotNull(name, "Name is null");
         return getCatalogHolder(name).getConnectorFactory();
     }


### PR DESCRIPTION
## Summary
- Setting `getConnectorFactory` to public so we can access beans required for changes
- Creating `getBeanIfAvailable` to avoid duplication logic and cleanly get beans