### PR TITLE
Remove jitpack.io as Maven repo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,6 @@ buildscript {
         maven {
             url "https://repo.spring.io/milestone/"
         }
-        maven { url 'https://jitpack.io' }
         gradlePluginPortal()
     }
 
@@ -72,9 +71,6 @@ allprojects {
         }
         maven {
             url "https://repository.apache.org/content/repositories/releases"
-        }
-        maven {
-            url 'https://jitpack.io'
         }
     }
 


### PR DESCRIPTION
Remove unneeded jitpack.io as Maven repo, which is causing build failures.