### PR TITLE
Validate names in Polaris connector

### DIFF
--- a/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/PolarisConnectorDatabaseService.java
+++ b/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/PolarisConnectorDatabaseService.java
@@ -59,6 +59,7 @@ public class PolarisConnectorDatabaseService implements ConnectorDatabaseService
     @Override
     public void create(final ConnectorRequestContext context, final DatabaseInfo databaseInfo) {
         final QualifiedName name = databaseInfo.getName();
+        PolarisUtils.validateName(name.getDatabaseName());
         final String createdBy = PolarisUtils.getUserOrDefault(context);
 
         // check exists then create in non-transactional optimistic manner

--- a/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/PolarisConnectorTableService.java
+++ b/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/PolarisConnectorTableService.java
@@ -94,6 +94,7 @@ public class PolarisConnectorTableService implements ConnectorTableService {
     @Override
     public void create(final ConnectorRequestContext requestContext, final TableInfo tableInfo) {
         final QualifiedName name = tableInfo.getName();
+        PolarisUtils.validateName(name.getTableName());
         final String createdBy = PolarisUtils.getUserOrDefault(requestContext);
         // check exists then create in non-transactional optimistic manner
         if (exists(requestContext, name)) {
@@ -126,6 +127,7 @@ public class PolarisConnectorTableService implements ConnectorTableService {
         final QualifiedName oldName,
         final QualifiedName newName
     ) {
+        PolarisUtils.validateName(newName.getTableName());
         // check exists then rename in non-transactional optimistic manner
         if (exists(context, newName)) {
             throw new TableAlreadyExistsException(newName);

--- a/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/common/PolarisUtils.java
+++ b/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/common/PolarisUtils.java
@@ -1,7 +1,10 @@
 package com.netflix.metacat.connector.polaris.common;
 
 import com.netflix.metacat.common.server.connectors.ConnectorRequestContext;
+import com.netflix.metacat.common.server.connectors.exception.InvalidMetaException;
 import org.apache.commons.lang3.StringUtils;
+
+import java.util.regex.Pattern;
 
 /**
  * Polaris connector utils.
@@ -12,6 +15,8 @@ public final class PolarisUtils {
      * Default metacat user.
      */
     public static final String DEFAULT_METACAT_USER = "metacat_user";
+
+    private static final Pattern VALID_NAME = Pattern.compile("[a-zA-Z0-9_]+");
 
     /**
      * Default Ctor.
@@ -28,5 +33,15 @@ public final class PolarisUtils {
     public static String getUserOrDefault(final ConnectorRequestContext context) {
         final String userName = context.getUserName();
         return StringUtils.isNotBlank(userName) ? userName : DEFAULT_METACAT_USER;
+    }
+
+    /**
+     * Rejects names containing anything other than letters, digits and underscores.
+     * @param name The name to validate.
+     */
+    public static void validateName(final String name) {
+        if (name == null || !VALID_NAME.matcher(name).matches()) {
+            throw new InvalidMetaException("Invalid name: " + name, null);
+        }
     }
 }

--- a/metacat-connector-polaris/src/test/java/com/netflix/metacat/connector/polaris/PolarisUtilsTest.java
+++ b/metacat-connector-polaris/src/test/java/com/netflix/metacat/connector/polaris/PolarisUtilsTest.java
@@ -1,0 +1,29 @@
+package com.netflix.metacat.connector.polaris;
+
+import com.netflix.metacat.common.server.connectors.exception.InvalidMetaException;
+import com.netflix.metacat.connector.polaris.common.PolarisUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class PolarisUtilsTest {
+    @ParameterizedTest
+    @ValueSource(strings = {"table", "my_table_1", "_MyTable"})
+    public void testValidNames(final String name) {
+        assertThatCode(() -> PolarisUtils.validateName(name)).doesNotThrowAnyException();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"my-table", "my table", "my.table", "my$table", ""})
+    public void testInvalidNames(final String name) {
+        assertThatThrownBy(() -> PolarisUtils.validateName(name)).isInstanceOf(InvalidMetaException.class);
+    }
+
+    @Test
+    public void testNullName() {
+        assertThatThrownBy(() -> PolarisUtils.validateName(null)).isInstanceOf(InvalidMetaException.class);
+    }
+}


### PR DESCRIPTION
This PR adds name validation for create and rename operations in the Polaris connector. A name is considered invalid if it contains a character other than a letter, number, or underscore.