### PR TITLE
Add metadata hash column and store null

### DIFF
--- a/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/iceberg/IcebergTableWrapper.java
+++ b/metacat-connector-hive/src/main/java/com/netflix/metacat/connector/hive/iceberg/IcebergTableWrapper.java
@@ -16,6 +16,7 @@
 
 package com.netflix.metacat.connector.hive.iceberg;
 
+import org.apache.iceberg.SnapshotRef;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableUtil;
 import lombok.Data;
@@ -69,7 +70,7 @@ public class IcebergTableWrapper {
      * @throws RuntimeException if unable to read table references
      */
     public Set<String> extractBranches() {
-        final var refs = table.refs();
+        final Map<String, SnapshotRef> refs = table.refs();
         if (refs == null || refs.isEmpty()) {
             return Collections.emptySet();
         }
@@ -84,7 +85,7 @@ public class IcebergTableWrapper {
      * @throws RuntimeException if unable to read table references
      */
     private Set<String> extractTags() {
-        final var refs = table.refs();
+        final Map<String, SnapshotRef> refs = table.refs();
             if (refs == null || refs.isEmpty()) {
                 return Collections.emptySet();
             }

--- a/metacat-connector-polaris/src/functionalTest/java/com/netflix/metacat/connector/polaris/store/PolarisStoreConnectorFunctionalTest.java
+++ b/metacat-connector-polaris/src/functionalTest/java/com/netflix/metacat/connector/polaris/store/PolarisStoreConnectorFunctionalTest.java
@@ -308,6 +308,7 @@ public class PolarisStoreConnectorFunctionalTest {
         final String metadataLocation = "s3/s3n://dataoven-prod/hive/dataoven_prod/warehouse/foo";
         final PolarisTableEntity e = new PolarisTableEntity(CATALOG_NAME_TEST, dbName, tblName, "metacatuser");
         e.setMetadataLocation(metadataLocation);
+        e.setMetadataSha256("a".repeat(64));
         polarisConnector.saveTable(e);
 
         final String newLocation = "s3/s3n://dataoven-prod/hive/dataoven_prod/warehouse/bar";
@@ -329,6 +330,7 @@ public class PolarisStoreConnectorFunctionalTest {
             getTable(CATALOG_NAME_TEST, dbName, tblName).orElseThrow(()
                         -> new RuntimeException("Expected to find saved entity"));
         Assert.assertEquals(updatedEntity.getPreviousMetadataLocation(), metadataLocation);
+        Assert.assertNull(updatedEntity.getMetadataSha256());
 
         // after the successful update, the same call should fail, since the current metadataLocation has changed.
         updatedSuccess = polarisConnector.updateTableMetadataLocation(
@@ -380,6 +382,7 @@ public class PolarisStoreConnectorFunctionalTest {
         final String metadataLocation = "s3/s3n://dataoven-prod/hive/dataoven_prod/warehouse/foo";
         final PolarisTableEntity e = new PolarisTableEntity(CATALOG_NAME_TEST, dbName, tblName, "metacatuser");
         e.setMetadataLocation(metadataLocation);
+        e.setMetadataSha256("a".repeat(64));
         polarisConnector.saveTable(e);
 
         final String newLocation = "s3/s3n://dataoven-prod/hive/dataoven_prod/warehouse/bar";
@@ -411,6 +414,7 @@ public class PolarisStoreConnectorFunctionalTest {
                         new RuntimeException("Expected to find saved entity"));
         Assert.assertEquals(updatedEntity.getPreviousMetadataLocation(), metadataLocation);
         Assert.assertEquals(updatedEntity.getParams(), params);
+        Assert.assertNull(updatedEntity.getMetadataSha256());
 
         final Map<String, String> updatedParams = new HashMap<>(params);
         for (int i = 9; i >= 0; i--) {

--- a/metacat-connector-polaris/src/functionalTest/resources/schema.sql
+++ b/metacat-connector-polaris/src/functionalTest/resources/schema.sql
@@ -24,6 +24,7 @@ CREATE TABLE TBLS (
                     tbl_name VARCHAR(255) NOT NULL,
                     previous_metadata_location VARCHAR(8192),
                     metadata_location VARCHAR(8192),
+                    metadata_sha256 VARCHAR(64),
                     params TEXT,
                     created_by VARCHAR(255),
                     created_date TIMESTAMP NOT NULL,

--- a/metacat-connector-polaris/src/functionalTest/scripts/datastores/aurora/docker-entrypoint-initdb-primary.d/schema.sql
+++ b/metacat-connector-polaris/src/functionalTest/scripts/datastores/aurora/docker-entrypoint-initdb-primary.d/schema.sql
@@ -30,6 +30,7 @@ CREATE TABLE TBLS (
                     tbl_name varchar(255) NOT NULL,
                     previous_metadata_location varchar(8192),
                     metadata_location varchar(8192),
+                    metadata_sha256 varchar(64),
                     params text,
                     created_by varchar(255),
                     created_date TIMESTAMP NOT NULL,

--- a/metacat-connector-polaris/src/functionalTest/scripts/datastores/aurora/docker-entrypoint-initdb-reader.d/schema.sql
+++ b/metacat-connector-polaris/src/functionalTest/scripts/datastores/aurora/docker-entrypoint-initdb-reader.d/schema.sql
@@ -30,6 +30,7 @@ CREATE TABLE TBLS (
                     tbl_name varchar(255) NOT NULL,
                     previous_metadata_location varchar(8192),
                     metadata_location varchar(8192),
+                    metadata_sha256 varchar(64),
                     params text,
                     created_by varchar(255),
                     created_date TIMESTAMP NOT NULL,

--- a/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/store/entities/PolarisTableEntity.java
+++ b/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/store/entities/PolarisTableEntity.java
@@ -67,6 +67,10 @@ public class PolarisTableEntity {
     @Column(name = "metadata_location", nullable = true, updatable = true)
     private String metadataLocation;
 
+    @Basic
+    @Column(name = "metadata_sha256", nullable = true, updatable = true, length = 64)
+    private String metadataSha256;
+
     @Embedded
     private AuditEntity audit;
 

--- a/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/store/jdbc/PolarisTableReplicaJDBC.java
+++ b/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/store/jdbc/PolarisTableReplicaJDBC.java
@@ -29,6 +29,7 @@ public class PolarisTableReplicaJDBC {
             .tblName(rs.getString("tbl_name"))
             .previousMetadataLocation(rs.getString("previous_metadata_location"))
             .metadataLocation(rs.getString("metadata_location"))
+            .metadataSha256(rs.getString("metadata_sha256"))
             .audit(AuditEntity.builder()
                 .createdBy(rs.getString("created_by"))
                 .lastModifiedBy(rs.getString("last_updated_by"))

--- a/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/store/repos/PolarisTableRepository.java
+++ b/metacat-connector-polaris/src/main/java/com/netflix/metacat/connector/polaris/store/repos/PolarisTableRepository.java
@@ -74,7 +74,8 @@ public interface PolarisTableRepository extends JpaRepository<PolarisTableEntity
      */
     @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Query("UPDATE PolarisTableEntity t SET t.metadataLocation = :newLocation, "
-            + "t.audit.lastModifiedBy = :lastModifiedBy, t.audit.lastModifiedDate = :lastModifiedDate, "
+            + "t.metadataSha256 = null, t.audit.lastModifiedBy = :lastModifiedBy, "
+            + "t.audit.lastModifiedDate = :lastModifiedDate, "
             + "t.previousMetadataLocation = t.metadataLocation, t.version = t.version + 1 "
             + "WHERE t.metadataLocation = :expectedLocation "
         + "AND t.catalogName = :catalogName AND t.dbName = :dbName AND t.tblName = :tableName")
@@ -102,7 +103,8 @@ public interface PolarisTableRepository extends JpaRepository<PolarisTableEntity
      */
     @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Query("UPDATE PolarisTableEntity t SET t.metadataLocation = :newLocation, t.params = :newParams,"
-        + "t.audit.lastModifiedBy = :lastModifiedBy, t.audit.lastModifiedDate = :lastModifiedDate, "
+        + "t.metadataSha256 = null, t.audit.lastModifiedBy = :lastModifiedBy, "
+        + "t.audit.lastModifiedDate = :lastModifiedDate, "
         + "t.previousMetadataLocation = t.metadataLocation, t.version = t.version + 1 "
         + "WHERE t.metadataLocation = :expectedLocation "
         + "AND t.catalogName = :catalogName AND t.dbName = :dbName AND t.tblName = :tableName")

--- a/metacat-connector-polaris/src/test/resources/h2db/schema.sql
+++ b/metacat-connector-polaris/src/test/resources/h2db/schema.sql
@@ -21,6 +21,7 @@ create table TBLS (
                     tbl_name varchar(255) not null,
                     previous_metadata_location varchar(1024),
                     metadata_location varchar(1024),
+                    metadata_sha256 varchar(64),
                     params TEXT,
                     constraint uniq_name unique(db_name, tbl_name),
                     created_by varchar(255),

--- a/metacat-functional-tests/metacat-test-cluster/datastores/aurora/docker-entrypoint-initdb-primary.d/schema.sql
+++ b/metacat-functional-tests/metacat-test-cluster/datastores/aurora/docker-entrypoint-initdb-primary.d/schema.sql
@@ -30,6 +30,7 @@ CREATE TABLE TBLS (
                     tbl_name varchar(255) NOT NULL,
                     previous_metadata_location varchar(8192),
                     metadata_location varchar(8192),
+                    metadata_sha256 varchar(64),
                     params text,
                     created_by varchar(255),
                     created_date TIMESTAMP NOT NULL,

--- a/metacat-functional-tests/metacat-test-cluster/datastores/aurora/docker-entrypoint-initdb-reader.d/schema.sql
+++ b/metacat-functional-tests/metacat-test-cluster/datastores/aurora/docker-entrypoint-initdb-reader.d/schema.sql
@@ -30,6 +30,7 @@ CREATE TABLE TBLS (
                     tbl_name varchar(255) NOT NULL,
                     previous_metadata_location varchar(8192),
                     metadata_location varchar(8192),
+                    metadata_sha256 varchar(64),
                     params text,
                     created_by varchar(255),
                     created_date TIMESTAMP NOT NULL,


### PR DESCRIPTION
This PR adds a new column to store a hash of the Iceberg metadata. This is for compatibility with IRC which will store the hash. Metacat will store `null` to overwrite any previously stored hash from IRC, to prevent the hash from becoming stale. IRC will skip the hash check if set to null. (The end goal is to deprecate Metacat and move all table operations to IRC with the hash check.)