### PR TITLE
remove block for secure view load

### DIFF
--- a/metacat-connector-polaris/src/functionalTest/java/com/netflix/metacat/connector/polaris/PolarisConnectorTableServiceFunctionalTest.java
+++ b/metacat-connector-polaris/src/functionalTest/java/com/netflix/metacat/connector/polaris/PolarisConnectorTableServiceFunctionalTest.java
@@ -433,26 +433,6 @@ public class PolarisConnectorTableServiceFunctionalTest {
     }
 
     /**
-     * Validate that loading a secure view returns only metadata with no field information.
-     */
-    @Test
-    public void testSecureViewLoadRestricted() {
-        final QualifiedName qualifiedName = QualifiedName.ofTable(CATALOG_NAME_TEST, DB_NAME, "secure_view2");
-        final String location = "src/test/resources/metadata/00001-abf48887-aa4f-4bcc-9219-1e1721314ee1.metadata.json";
-        // Plant the row directly via the store (bypassing the service-layer block) to simulate an existing secure view.
-        polarisStoreService.createTable(CATALOG_NAME_TEST, DB_NAME, "secure_view2",
-            location, ImmutableMap.of("secure_view", "true"), "metacat_user");
-
-        final TableInfo result = polarisTableService.get(requestContext, qualifiedName);
-        Assert.assertEquals("true", result.getMetadata().get("secure_view"));
-        Assert.assertEquals(location, result.getMetadata().get("metadata_location"));
-        Assert.assertEquals(result.getMetadata().toString(),
-            ImmutableSet.of("secure_view", "metadata_location"), result.getMetadata().keySet());
-
-        polarisTableService.delete(requestContext, qualifiedName);
-    }
-
-    /**
      * Test get table names.
      */
     @Test

--- a/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/PolarisConnectorTableService.java
+++ b/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/PolarisConnectorTableService.java
@@ -164,15 +164,15 @@ public class PolarisConnectorTableService implements ConnectorTableService {
             final String tableLoc = HiveTableUtil.getIcebergTableMetadataLocation(info);
 
             // Return the iceberg table with just the metadata location included if requested.
-            if (isSecureView || (connectorContext.getConfig().shouldFetchOnlyMetadataLocationEnabled()
-                    && requestContext.isIncludeMetadataLocationOnly())) {
+            if (connectorContext.getConfig().shouldFetchOnlyMetadataLocationEnabled()
+                    && requestContext.isIncludeMetadataLocationOnly()) {
                 return TableInfo.builder()
                         .auditInfo(info.getAudit())
                         .metadata(Maps.newHashMap(info.getMetadata()))
                         .fields(Collections.emptyList())
                         .build();
             }
-            if (isView) {
+            if (isView || isSecureView) {
                 return getCommonView(name, tableLoc, info, connectorContext.getConfig().isIcebergCacheEnabled());
             } else {
                 return getIcebergTable(name, tableLoc, info,


### PR DESCRIPTION
Currently, there is a block in the PolarisTableConnector get path to prevent plainly loading secure views. I'm going to be adding internal logic to do a partial load and return the Schema in a follow-up [PR](https://github.netflix.net/corp/dseplat-metacat-netflix/pull/2016), so I'm unblocking the load path here. 