### PR TITLE
fetch and set table version and branch names

### DIFF
--- a/metacat-common/src/main/java/com/netflix/metacat/common/dto/TableDto.java
+++ b/metacat-common/src/main/java/com/netflix/metacat/common/dto/TableDto.java
@@ -19,6 +19,7 @@ package com.netflix.metacat.common.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.netflix.metacat.common.QualifiedName;
@@ -33,11 +34,13 @@ import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * Table DTO.
@@ -52,8 +55,13 @@ import java.util.Optional;
 public class TableDto extends BaseDto implements HasDataMetadata, HasDefinitionMetadata {
     /** Metadata key holding the Iceberg current snapshot id ({@code -1} if none); absent for non-Iceberg tables. */
     public static final String CURRENT_SNAPSHOT_ID_METADATA_KEY = "current_snapshot_id";
+    /** Metadata key holding the JSON array of Iceberg branch names; absent for non-Iceberg tables. */
+    public static final String BRANCHES_METADATA_KEY = "branches";
+    /** Metadata key holding the Iceberg table format version; absent for non-Iceberg tables. */
+    public static final String TABLE_VERSION_METADATA_KEY = "table_version";
 
     private static final long serialVersionUID = 5922768252406041451L;
+    private static final TypeReference<Set<String>> BRANCHES_TYPE_REFERENCE = new TypeReference<Set<String>>() { };
 
     @Schema(description = "Contains information about table changes")
     private AuditDto audit;
@@ -127,6 +135,61 @@ public class TableDto extends BaseDto implements HasDataMetadata, HasDefinitionM
         }
         try {
             return Optional.of(Long.parseLong(rawSnapshotId.trim()));
+        } catch (final NumberFormatException e) {
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Encodes a set of Iceberg branch names into the string form stored under
+     * {@value #BRANCHES_METADATA_KEY} in the metadata map.
+     *
+     * @param branches the branch names to encode
+     * @return the JSON array encoding of the branch names
+     */
+    public static String encodeBranches(final Collection<String> branches) {
+        return METACAT_JSON_LOCATOR.toJsonString(branches);
+    }
+
+    /**
+     * Returns the set of Iceberg branch names, or empty for a non-Iceberg table or when the
+     * {@value #BRANCHES_METADATA_KEY} property is missing or unparseable.
+     *
+     * @return set of Iceberg branch names, or empty set if unknown
+     */
+    @JsonIgnore
+    public Set<String> getBranches() {
+        if (metadata == null) {
+            return Collections.emptySet();
+        }
+        final String rawBranches = metadata.get(BRANCHES_METADATA_KEY);
+        if (rawBranches == null || rawBranches.trim().isEmpty()) {
+            return Collections.emptySet();
+        }
+        try {
+            return METACAT_JSON_LOCATOR.getObjectMapper().readValue(rawBranches, BRANCHES_TYPE_REFERENCE);
+        } catch (final IOException e) {
+            return Collections.emptySet();
+        }
+    }
+
+    /**
+     * Returns the Iceberg table format version, or empty for a non-Iceberg table or when the
+     * {@value #TABLE_VERSION_METADATA_KEY} property is missing or unparseable.
+     *
+     * @return the Iceberg table format version, or empty if unknown
+     */
+    @JsonIgnore
+    public Optional<Integer> getTableVersion() {
+        if (metadata == null) {
+            return Optional.empty();
+        }
+        final String rawVersion = metadata.get(TABLE_VERSION_METADATA_KEY);
+        if (rawVersion == null || rawVersion.trim().isEmpty()) {
+            return Optional.empty();
+        }
+        try {
+            return Optional.of(Integer.parseInt(rawVersion.trim()));
         } catch (final NumberFormatException e) {
             return Optional.empty();
         }

--- a/metacat-common/src/test/groovy/com/netflix/metacat/common/dto/TableDtoSpec.groovy
+++ b/metacat-common/src/test/groovy/com/netflix/metacat/common/dto/TableDtoSpec.groovy
@@ -26,6 +26,8 @@ import spock.lang.Unroll
 class TableDtoSpec extends Specification {
 
     static final String KEY = TableDto.CURRENT_SNAPSHOT_ID_METADATA_KEY
+    static final String BRANCHES_KEY = TableDto.BRANCHES_METADATA_KEY
+    static final String VERSION_KEY = TableDto.TABLE_VERSION_METADATA_KEY
 
     @Unroll
     def "getCurrentSnapshotId: #scenario"() {
@@ -65,5 +67,34 @@ class TableDtoSpec extends Specification {
         value                   || expected
         '5186921321658503645'   || Optional.of(5186921321658503645L)
         '-1'                    || Optional.of(-1L)
+    }
+
+    @Unroll
+    def "getBranches: #scenario"() {
+        expect:
+        new TableDto(metadata: metadata).getBranches() == expected
+
+        where:
+        scenario                         | metadata                            || expected
+        "present multiple branches"      | [(BRANCHES_KEY): '["main","dev"]']  || ['main', 'dev'] as Set
+        "branch name containing a comma" | [(BRANCHES_KEY): '["main","a,b"]']  || ['main', 'a,b'] as Set
+        "key absent (non-iceberg)"       | ['metadata_location': 's3']         || [] as Set
+        "null metadata map"              | null                                || [] as Set
+        "blank value"                    | [(BRANCHES_KEY): '   ']             || [] as Set
+        "malformed json"                 | [(BRANCHES_KEY): 'not-json']        || [] as Set
+    }
+
+    @Unroll
+    def "getTableVersion: #scenario"() {
+        expect:
+        new TableDto(metadata: metadata).getTableVersion() == expected
+
+        where:
+        scenario                   | metadata                     || expected
+        "present version"          | [(VERSION_KEY): '2']         || Optional.of(2)
+        "key absent (non-iceberg)" | ['metadata_location': 's3']  || Optional.empty()
+        "null metadata map"        | null                         || Optional.empty()
+        "blank value"              | [(VERSION_KEY): '   ']       || Optional.empty()
+        "non-numeric value"        | [(VERSION_KEY): 'abc']       || Optional.empty()
     }
 }

--- a/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/converters/HiveConnectorInfoConverter.java
+++ b/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/converters/HiveConnectorInfoConverter.java
@@ -22,6 +22,7 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.netflix.metacat.common.QualifiedName;
+import com.netflix.metacat.common.dto.TableDto;
 import com.netflix.metacat.common.server.connectors.ConnectorInfoConverter;
 import com.netflix.metacat.common.server.connectors.model.AuditInfo;
 import com.netflix.metacat.common.server.connectors.model.DatabaseInfo;
@@ -200,11 +201,16 @@ public class HiveConnectorInfoConverter implements ConnectorInfoConverter<Databa
         // Populate branch/tag metadata for optimization purposes
         tableParameters.putAll(tableWrapper.populateBranchTagMetadata());
         tableParameters.putAll(tableWrapper.getExtraProperties());
-        // Surface the current snapshot id (-1 when the table has no snapshot). Written last so it cannot
-        // be shadowed by an injected property of the same name.
+        // Surface the current snapshot id (-1 when the table has no snapshot), the branch name list,
+        // and the table format version. Written last so they cannot be shadowed by an injected
+        // property of the same name.
         final Snapshot currentSnapshot = table.currentSnapshot();
         tableParameters.put(DirectSqlTable.PARAM_CURRENT_SNAPSHOT_ID,
             String.valueOf(currentSnapshot == null ? -1L : currentSnapshot.snapshotId()));
+        tableParameters.put(DirectSqlTable.PARAM_BRANCHES,
+            TableDto.encodeBranches(tableWrapper.extractBranches()));
+        tableParameters.put(DirectSqlTable.PARAM_TABLE_VERSION,
+            String.valueOf(tableWrapper.getTableVersion()));
         final StorageInfo.StorageInfoBuilder storageInfoBuilder = StorageInfo.builder();
         if (tableInfo.getSerde() != null) {
             // Adding the serde properties to support old engines.

--- a/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/iceberg/IcebergTableWrapper.java
+++ b/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/iceberg/IcebergTableWrapper.java
@@ -64,25 +64,6 @@ public class IcebergTableWrapper {
     }
 
     /**
-     * Get summary information about branches and tags for logging/debugging.
-     * @return formatted string with branch and tag counts and names
-     */
-    public String getBranchesAndTagsSummary() {
-        final Set<String> branches = extractBranches();
-        final Set<String> tags = extractTags();
-        final StringBuilder summary = new StringBuilder();
-        summary.append(String.format("branches=%d", branches.size()));
-        if (!branches.isEmpty()) {
-            summary.append(String.format(" %s", branches));
-        }
-        summary.append(String.format(", tags=%d", tags.size()));
-        if (!tags.isEmpty()) {
-            summary.append(String.format(" %s", tags));
-        }
-        return summary.toString();
-    }
-
-    /**
      * Extract branch names from the table references.
      * @return set of branch names
      * @throws RuntimeException if unable to read table references

--- a/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/iceberg/IcebergTableWrapper.java
+++ b/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/iceberg/IcebergTableWrapper.java
@@ -17,6 +17,7 @@
 package com.netflix.metacat.connector.hive.iceberg;
 
 import org.apache.iceberg.Table;
+import org.apache.iceberg.TableUtil;
 import lombok.Data;
 
 import java.util.Collections;
@@ -29,21 +30,10 @@ import java.util.Set;
  */
 @Data
 public class IcebergTableWrapper {
-    /** Key for indicating if the table has non-main branches. */
-    public static final String ICEBERG_HAS_NON_MAIN_BRANCHES_KEY = "iceberg.has.non.main.branches";
     /** Key for indicating if the table has tags. */
     public static final String ICEBERG_HAS_TAGS_KEY = "iceberg.has.tags";
     private final Table table;
     private final Map<String, String> extraProperties;
-
-    /**
-     * Check if the table has any non-main branches.
-     * @return true if the table has branches other than main
-     */
-    public boolean hasNonMainBranches() {
-        final Set<String> branches = extractBranches();
-        return branches.size() > 1;
-    }
 
     /**
      * Check if the table has any tags.
@@ -61,9 +51,16 @@ public class IcebergTableWrapper {
      */
     public Map<String, String> populateBranchTagMetadata() {
         final Map<String, String> branchTagMetadata = new HashMap<>();
-        branchTagMetadata.put(ICEBERG_HAS_NON_MAIN_BRANCHES_KEY, String.valueOf(hasNonMainBranches()));
         branchTagMetadata.put(ICEBERG_HAS_TAGS_KEY, String.valueOf(hasTags()));
         return branchTagMetadata;
+    }
+
+    /**
+     * Get the Iceberg table format version.
+     * @return the format version
+     */
+    public int getTableVersion() {
+        return TableUtil.formatVersion(table);
     }
 
     /**
@@ -90,7 +87,7 @@ public class IcebergTableWrapper {
      * @return set of branch names
      * @throws RuntimeException if unable to read table references
      */
-    private Set<String> extractBranches() {
+    public Set<String> extractBranches() {
         final var refs = table.refs();
         if (refs == null || refs.isEmpty()) {
             return Collections.emptySet();

--- a/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/sql/DirectSqlTable.java
+++ b/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/sql/DirectSqlTable.java
@@ -99,6 +99,10 @@ public class DirectSqlTable {
     public static final String PARAM_METADATA_CONTENT = "metadata_content";
     /** Read-only Iceberg current snapshot id, surfaced on read and never persisted. */
     public static final String PARAM_CURRENT_SNAPSHOT_ID = TableDto.CURRENT_SNAPSHOT_ID_METADATA_KEY;
+    /** Read-only JSON array of Iceberg branch names, surfaced on read and never persisted. */
+    public static final String PARAM_BRANCHES = TableDto.BRANCHES_METADATA_KEY;
+    /** Read-only Iceberg table format version, surfaced on read and never persisted. */
+    public static final String PARAM_TABLE_VERSION = TableDto.TABLE_VERSION_METADATA_KEY;
     /**
      * List of parameter that needs to be excluded when updating an iceberg table.
      */

--- a/metacat-connector-hive/src/test/groovy/com/netflix/metacat/connector/hive/converters/HiveConnectorInfoConvertorSpec.groovy
+++ b/metacat-connector-hive/src/test/groovy/com/netflix/metacat/connector/hive/converters/HiveConnectorInfoConvertorSpec.groovy
@@ -502,7 +502,7 @@ class HiveConnectorInfoConvertorSpec extends Specification{
 
     def "test fromIcebergTableToTableInfo"() {
         def icebergTable = Mock(org.apache.iceberg.Table)
-        def icebergTableWrapper = new IcebergTableWrapper(icebergTable, [:])
+        def icebergTableWrapper = Spy(new IcebergTableWrapper(icebergTable, [:]))
         def partSpec = Mock(PartitionSpec)
         def field = Mock(PartitionField)
         def schema =  Mock(Schema)
@@ -520,6 +520,7 @@ class HiveConnectorInfoConvertorSpec extends Specification{
             isBranch() >> true
             isTag() >> false
         }]
+        1 * icebergTableWrapper.getTableVersion() >> 2
         1 * partSpec.fields() >> [ field]
         1 * icebergTable.schema() >> schema
         1 * schema.columns() >> [nestedField, nestedField2]
@@ -551,7 +552,6 @@ class HiveConnectorInfoConvertorSpec extends Specification{
         then:
         1 * icebergTableWrapper.getTable() >> icebergTable
         1 * icebergTableWrapper.populateBranchTagMetadata() >> [
-            "iceberg.has.non.main.branches": "true",
             "iceberg.has.tags": "false"
         ] // Called by converter and returns metadata map
         1 * icebergTableWrapper.getExtraProperties() >> [:] // Called by converter for other properties
@@ -563,9 +563,8 @@ class HiveConnectorInfoConvertorSpec extends Specification{
             fields() >> []
             toString() >> "[]"
         }
-        
-        // Verify that non-main-branch/tag metadata is injected via extraProperties
-        tableInfo.getMetadata().get("iceberg.has.non.main.branches") == "true"
+
+        // Verify that tag metadata is injected via extraProperties
         tableInfo.getMetadata().get("iceberg.has.tags") == "false"
     }
 

--- a/metacat-connector-hive/src/test/groovy/com/netflix/metacat/connector/hive/converters/HiveConnectorInfoConvertorSpec.groovy
+++ b/metacat-connector-hive/src/test/groovy/com/netflix/metacat/connector/hive/converters/HiveConnectorInfoConvertorSpec.groovy
@@ -553,8 +553,8 @@ class HiveConnectorInfoConvertorSpec extends Specification{
         1 * icebergTableWrapper.getTable() >> icebergTable
         1 * icebergTableWrapper.populateBranchTagMetadata() >> [
             "iceberg.has.tags": "false"
-        ] // Called by converter and returns metadata map
-        1 * icebergTableWrapper.getExtraProperties() >> [:] // Called by converter for other properties
+        ]
+        1 * icebergTableWrapper.getExtraProperties() >> [:]
         1 * icebergTable.properties() >> [:]
         1 * icebergTable.schema() >> Mock(Schema) {
             columns() >> []
@@ -564,7 +564,6 @@ class HiveConnectorInfoConvertorSpec extends Specification{
             toString() >> "[]"
         }
 
-        // Verify that tag metadata is injected via extraProperties
         tableInfo.getMetadata().get("iceberg.has.tags") == "false"
     }
 

--- a/metacat-connector-hive/src/test/groovy/com/netflix/metacat/connector/hive/iceberg/IcebergMetadataValidationSpec.groovy
+++ b/metacat-connector-hive/src/test/groovy/com/netflix/metacat/connector/hive/iceberg/IcebergMetadataValidationSpec.groovy
@@ -45,7 +45,7 @@ class IcebergMetadataValidationSpec extends Specification {
         def refs = json.get("refs")
         refs.has("main")
         refs.has("feature-branch")
-        refs.has("experimental")
+        refs.has("experimental,beta")
         refs.has("v1.0.0")
         refs.has("v2.0.0")
         refs.has("release-2024-01")
@@ -53,7 +53,7 @@ class IcebergMetadataValidationSpec extends Specification {
         // Verify branches
         refs.get("main").get("type").asText() == "branch"
         refs.get("feature-branch").get("type").asText() == "branch"
-        refs.get("experimental").get("type").asText() == "branch"
+        refs.get("experimental,beta").get("type").asText() == "branch"
         
         // Verify tags
         refs.get("v1.0.0").get("type").asText() == "tag"
@@ -189,7 +189,7 @@ class IcebergMetadataValidationSpec extends Specification {
         oldClientJson.get("format-version").asInt() == 1
         
         // Verify expected counts for our integration tests
-        branchCount == 3  // main, feature-branch, experimental
+        branchCount == 3  // main, feature-branch, experimental,beta
         tagCount == 3     // v1.0.0, v2.0.0, release-2024-01
         mainOnlyBranchCount == 1  // only main
         mainOnlyTagCount == 0     // no tags

--- a/metacat-connector-hive/src/test/groovy/com/netflix/metacat/connector/hive/iceberg/IcebergMetadataValidationSpec.groovy
+++ b/metacat-connector-hive/src/test/groovy/com/netflix/metacat/connector/hive/iceberg/IcebergMetadataValidationSpec.groovy
@@ -197,13 +197,10 @@ class IcebergMetadataValidationSpec extends Specification {
         v1WithRefsTagCount == 1    // v3.0.0
         
         // This confirms our integration test expectations (via Iceberg runtime, not JSON):
-        // - branchesTagsFile should trigger hasNonMainBranches() == true (3 > 1)
-        // - branchesTagsFile should trigger hasTags() == true (3 > 0)  
-        // - mainOnlyFile should trigger hasNonMainBranches() == false (1 == 1)
+        // - branchesTagsFile should trigger hasTags() == true (3 > 0)
         // - mainOnlyFile should trigger hasTags() == false (0 == 0)
         // - oldClientFile (Iceberg < 0.14.1): JSON has no refs, but Iceberg runtime auto-creates main branch
-        //   so hasNonMainBranches() == false (1 branch - auto-created main only), hasTags() == false (0 tags)
-        // - v1WithRefsFile should trigger hasNonMainBranches() == true (2 > 1)
+        //   so hasTags() == false (0 tags)
         // - v1WithRefsFile should trigger hasTags() == true (1 > 0)
     }
 }

--- a/metacat-connector-hive/src/test/groovy/com/netflix/metacat/connector/hive/iceberg/IcebergMetadataValidationSpec.groovy
+++ b/metacat-connector-hive/src/test/groovy/com/netflix/metacat/connector/hive/iceberg/IcebergMetadataValidationSpec.groovy
@@ -50,12 +50,10 @@ class IcebergMetadataValidationSpec extends Specification {
         refs.has("v2.0.0")
         refs.has("release-2024-01")
         
-        // Verify branches
         refs.get("main").get("type").asText() == "branch"
         refs.get("feature-branch").get("type").asText() == "branch"
         refs.get("experimental,beta").get("type").asText() == "branch"
-        
-        // Verify tags
+
         refs.get("v1.0.0").get("type").asText() == "tag"
         refs.get("v2.0.0").get("type").asText() == "tag"
         refs.get("release-2024-01").get("type").asText() == "tag"
@@ -146,7 +144,6 @@ class IcebergMetadataValidationSpec extends Specification {
         def oldClientJson = objectMapper.readTree(oldClientFile)
         def v1WithRefsJson = objectMapper.readTree(v1WithRefsFile)
         
-        // Count branches and tags in the branches/tags file
         def branchesTagsRefs = branchesTagsJson.get("refs")
         def branchCount = 0
         def tagCount = 0
@@ -157,8 +154,7 @@ class IcebergMetadataValidationSpec extends Specification {
                 tagCount++
             }
         }
-        
-        // Count branches in the main-only file
+
         def mainOnlyRefs = mainOnlyJson.get("refs")
         def mainOnlyBranchCount = 0
         def mainOnlyTagCount = 0
@@ -169,8 +165,7 @@ class IcebergMetadataValidationSpec extends Specification {
                 mainOnlyTagCount++
             }
         }
-        
-        // Count branches and tags in the v1-with-refs file
+
         def v1WithRefsRefs = v1WithRefsJson.get("refs")
         def v1WithRefsBranchCount = 0
         def v1WithRefsTagCount = 0
@@ -181,26 +176,15 @@ class IcebergMetadataValidationSpec extends Specification {
                 v1WithRefsTagCount++
             }
         }
-        
-        // JSON metadata vs Iceberg runtime behavior
-        // - JSON metadata: Iceberg < 0.14.1 client tables have NO refs section
-        // - Iceberg runtime: ALL tables get at least a "main" branch (auto-created by Iceberg)
-        !oldClientJson.has("refs")  // JSON has no refs section for pre-0.14.1 clients
+
+        !oldClientJson.has("refs")
         oldClientJson.get("format-version").asInt() == 1
-        
-        // Verify expected counts for our integration tests
-        branchCount == 3  // main, feature-branch, experimental,beta
-        tagCount == 3     // v1.0.0, v2.0.0, release-2024-01
-        mainOnlyBranchCount == 1  // only main
-        mainOnlyTagCount == 0     // no tags
-        v1WithRefsBranchCount == 2 // main, dev-branch
-        v1WithRefsTagCount == 1    // v3.0.0
-        
-        // This confirms our integration test expectations (via Iceberg runtime, not JSON):
-        // - branchesTagsFile should trigger hasTags() == true (3 > 0)
-        // - mainOnlyFile should trigger hasTags() == false (0 == 0)
-        // - oldClientFile (Iceberg < 0.14.1): JSON has no refs, but Iceberg runtime auto-creates main branch
-        //   so hasTags() == false (0 tags)
-        // - v1WithRefsFile should trigger hasTags() == true (1 > 0)
+
+        branchCount == 3
+        tagCount == 3
+        mainOnlyBranchCount == 1
+        mainOnlyTagCount == 0
+        v1WithRefsBranchCount == 2
+        v1WithRefsTagCount == 1
     }
 }

--- a/metacat-connector-hive/src/test/groovy/com/netflix/metacat/connector/hive/iceberg/IcebergTableWrapperSpec.groovy
+++ b/metacat-connector-hive/src/test/groovy/com/netflix/metacat/connector/hive/iceberg/IcebergTableWrapperSpec.groovy
@@ -37,8 +37,7 @@ class IcebergTableWrapperSpec extends Specification {
         when: "Creating wrapper"
         def wrapper = new IcebergTableWrapper(mockTable, extraProperties)
 
-        then: "Should detect no non-main branches or tags"
-        !wrapper.hasNonMainBranches()
+        then: "Should detect no tags"
         !wrapper.hasTags()
         wrapper.getBranchesAndTagsSummary() == "branches=0, tags=0"
     }
@@ -57,8 +56,7 @@ class IcebergTableWrapperSpec extends Specification {
         when: "Creating wrapper"
         def wrapper = new IcebergTableWrapper(mockTable, extraProperties)
 
-        then: "Should detect main branch but not consider it as having non-main branches"
-        !wrapper.hasNonMainBranches() // main branch alone doesn't count as "having non-main branches"
+        then: "Should detect main branch"
         !wrapper.hasTags()
         wrapper.getBranchesAndTagsSummary() == "branches=1 [main], tags=0"
     }
@@ -78,7 +76,6 @@ class IcebergTableWrapperSpec extends Specification {
         def wrapper = new IcebergTableWrapper(mockTable, extraProperties)
 
         then: "Should detect multiple branches"
-        wrapper.hasNonMainBranches() // multiple branches count as "having non-main branches"
         !wrapper.hasTags()
 
         wrapper.getBranchesAndTagsSummary().startsWith("branches=3")
@@ -100,7 +97,6 @@ class IcebergTableWrapperSpec extends Specification {
         def wrapper = new IcebergTableWrapper(mockTable, extraProperties)
 
         then: "Should detect tags only"
-        !wrapper.hasNonMainBranches()
         wrapper.hasTags()
         wrapper.getBranchesAndTagsSummary().startsWith("branches=0, tags=3")
     }
@@ -128,8 +124,7 @@ class IcebergTableWrapperSpec extends Specification {
         when: "Creating wrapper"
         def wrapper = new IcebergTableWrapper(mockTable, extraProperties)
 
-        then: "Should detect both non-main branches and tags"
-        wrapper.hasNonMainBranches() // more than just main
+        then: "Should detect both branches and tags"
         wrapper.hasTags()
 
         def summary = wrapper.getBranchesAndTagsSummary()
@@ -151,11 +146,9 @@ class IcebergTableWrapperSpec extends Specification {
         when: "Creating wrapper"
         def wrapper = new IcebergTableWrapper(mockTable, extraProperties)
 
-        then: "Should detect multiple branches as having non-main branches"
-        wrapper.hasNonMainBranches() // multiple branches (main + feature) count as having non-main branches
+        then: "Should detect multiple branches"
         !wrapper.hasTags()
 
- // has non-main branches
         def summary = wrapper.getBranchesAndTagsSummary()
         summary.contains("branches=2")
         summary.contains("main")
@@ -177,9 +170,8 @@ class IcebergTableWrapperSpec extends Specification {
         when: "Creating wrapper"
         def wrapper = new IcebergTableWrapper(mockTable, extraProperties)
 
-        then: "Should detect main branch but no additional branches or tags"
-        !wrapper.hasNonMainBranches()  // Only main branch (size == 1), no additional branches
-        !wrapper.hasTags()             // No tags for pre-0.14.1 client tables  
+        then: "Should detect main branch but no tags"
+        !wrapper.hasTags()             // No tags for pre-0.14.1 client tables
         wrapper.getBranchesAndTagsSummary() == "branches=1 [main], tags=0"  // Main branch exists
 
         when: "Populating metadata for pre-0.14.1 client table"
@@ -187,29 +179,10 @@ class IcebergTableWrapperSpec extends Specification {
 
         then: "Should return correct values"
         noExceptionThrown()
-        metadataMap.get(IcebergTableWrapper.ICEBERG_HAS_NON_MAIN_BRANCHES_KEY) == "false"
         metadataMap.get(IcebergTableWrapper.ICEBERG_HAS_TAGS_KEY) == "false"
         // extraProperties should NOT be populated by this method
-        !extraProperties.containsKey(IcebergTableWrapper.ICEBERG_HAS_NON_MAIN_BRANCHES_KEY)
         !extraProperties.containsKey(IcebergTableWrapper.ICEBERG_HAS_TAGS_KEY)
     }
-
-    // TODO: Fix this test - mock setup issue
-    /*
-    def "test table with IO error throws exception"() {
-        given: "A table where refs() throws an IO error"
-        def mockTable = Mock(Table)
-        def extraProperties = [:]
-
-        when: "refs() throws RuntimeException and we call hasNonMainBranches"
-        mockTable.refs() >> { throw new RuntimeException("Network connection failed") }
-        def wrapper = new IcebergTableWrapper(mockTable, extraProperties)
-        wrapper.hasNonMainBranches()
-
-        then: "Exception should be thrown"
-        thrown(RuntimeException)
-    }
-    */
 
     def "test getBranchesAndTagsSummary with various combinations"() {
         given: "A table with different ref combinations"
@@ -267,15 +240,12 @@ class IcebergTableWrapperSpec extends Specification {
         def wrapper = new IcebergTableWrapper(mockTable, extraProperties)
         def metadataMap = wrapper.populateBranchTagMetadata()
 
-        then: "Should return both separate keys correctly"
-        metadataMap.get(IcebergTableWrapper.ICEBERG_HAS_NON_MAIN_BRANCHES_KEY) == "true"
+        then: "Should return the tags key correctly"
         metadataMap.get(IcebergTableWrapper.ICEBERG_HAS_TAGS_KEY) == "true"
         // extraProperties should NOT be populated by this method - it's a pure function
-        !extraProperties.containsKey(IcebergTableWrapper.ICEBERG_HAS_NON_MAIN_BRANCHES_KEY)
         !extraProperties.containsKey(IcebergTableWrapper.ICEBERG_HAS_TAGS_KEY)
-        
-        and: "Static constants should have expected values"
-        IcebergTableWrapper.ICEBERG_HAS_NON_MAIN_BRANCHES_KEY == "iceberg.has.non.main.branches"
+
+        and: "Static constant should have expected value"
         IcebergTableWrapper.ICEBERG_HAS_TAGS_KEY == "iceberg.has.tags"
     }
 
@@ -294,11 +264,9 @@ class IcebergTableWrapperSpec extends Specification {
         def wrapper = new IcebergTableWrapper(mockTable, extraProperties)
         def metadataMap = wrapper.populateBranchTagMetadata()
 
-        then: "Should return non-main-branches=true, tags=false"
-        metadataMap.get(IcebergTableWrapper.ICEBERG_HAS_NON_MAIN_BRANCHES_KEY) == "true"
+        then: "Should return tags=false"
         metadataMap.get(IcebergTableWrapper.ICEBERG_HAS_TAGS_KEY) == "false"
         // extraProperties should NOT be populated by this method - it's a pure function
-        !extraProperties.containsKey(IcebergTableWrapper.ICEBERG_HAS_NON_MAIN_BRANCHES_KEY)
         !extraProperties.containsKey(IcebergTableWrapper.ICEBERG_HAS_TAGS_KEY)
     }
 
@@ -317,11 +285,9 @@ class IcebergTableWrapperSpec extends Specification {
         def wrapper = new IcebergTableWrapper(mockTable, extraProperties)
         def metadataMap = wrapper.populateBranchTagMetadata()
 
-        then: "Should return non-main-branches=false, tags=true"
-        metadataMap.get(IcebergTableWrapper.ICEBERG_HAS_NON_MAIN_BRANCHES_KEY) == "false"
+        then: "Should return tags=true"
         metadataMap.get(IcebergTableWrapper.ICEBERG_HAS_TAGS_KEY) == "true"
         // extraProperties should NOT be populated by this method - it's a pure function
-        !extraProperties.containsKey(IcebergTableWrapper.ICEBERG_HAS_NON_MAIN_BRANCHES_KEY)
         !extraProperties.containsKey(IcebergTableWrapper.ICEBERG_HAS_TAGS_KEY)
     }
 
@@ -340,11 +306,9 @@ class IcebergTableWrapperSpec extends Specification {
         def wrapper = new IcebergTableWrapper(mockTable, extraProperties)
         def metadataMap = wrapper.populateBranchTagMetadata()
 
-        then: "Should return both as false"
-        metadataMap.get(IcebergTableWrapper.ICEBERG_HAS_NON_MAIN_BRANCHES_KEY) == "false"
+        then: "Should return tags=false"
         metadataMap.get(IcebergTableWrapper.ICEBERG_HAS_TAGS_KEY) == "false"
         // extraProperties should NOT be populated by this method - it's a pure function
-        !extraProperties.containsKey(IcebergTableWrapper.ICEBERG_HAS_NON_MAIN_BRANCHES_KEY)
         !extraProperties.containsKey(IcebergTableWrapper.ICEBERG_HAS_TAGS_KEY)
     }
 
@@ -367,11 +331,9 @@ class IcebergTableWrapperSpec extends Specification {
         def wrapper = new IcebergTableWrapper(mockTable, extraProperties)
 
         then: "Should NOT automatically populate metadata keys"
-        !extraProperties.containsKey(IcebergTableWrapper.ICEBERG_HAS_NON_MAIN_BRANCHES_KEY)
         !extraProperties.containsKey(IcebergTableWrapper.ICEBERG_HAS_TAGS_KEY)
-        
+
         and: "Methods should still work"
-        wrapper.hasNonMainBranches()
         wrapper.hasTags()
     }
 
@@ -393,10 +355,9 @@ class IcebergTableWrapperSpec extends Specification {
         when: "Creating wrapper"
         def wrapper = new IcebergTableWrapper(mockTable, extraProperties)
 
-        then: "Should work correctly and detect non-main branches/tags"
+        then: "Should work correctly and detect tags"
         wrapper.getTable() == mockTable
         wrapper.getExtraProperties() == extraProperties
-        wrapper.hasNonMainBranches()
         wrapper.hasTags()
     }
 
@@ -427,7 +388,6 @@ class IcebergTableWrapperSpec extends Specification {
         def wrapper = new IcebergTableWrapper(mockTable, extraProperties)
 
         then: "Should only detect known reference types"
-        !wrapper.hasNonMainBranches() // only main branch
         wrapper.hasTags()
     }
 
@@ -453,7 +413,6 @@ class IcebergTableWrapperSpec extends Specification {
         def wrapper = new IcebergTableWrapper(mockTable, extraProperties)
 
         then: "Should only detect valid reference types"
-        !wrapper.hasNonMainBranches()
         !wrapper.hasTags()
     }
 }

--- a/metacat-connector-hive/src/test/groovy/com/netflix/metacat/connector/hive/iceberg/IcebergTableWrapperSpec.groovy
+++ b/metacat-connector-hive/src/test/groovy/com/netflix/metacat/connector/hive/iceberg/IcebergTableWrapperSpec.groovy
@@ -39,7 +39,6 @@ class IcebergTableWrapperSpec extends Specification {
 
         then: "Should detect no tags"
         !wrapper.hasTags()
-        wrapper.getBranchesAndTagsSummary() == "branches=0, tags=0"
     }
 
     def "test table with only main branch"() {
@@ -58,7 +57,6 @@ class IcebergTableWrapperSpec extends Specification {
 
         then: "Should detect main branch"
         !wrapper.hasTags()
-        wrapper.getBranchesAndTagsSummary() == "branches=1 [main], tags=0"
     }
 
     def "test table with multiple branches including main"() {
@@ -77,9 +75,6 @@ class IcebergTableWrapperSpec extends Specification {
 
         then: "Should detect multiple branches"
         !wrapper.hasTags()
-
-        wrapper.getBranchesAndTagsSummary().startsWith("branches=3")
-        wrapper.getBranchesAndTagsSummary().contains("tags=0")
     }
 
     def "test table with only tags"() {
@@ -98,7 +93,6 @@ class IcebergTableWrapperSpec extends Specification {
 
         then: "Should detect tags only"
         wrapper.hasTags()
-        wrapper.getBranchesAndTagsSummary().startsWith("branches=0, tags=3")
     }
 
     def "test table with branches and tags"() {
@@ -126,10 +120,6 @@ class IcebergTableWrapperSpec extends Specification {
 
         then: "Should detect both branches and tags"
         wrapper.hasTags()
-
-        def summary = wrapper.getBranchesAndTagsSummary()
-        summary.contains("branches=2")
-        summary.contains("tags=2")
     }
 
     def "test table with main and feature branch"() {
@@ -148,12 +138,6 @@ class IcebergTableWrapperSpec extends Specification {
 
         then: "Should detect multiple branches"
         !wrapper.hasTags()
-
-        def summary = wrapper.getBranchesAndTagsSummary()
-        summary.contains("branches=2")
-        summary.contains("main")
-        summary.contains("feature-only")
-        summary.contains("tags=0")
     }
 
     def "test table created with Iceberg client < 0.14.1 (has main branch only)"() {
@@ -163,7 +147,7 @@ class IcebergTableWrapperSpec extends Specification {
             isTag() >> false
         }
         def mockTable = Mock(Table) {
-            refs() >> ["main": mockMainBranch]  // Even pre-0.14.1 tables get main branch auto-created
+            refs() >> ["main": mockMainBranch]
         }
         def extraProperties = [:]
 
@@ -171,8 +155,7 @@ class IcebergTableWrapperSpec extends Specification {
         def wrapper = new IcebergTableWrapper(mockTable, extraProperties)
 
         then: "Should detect main branch but no tags"
-        !wrapper.hasTags()             // No tags for pre-0.14.1 client tables
-        wrapper.getBranchesAndTagsSummary() == "branches=1 [main], tags=0"  // Main branch exists
+        !wrapper.hasTags()
 
         when: "Populating metadata for pre-0.14.1 client table"
         def metadataMap = wrapper.populateBranchTagMetadata()
@@ -180,45 +163,7 @@ class IcebergTableWrapperSpec extends Specification {
         then: "Should return correct values"
         noExceptionThrown()
         metadataMap.get(IcebergTableWrapper.ICEBERG_HAS_TAGS_KEY) == "false"
-        // extraProperties should NOT be populated by this method
         !extraProperties.containsKey(IcebergTableWrapper.ICEBERG_HAS_TAGS_KEY)
-    }
-
-    def "test getBranchesAndTagsSummary with various combinations"() {
-        given: "A table with different ref combinations"
-        def mockTable = Mock(Table)
-        
-        when: "Creating wrapper and getting summary"
-        mockTable.refs() >> createRefsMap(refsSpec)
-        def wrapper = new IcebergTableWrapper(mockTable, [:])
-        def actualSummary = wrapper.getBranchesAndTagsSummary()
-
-        then: "Summary format is correct"
-        if (expectedSummary instanceof String) {
-            actualSummary == expectedSummary
-        } else {
-            actualSummary ==~ expectedSummary
-        }
-
-        where:
-        refsSpec                                      | expectedSummary
-        [:]                                           | "branches=0, tags=0"
-        ["main": "branch"]                           | "branches=1 [main], tags=0"
-        ["v1.0": "tag"]                              | "branches=0, tags=1 [v1.0]"
-        ["main": "branch", "v1.0": "tag"]           | ~/branches=1 \[main\], tags=1 \[v1\.0\]/
-        ["b1": "branch", "b2": "branch"]             | ~/branches=2 \[.*\], tags=0/
-        ["t1": "tag", "t2": "tag", "t3": "tag"]      | ~/branches=0, tags=3 \[.*\]/
-    }
-    
-    private Map<String, SnapshotRef> createRefsMap(Map<String, String> refsSpec) {
-        def result = [:]
-        refsSpec.each { name, type ->
-            result[name] = Mock(SnapshotRef) {
-                isBranch() >> (type == "branch")
-                isTag() >> (type == "tag")
-            }
-        }
-        return result
     }
 
     def "test static constants and separate key population"() {
@@ -242,7 +187,6 @@ class IcebergTableWrapperSpec extends Specification {
 
         then: "Should return the tags key correctly"
         metadataMap.get(IcebergTableWrapper.ICEBERG_HAS_TAGS_KEY) == "true"
-        // extraProperties should NOT be populated by this method - it's a pure function
         !extraProperties.containsKey(IcebergTableWrapper.ICEBERG_HAS_TAGS_KEY)
 
         and: "Static constant should have expected value"
@@ -266,7 +210,6 @@ class IcebergTableWrapperSpec extends Specification {
 
         then: "Should return tags=false"
         metadataMap.get(IcebergTableWrapper.ICEBERG_HAS_TAGS_KEY) == "false"
-        // extraProperties should NOT be populated by this method - it's a pure function
         !extraProperties.containsKey(IcebergTableWrapper.ICEBERG_HAS_TAGS_KEY)
     }
 
@@ -287,7 +230,6 @@ class IcebergTableWrapperSpec extends Specification {
 
         then: "Should return tags=true"
         metadataMap.get(IcebergTableWrapper.ICEBERG_HAS_TAGS_KEY) == "true"
-        // extraProperties should NOT be populated by this method - it's a pure function
         !extraProperties.containsKey(IcebergTableWrapper.ICEBERG_HAS_TAGS_KEY)
     }
 
@@ -298,7 +240,7 @@ class IcebergTableWrapperSpec extends Specification {
             isTag() >> false
         }
         def mockTable = Mock(Table) {
-            refs() >> ["main": mockBranch]  // Only main branch doesn't count as "having branches"
+            refs() >> ["main": mockBranch]
         }
         def extraProperties = [:]
 
@@ -308,7 +250,6 @@ class IcebergTableWrapperSpec extends Specification {
 
         then: "Should return tags=false"
         metadataMap.get(IcebergTableWrapper.ICEBERG_HAS_TAGS_KEY) == "false"
-        // extraProperties should NOT be populated by this method - it's a pure function
         !extraProperties.containsKey(IcebergTableWrapper.ICEBERG_HAS_TAGS_KEY)
     }
 

--- a/metacat-functional-tests/metacat-test-cluster/etc-metacat/data/metadata/00003-with-branches-and-tags.metadata.json
+++ b/metacat-functional-tests/metacat-test-cluster/etc-metacat/data/metadata/00003-with-branches-and-tags.metadata.json
@@ -86,7 +86,7 @@
       "snapshot-id" : 8158962092416812123,
       "type" : "branch"
     },
-    "experimental" : {
+    "experimental,beta" : {
       "snapshot-id" : 8158962092416812124,
       "type" : "branch"
     },

--- a/metacat-functional-tests/metacat-test-cluster/etc-metacat/data/metadata/00007-basic-v2.metadata.json
+++ b/metacat-functional-tests/metacat-test-cluster/etc-metacat/data/metadata/00007-basic-v2.metadata.json
@@ -1,0 +1,55 @@
+{
+  "format-version" : 2,
+  "table-uuid" : "2adba3fa-118d-4e0c-939d-9f4f8f7a34ef",
+  "location" : "file:/tmp/data",
+  "last-updated-ms" : 1612554048968,
+  "last-column-id" : 3,
+  "last-sequence-number" : 0,
+  "last-partition-id" : 1000,
+  "current-schema-id" : 0,
+  "schemas" : [ {
+    "schema-id" : 0,
+    "type" : "struct",
+    "fields" : [ {
+      "id" : 1,
+      "name" : "id",
+      "required" : false,
+      "type" : "long",
+      "doc" : "1st field"
+    }, {
+      "id" : 2,
+      "name" : "data",
+      "required" : false,
+      "type" : "string",
+      "doc" : "2nd field"
+    }, {
+      "id" : 3,
+      "name" : "dateint",
+      "required" : false,
+      "type" : "int",
+      "doc" : "3rd field"
+    } ]
+  } ],
+  "default-spec-id" : 0,
+  "partition-specs" : [ {
+    "spec-id" : 0,
+    "fields" : [ {
+      "name" : "dateint",
+      "transform" : "identity",
+      "source-id" : 3,
+      "field-id" : 1000
+    } ]
+  } ],
+  "default-sort-order-id" : 0,
+  "sort-orders" : [ {
+    "order-id" : 0,
+    "fields" : [ ]
+  } ],
+  "properties" : {
+    "field.metadata.json" : "{\n  \"1\" : {\n    \"comment\" : \"1st field\"\n  },\n  \"2\" : {\n    \"comment\" : \"2nd field\"\n  },\n  \"3\" : {\n    \"comment\" : \"3rd field\"\n  }\n}"
+  },
+  "current-snapshot-id" : -1,
+  "snapshots" : [ ],
+  "snapshot-log" : [ ],
+  "metadata-log" : [ ]
+}

--- a/metacat-functional-tests/src/functionalTest/groovy/com/netflix/metacat/MetacatSmokeSpec.groovy
+++ b/metacat-functional-tests/src/functionalTest/groovy/com/netflix/metacat/MetacatSmokeSpec.groovy
@@ -959,13 +959,9 @@ class MetacatSmokeSpec extends Specification {
         retrievedTable.metadata.containsKey('metadata_location')
         retrievedTable.metadata.get('metadata_location') == metadataLocation
 
-        // Verify that the iceberg.has.tags flag is populated correctly
         retrievedTable.metadata.containsKey('iceberg.has.tags')
-        // Basic test tables without additional tags should return "false"
-        // This verifies both the injection mechanism AND the logic correctness for simple tables
         retrievedTable.metadata.get('iceberg.has.tags') == 'false'
 
-        // Verify that the branches and table_version metadata are populated correctly
         retrievedTable.metadata.containsKey(TableDto.BRANCHES_METADATA_KEY)
         retrievedTable.getBranches() == ['main'] as Set
         retrievedTable.metadata.get(TableDto.TABLE_VERSION_METADATA_KEY) == '2'
@@ -1009,17 +1005,9 @@ class MetacatSmokeSpec extends Specification {
         retrievedTable.metadata.containsKey('metadata_location')
         retrievedTable.metadata.get('metadata_location') == metadataLocation
 
-        // Verify that the metadata flag correctly detects the tags from the real metadata file
         retrievedTable.metadata.containsKey('iceberg.has.tags')
-
-        // The metadata file has 3 branches (main, feature-branch, experimental,beta) and 3 tags (v1.0.0, v2.0.0, release-2024-01)
-        // So the flag should be "true"
         retrievedTable.metadata.get('iceberg.has.tags') == 'true'
 
-        // Verify that only the branch names (not the tag names) are surfaced under branches, and the
-        // table_version metadata reflects the metadata file's format-version.
-        // "experimental,beta" also verifies that a comma inside a branch name survives encoding/decoding
-        // intact (branch names are JSON-array encoded, not comma-joined) rather than being split apart.
         retrievedTable.getBranches() == ['main', 'feature-branch', 'experimental,beta'] as Set
         retrievedTable.getTableVersion() == Optional.of(2)
 
@@ -1039,7 +1027,6 @@ class MetacatSmokeSpec extends Specification {
         def tableDto = PigDataDtoProvider.getTable(catalogName, databaseName, tableName, 'test', uri)
         tableDto.setFields([])
 
-        // Use the metadata file that contains only the main branch (no additional branches or tags)
         def metadataLocation = '/tmp/data/metadata/00004-main-branch-only.metadata.json'
         def metadata = [table_type: 'ICEBERG', metadata_location: metadataLocation]
         tableDto.setMetadata(metadata)
@@ -1062,11 +1049,7 @@ class MetacatSmokeSpec extends Specification {
         retrievedTable.metadata.containsKey('metadata_location')
         retrievedTable.metadata.get('metadata_location') == metadataLocation
 
-        // Verify that the metadata flag correctly detects no additional tags
         retrievedTable.metadata.containsKey('iceberg.has.tags')
-
-        // The metadata file has only 1 branch (main) and 0 tags
-        // So the flag should be "false"
         retrievedTable.metadata.get('iceberg.has.tags') == 'false'
 
         retrievedTable.getBranches() == ['main'] as Set
@@ -1088,8 +1071,6 @@ class MetacatSmokeSpec extends Specification {
         def tableDto = PigDataDtoProvider.getTable(catalogName, databaseName, tableName, 'test', uri)
         tableDto.setFields([])
 
-        // Use REAL metadata file created with Iceberg client < 0.14.1 (Dec 2021, before refs support)
-        // Note: This is v1 format but could be any format - client version determines refs support
         def metadataLocation = '/tmp/data/metadata/00005-old-client-no-refs.metadata.json'
         def metadata = [table_type: 'ICEBERG', metadata_location: metadataLocation]
         tableDto.setMetadata(metadata)
@@ -1112,16 +1093,9 @@ class MetacatSmokeSpec extends Specification {
         retrievedTable.metadata.containsKey('metadata_location')
         retrievedTable.metadata.get('metadata_location') == metadataLocation
 
-        // Verify that tables created with Iceberg < 0.14.1 are handled correctly
         retrievedTable.metadata.containsKey('iceberg.has.tags')
-
-        // CRITICAL: JSON metadata has no refs section, but Iceberg runtime auto-creates "main" branch
-        // Tables created with Iceberg < 0.14.1: JSON has no refs, but runtime has main branch
-        // - hasTags() == false (no tags in auto-created refs)
-        // This ensures backward compatibility with tables created before branches/tags support
         retrievedTable.metadata.get('iceberg.has.tags') == 'false'
 
-        // The runtime auto-creates a "main" branch even though the JSON has no refs section
         retrievedTable.getBranches() == ['main'] as Set
         retrievedTable.getTableVersion() == Optional.of(1)
 
@@ -1141,8 +1115,6 @@ class MetacatSmokeSpec extends Specification {
         def tableDto = PigDataDtoProvider.getTable(catalogName, databaseName, tableName, 'test', uri)
         tableDto.setFields([])
 
-        // Use v1 format metadata file with branches/tags (created with Iceberg client >= 0.14.1)
-        // This proves that format version != client capability - v1 can have refs!
         def metadataLocation = '/tmp/data/metadata/00006-v1-with-branches-tags.metadata.json'
         def metadata = [table_type: 'ICEBERG', metadata_location: metadataLocation]
         tableDto.setMetadata(metadata)
@@ -1165,14 +1137,9 @@ class MetacatSmokeSpec extends Specification {
         retrievedTable.metadata.containsKey('metadata_location')
         retrievedTable.metadata.get('metadata_location') == metadataLocation
 
-        // Verify that v1 format tables created with Iceberg >= 0.14.1 DO support branches/tags
         retrievedTable.metadata.containsKey('iceberg.has.tags')
-
-        // v1 format with refs should detect branches/tags correctly
-        // This table has 2 branches (main, dev-branch) + 1 tag (v3.0.0)
         retrievedTable.metadata.get('iceberg.has.tags') == 'true'
 
-        // format-version can be 1 even when refs are present - version and refs support are independent
         retrievedTable.getBranches() == ['main', 'dev-branch'] as Set
         retrievedTable.getTableVersion() == Optional.of(1)
 

--- a/metacat-functional-tests/src/functionalTest/groovy/com/netflix/metacat/MetacatSmokeSpec.groovy
+++ b/metacat-functional-tests/src/functionalTest/groovy/com/netflix/metacat/MetacatSmokeSpec.groovy
@@ -963,7 +963,7 @@ class MetacatSmokeSpec extends Specification {
         retrievedTable.metadata.get('iceberg.has.tags') == 'false'
 
         retrievedTable.metadata.containsKey(TableDto.BRANCHES_METADATA_KEY)
-        retrievedTable.getBranches() == ['main'] as Set
+        retrievedTable.getBranches() == [] as Set
         retrievedTable.metadata.get(TableDto.TABLE_VERSION_METADATA_KEY) == '2'
         retrievedTable.getTableVersion() == Optional.of(2)
 

--- a/metacat-functional-tests/src/functionalTest/groovy/com/netflix/metacat/MetacatSmokeSpec.groovy
+++ b/metacat-functional-tests/src/functionalTest/groovy/com/netflix/metacat/MetacatSmokeSpec.groovy
@@ -937,7 +937,7 @@ class MetacatSmokeSpec extends Specification {
         def uri = isLocalEnv ? String.format('file:/tmp/%s/%s', databaseName, tableName) : null
         def tableDto = PigDataDtoProvider.getTable(catalogName, databaseName, tableName, 'test', uri)
         tableDto.setFields([])
-        def metadataLocation = '/tmp/data/metadata/00000-9b5d4c36-130c-4288-9599-7d850c203d11.metadata.json'
+        def metadataLocation = '/tmp/data/metadata/00007-basic-v2.metadata.json'
         def metadata = [table_type: 'ICEBERG', metadata_location: metadataLocation]
         tableDto.setMetadata(metadata)
 
@@ -959,13 +959,17 @@ class MetacatSmokeSpec extends Specification {
         retrievedTable.metadata.containsKey('metadata_location')
         retrievedTable.metadata.get('metadata_location') == metadataLocation
 
-        // Verify that the iceberg.has.non.main.branches and iceberg.has.tags flags are populated correctly
-        retrievedTable.metadata.containsKey('iceberg.has.non.main.branches')
+        // Verify that the iceberg.has.tags flag is populated correctly
         retrievedTable.metadata.containsKey('iceberg.has.tags')
-        // Basic test tables without additional non-main branches/tags should return "false" for both
+        // Basic test tables without additional tags should return "false"
         // This verifies both the injection mechanism AND the logic correctness for simple tables
-        retrievedTable.metadata.get('iceberg.has.non.main.branches') == 'false'
         retrievedTable.metadata.get('iceberg.has.tags') == 'false'
+
+        // Verify that the branches and table_version metadata are populated correctly
+        retrievedTable.metadata.containsKey(TableDto.BRANCHES_METADATA_KEY)
+        retrievedTable.getBranches() == ['main'] as Set
+        retrievedTable.metadata.get(TableDto.TABLE_VERSION_METADATA_KEY) == '2'
+        retrievedTable.getTableVersion() == Optional.of(2)
 
         cleanup:
         api.deleteTable(catalogName, databaseName, tableName)
@@ -1005,14 +1009,17 @@ class MetacatSmokeSpec extends Specification {
         retrievedTable.metadata.containsKey('metadata_location')
         retrievedTable.metadata.get('metadata_location') == metadataLocation
 
-        // Verify that the metadata flags correctly detect the branches and tags from the real metadata file
-        retrievedTable.metadata.containsKey('iceberg.has.non.main.branches')
+        // Verify that the metadata flag correctly detects the tags from the real metadata file
         retrievedTable.metadata.containsKey('iceberg.has.tags')
 
         // The metadata file has 3 branches (main, feature-branch, experimental) and 3 tags (v1.0.0, v2.0.0, release-2024-01)
-        // So both flags should be "true"
-        retrievedTable.metadata.get('iceberg.has.non.main.branches') == 'true'
+        // So the flag should be "true"
         retrievedTable.metadata.get('iceberg.has.tags') == 'true'
+
+        // Verify that only the branch names (not the tag names) are surfaced under branches, and the
+        // table_version metadata reflects the metadata file's format-version
+        retrievedTable.getBranches() == ['main', 'feature-branch', 'experimental'] as Set
+        retrievedTable.getTableVersion() == Optional.of(2)
 
         cleanup:
         api.deleteTable(catalogName, databaseName, tableName)
@@ -1053,14 +1060,15 @@ class MetacatSmokeSpec extends Specification {
         retrievedTable.metadata.containsKey('metadata_location')
         retrievedTable.metadata.get('metadata_location') == metadataLocation
 
-        // Verify that the metadata flags correctly detect no additional branches or tags
-        retrievedTable.metadata.containsKey('iceberg.has.non.main.branches')
+        // Verify that the metadata flag correctly detects no additional tags
         retrievedTable.metadata.containsKey('iceberg.has.tags')
 
         // The metadata file has only 1 branch (main) and 0 tags
-        // So both flags should be "false"
-        retrievedTable.metadata.get('iceberg.has.non.main.branches') == 'false'
+        // So the flag should be "false"
         retrievedTable.metadata.get('iceberg.has.tags') == 'false'
+
+        retrievedTable.getBranches() == ['main'] as Set
+        retrievedTable.getTableVersion() == Optional.of(2)
 
         cleanup:
         api.deleteTable(catalogName, databaseName, tableName)
@@ -1103,16 +1111,17 @@ class MetacatSmokeSpec extends Specification {
         retrievedTable.metadata.get('metadata_location') == metadataLocation
 
         // Verify that tables created with Iceberg < 0.14.1 are handled correctly
-        retrievedTable.metadata.containsKey('iceberg.has.non.main.branches')
         retrievedTable.metadata.containsKey('iceberg.has.tags')
 
         // CRITICAL: JSON metadata has no refs section, but Iceberg runtime auto-creates "main" branch
         // Tables created with Iceberg < 0.14.1: JSON has no refs, but runtime has main branch
-        // - hasNonMainBranches() == false (only auto-created main branch, size=1, so 1 > 1 is false)
         // - hasTags() == false (no tags in auto-created refs)
         // This ensures backward compatibility with tables created before branches/tags support
-        retrievedTable.metadata.get('iceberg.has.non.main.branches') == 'false'
         retrievedTable.metadata.get('iceberg.has.tags') == 'false'
+
+        // The runtime auto-creates a "main" branch even though the JSON has no refs section
+        retrievedTable.getBranches() == ['main'] as Set
+        retrievedTable.getTableVersion() == Optional.of(1)
 
         cleanup:
         api.deleteTable(catalogName, databaseName, tableName)
@@ -1155,13 +1164,15 @@ class MetacatSmokeSpec extends Specification {
         retrievedTable.metadata.get('metadata_location') == metadataLocation
 
         // Verify that v1 format tables created with Iceberg >= 0.14.1 DO support branches/tags
-        retrievedTable.metadata.containsKey('iceberg.has.non.main.branches')
         retrievedTable.metadata.containsKey('iceberg.has.tags')
 
         // v1 format with refs should detect branches/tags correctly
         // This table has 2 branches (main, dev-branch) + 1 tag (v3.0.0)
-        retrievedTable.metadata.get('iceberg.has.non.main.branches') == 'true'
         retrievedTable.metadata.get('iceberg.has.tags') == 'true'
+
+        // format-version can be 1 even when refs are present - version and refs support are independent
+        retrievedTable.getBranches() == ['main', 'dev-branch'] as Set
+        retrievedTable.getTableVersion() == Optional.of(1)
 
         cleanup:
         api.deleteTable(catalogName, databaseName, tableName)

--- a/metacat-functional-tests/src/functionalTest/groovy/com/netflix/metacat/MetacatSmokeSpec.groovy
+++ b/metacat-functional-tests/src/functionalTest/groovy/com/netflix/metacat/MetacatSmokeSpec.groovy
@@ -1012,13 +1012,15 @@ class MetacatSmokeSpec extends Specification {
         // Verify that the metadata flag correctly detects the tags from the real metadata file
         retrievedTable.metadata.containsKey('iceberg.has.tags')
 
-        // The metadata file has 3 branches (main, feature-branch, experimental) and 3 tags (v1.0.0, v2.0.0, release-2024-01)
+        // The metadata file has 3 branches (main, feature-branch, experimental,beta) and 3 tags (v1.0.0, v2.0.0, release-2024-01)
         // So the flag should be "true"
         retrievedTable.metadata.get('iceberg.has.tags') == 'true'
 
         // Verify that only the branch names (not the tag names) are surfaced under branches, and the
-        // table_version metadata reflects the metadata file's format-version
-        retrievedTable.getBranches() == ['main', 'feature-branch', 'experimental'] as Set
+        // table_version metadata reflects the metadata file's format-version.
+        // "experimental,beta" also verifies that a comma inside a branch name survives encoding/decoding
+        // intact (branch names are JSON-array encoded, not comma-joined) rather than being split apart.
+        retrievedTable.getBranches() == ['main', 'feature-branch', 'experimental,beta'] as Set
         retrievedTable.getTableVersion() == Optional.of(2)
 
         cleanup:


### PR DESCRIPTION
1. Pull iceberg table format version and branches name out and set it into the dto object
2. Cleanup some unused function and existing branch metadata key in favor of the branch names.